### PR TITLE
Release v3.10.2b2: MCP tool per-actor visibility and description predicates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,15 @@ CHANGELOG
 Unreleased
 ----------
 
+v3.10.2b2: May 1, 2026
+-----------------------
+
+ADDED
+~~~~~
+
+- **MCP tool per-actor visibility**: ``@mcp_tool`` accepts a ``visibility_predicate(actor) -> bool`` to omit tools from ``tools/list`` for actors that should not see them (fail-closed on predicate errors)
+- **MCP tool per-actor descriptions**: ``@mcp_tool`` accepts a ``description_predicate(actor) -> str | None`` to override the tool description per actor, taking precedence over ``client_descriptions`` and the static ``description`` (useful for keeping feature-flagged terminology out of descriptions for actors without the feature)
+
 v3.10.2b1: Apr 7, 2026
 -----------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ v3.10.2b2: May 1, 2026
 ADDED
 ~~~~~
 
-- **MCP tool per-actor visibility**: ``@mcp_tool`` accepts a ``visibility_predicate(actor) -> bool`` to omit tools from ``tools/list`` for actors that should not see them (fail-closed on predicate errors)
+- **MCP tool per-actor visibility**: ``@mcp_tool`` accepts a ``visibility_predicate(actor) -> bool`` to omit tools from ``tools/list`` for actors that should not see them (fail-closed on predicate errors). Note: visibility filtering applies to ``tools/list`` only — omitted tools can still be invoked by name, so call-time enforcement must be implemented separately for any tool that gates privileged behavior.
 - **MCP tool per-actor descriptions**: ``@mcp_tool`` accepts a ``description_predicate(actor) -> str | None`` to override the tool description per actor, taking precedence over ``client_descriptions`` and the static ``description`` (useful for keeping feature-flagged terminology out of descriptions for actors without the feature)
 
 v3.10.2b1: Apr 7, 2026

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.10.2b1"
+__version__ = "3.10.2b2"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/handlers/mcp.py
+++ b/actingweb/handlers/mcp.py
@@ -408,6 +408,21 @@ class MCPHandler(BaseHandler):
                             )
                             continue
 
+                    # Filter by visibility_predicate (per-actor gating)
+                    visibility_predicate = metadata.get("visibility_predicate")
+                    if visibility_predicate is not None:
+                        try:
+                            if not visibility_predicate(actor):
+                                logger.debug(
+                                    f"Tool '{tool_name}' filtered out by visibility_predicate for actor {getattr(actor, 'id', '?')}"
+                                )
+                                continue
+                        except Exception as e:
+                            logger.warning(
+                                f"visibility_predicate for tool '{tool_name}' raised {e}; treating as not visible (fail-closed)"
+                            )
+                            continue
+
                     # Filter by permissions when we have context
                     if peer_id and evaluator:
                         try:
@@ -429,15 +444,33 @@ class MCPHandler(BaseHandler):
                             )
                             # Fail-open on evaluation errors to avoid hard lockouts
 
-                    # Use client-specific description if available
-                    client_descriptions = metadata.get("client_descriptions", {})
-                    if client_type and client_type in client_descriptions:
-                        description = client_descriptions[client_type]
-                    else:
-                        description = (
-                            metadata.get("description")
-                            or f"Execute {action_name} action"
-                        )
+                    # Description precedence (most specific wins):
+                    #   1. description_predicate(actor) — per-actor override.
+                    #      Used by feature-flagged tools to keep feature names out
+                    #      of descriptions for actors without the feature.
+                    #   2. client_descriptions[client_type] — per-client override.
+                    #   3. metadata["description"] — static base description.
+                    description = None
+                    description_predicate = metadata.get("description_predicate")
+                    if description_predicate is not None:
+                        try:
+                            override = description_predicate(actor)
+                            if override is not None:
+                                description = override
+                        except Exception as e:
+                            logger.warning(
+                                f"description_predicate for tool '{tool_name}' raised {e}; falling back to static description"
+                            )
+
+                    if description is None:
+                        client_descriptions = metadata.get("client_descriptions", {})
+                        if client_type and client_type in client_descriptions:
+                            description = client_descriptions[client_type]
+                        else:
+                            description = (
+                                metadata.get("description")
+                                or f"Execute {action_name} action"
+                            )
 
                     tool_def = {
                         "name": tool_name,

--- a/actingweb/mcp/decorators.py
+++ b/actingweb/mcp/decorators.py
@@ -20,6 +20,8 @@ def mcp_tool(
     title: str | None = None,
     output_schema: dict[str, Any] | None = None,
     annotations: dict[str, Any] | None = None,
+    visibility_predicate: Callable[[Any], bool] | None = None,
+    description_predicate: Callable[[Any], str | None] | None = None,
 ) -> Callable[..., Any]:
     """
     Decorator to expose an ActingWeb action as an MCP tool.
@@ -43,6 +45,19 @@ def mcp_tool(
                         "idempotentHint": False,  # Repeated calls have different effects
                         "openWorldHint": False    # Tool doesn't interact with outside world
                     }
+        visibility_predicate: Optional callable that takes the resolved ActorInterface
+                    for the request and returns True if the tool should appear in
+                    tools/list for that actor, False to omit it. Tools omitted from
+                    listing can still be called by name; gated tools should also
+                    enforce access at call time. Predicate exceptions are logged
+                    and treated as False (fail-closed).
+        description_predicate: Optional callable that takes the resolved ActorInterface
+                    for the request and returns a per-actor description override (or
+                    None to fall back to the static ``description`` / ``client_descriptions``).
+                    Useful for feature-flagged tools whose description should mention
+                    the feature only to actors who have it enabled, avoiding
+                    information leakage to actors without the feature. Predicate
+                    exceptions are logged and treated as None (fall back to default).
 
     Example:
         @action_hook("delete_note")
@@ -73,6 +88,8 @@ def mcp_tool(
             "title": title,
             "output_schema": output_schema,
             "annotations": annotations,
+            "visibility_predicate": visibility_predicate,
+            "description_predicate": description_predicate,
         }
         return func
 

--- a/actingweb/mcp/sdk_server.py
+++ b/actingweb/mcp/sdk_server.py
@@ -137,6 +137,23 @@ class ActingWebMCPServer:
                             if metadata and metadata.get("type") == "tool":
                                 tool_name = metadata.get("name", action_name)
 
+                                # Filter by visibility_predicate (per-actor gating)
+                                visibility_predicate = metadata.get(
+                                    "visibility_predicate"
+                                )
+                                if visibility_predicate is not None:
+                                    try:
+                                        if not visibility_predicate(self.actor):
+                                            logger.debug(
+                                                f"Tool '{tool_name}' filtered out by visibility_predicate for actor {self.actor_id}"
+                                            )
+                                            continue
+                                    except Exception as e:
+                                        logger.warning(
+                                            f"visibility_predicate for tool '{tool_name}' raised {e}; treating as not visible (fail-closed)"
+                                        )
+                                        continue
+
                                 # Check permission for this tool
                                 if peer_id and evaluator:
                                     permission_result = evaluator.evaluate_permission(
@@ -151,12 +168,33 @@ class ActingWebMCPServer:
                                         )
                                         continue
 
+                                # Resolve description: per-actor predicate wins
+                                # over static base description (keeps
+                                # feature-flagged terminology out of descriptions
+                                # for actors without the feature).
+                                description = None
+                                description_predicate = metadata.get(
+                                    "description_predicate"
+                                )
+                                if description_predicate is not None:
+                                    try:
+                                        override = description_predicate(self.actor)
+                                        if override is not None:
+                                            description = override
+                                    except Exception as e:
+                                        logger.warning(
+                                            f"description_predicate for tool '{tool_name}' raised {e}; falling back to static description"
+                                        )
+                                if description is None:
+                                    description = metadata.get(
+                                        "description",
+                                        f"Execute {action_name} action",
+                                    )
+
                                 # Build tool with optional fields
                                 tool_kwargs = {
                                     "name": tool_name,
-                                    "description": metadata.get(
-                                        "description", f"Execute {action_name} action"
-                                    ),
+                                    "description": description,
                                     "inputSchema": metadata.get(
                                         "input_schema",
                                         {

--- a/actingweb/mcp/sdk_server.py
+++ b/actingweb/mcp/sdk_server.py
@@ -186,6 +186,12 @@ class ActingWebMCPServer:
                                             f"description_predicate for tool '{tool_name}' raised {e}; falling back to static description"
                                         )
                                 if description is None:
+                                    # Note: client_descriptions[client_type] is
+                                    # honored by the legacy MCPHandler path but
+                                    # not here — the SDK server has no
+                                    # client_type detection. Adding it requires
+                                    # plumbing client identity through the MCP
+                                    # SDK session.
                                     description = metadata.get(
                                         "description",
                                         f"Execute {action_name} action",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.10.2b1"
+version = "3.10.2b2"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@greger.io>"]
 maintainers = ["Greger Wedel <support@greger.io>"]

--- a/tests/test_mcp_tool_visibility.py
+++ b/tests/test_mcp_tool_visibility.py
@@ -1,0 +1,129 @@
+"""Tests for the visibility_predicate parameter on @mcp_tool.
+
+The predicate gates whether a tool appears in tools/list for a given actor.
+Tools without a predicate are always visible (regression). Predicate
+exceptions are treated as "not visible" (fail-closed).
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from actingweb.handlers.mcp import MCPHandler
+from actingweb.interface.hooks import HookRegistry
+from actingweb.mcp.decorators import get_mcp_metadata, mcp_tool
+
+
+class FakeActor:
+    def __init__(self, actor_id: str = "actor1", peer_id: str = "") -> None:
+        self.id = actor_id
+        self._mcp_trust_context = {"peer_id": peer_id} if peer_id else {}
+
+
+class TestVisibilityPredicateMetadata(unittest.TestCase):
+    def test_default_predicate_is_none(self) -> None:
+        @mcp_tool(description="x")
+        def f(actor, action_name, data):
+            return {}
+
+        metadata = get_mcp_metadata(f)
+        assert metadata is not None
+        self.assertIsNone(metadata.get("visibility_predicate"))
+
+    def test_predicate_stored_on_metadata(self) -> None:
+        sentinel = lambda actor: True  # noqa: E731
+
+        @mcp_tool(description="x", visibility_predicate=sentinel)
+        def f(actor, action_name, data):
+            return {}
+
+        metadata = get_mcp_metadata(f)
+        assert metadata is not None
+        self.assertIs(metadata.get("visibility_predicate"), sentinel)
+
+
+def _make_hooks_with_predicates(predicates: dict) -> HookRegistry:
+    """Build hooks where each tool name maps to its visibility predicate."""
+    hooks = HookRegistry()
+
+    for tool_name, predicate in predicates.items():
+
+        def make_hook(name=tool_name):
+            @mcp_tool(description=f"tool {name}", visibility_predicate=predicate)
+            def hook(actor, action_name, data):
+                return {"name": name}
+
+            return hook
+
+        hooks.register_action_hook(tool_name, make_hook())
+
+    return hooks
+
+
+class TestVisibilityPredicateFiltering(unittest.TestCase):
+    def setUp(self) -> None:
+        self.actor = FakeActor()
+        self.handler = MCPHandler()
+
+    def _list_tool_names(self) -> set[str]:
+        with patch.object(
+            MCPHandler, "authenticate_and_get_actor_cached", return_value=self.actor
+        ), patch("actingweb.handlers.mcp.RuntimeContext") as mock_rc:
+            mock_mcp_context = Mock()
+            mock_mcp_context.peer_id = None
+            mock_rc.return_value.get_mcp_context.return_value = mock_mcp_context
+            resp = self.handler.post(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "1",
+                    "method": "tools/list",
+                    "params": {},
+                }
+            )
+        return {t.get("name") for t in resp.get("result", {}).get("tools", [])}
+
+    def test_predicate_false_omits_tool(self) -> None:
+        self.handler.hooks = _make_hooks_with_predicates(
+            {
+                "visible_tool": lambda actor: True,
+                "hidden_tool": lambda actor: False,
+            }
+        )
+        names = self._list_tool_names()
+        self.assertIn("visible_tool", names)
+        self.assertNotIn("hidden_tool", names)
+
+    def test_no_predicate_is_visible(self) -> None:
+        hooks = HookRegistry()
+
+        @mcp_tool(description="legacy")
+        def legacy(actor, action_name, data):
+            return {}
+
+        hooks.register_action_hook("legacy_tool", legacy)
+        self.handler.hooks = hooks
+        names = self._list_tool_names()
+        self.assertIn("legacy_tool", names)
+
+    def test_predicate_exception_fails_closed(self) -> None:
+        def boom(actor):
+            raise RuntimeError("kaboom")
+
+        self.handler.hooks = _make_hooks_with_predicates({"crash_tool": boom})
+        names = self._list_tool_names()
+        self.assertNotIn("crash_tool", names)
+
+    def test_predicate_receives_actor(self) -> None:
+        seen: list = []
+
+        def capture(actor):
+            seen.append(actor)
+            return True
+
+        self.handler.hooks = _make_hooks_with_predicates({"observe_tool": capture})
+        self._list_tool_names()
+        self.assertEqual(len(seen), 1)
+        self.assertIs(seen[0], self.actor)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mcp_tool_visibility.py
+++ b/tests/test_mcp_tool_visibility.py
@@ -47,8 +47,8 @@ def _make_hooks_with_predicates(predicates: dict) -> HookRegistry:
 
     for tool_name, predicate in predicates.items():
 
-        def make_hook(name=tool_name):
-            @mcp_tool(description=f"tool {name}", visibility_predicate=predicate)
+        def make_hook(name=tool_name, pred=predicate):
+            @mcp_tool(description=f"tool {name}", visibility_predicate=pred)
             def hook(actor, action_name, data):
                 return {"name": name}
 

--- a/tests/test_mcp_tool_visibility.py
+++ b/tests/test_mcp_tool_visibility.py
@@ -125,5 +125,115 @@ class TestVisibilityPredicateFiltering(unittest.TestCase):
         self.assertIs(seen[0], self.actor)
 
 
+def _make_hooks_with_description_predicates(predicates: dict) -> HookRegistry:
+    """Build hooks where each tool name maps to its description predicate."""
+    hooks = HookRegistry()
+
+    for tool_name, predicate in predicates.items():
+
+        def make_hook(name=tool_name, pred=predicate):
+            @mcp_tool(description=f"static {name}", description_predicate=pred)
+            def hook(actor, action_name, data):
+                return {"name": name}
+
+            return hook
+
+        hooks.register_action_hook(tool_name, make_hook())
+
+    return hooks
+
+
+class TestDescriptionPredicate(unittest.TestCase):
+    def setUp(self) -> None:
+        self.actor = FakeActor()
+        self.handler = MCPHandler()
+
+    def _list_tools(self) -> list:
+        with patch.object(
+            MCPHandler, "authenticate_and_get_actor_cached", return_value=self.actor
+        ), patch("actingweb.handlers.mcp.RuntimeContext") as mock_rc:
+            mock_mcp_context = Mock()
+            mock_mcp_context.peer_id = None
+            mock_rc.return_value.get_mcp_context.return_value = mock_mcp_context
+            resp = self.handler.post(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "1",
+                    "method": "tools/list",
+                    "params": {},
+                }
+            )
+        return resp.get("result", {}).get("tools", [])
+
+    def _description_for(self, name: str) -> str | None:
+        for t in self._list_tools():
+            if t.get("name") == name:
+                return t.get("description")
+        return None
+
+    def test_predicate_string_overrides_description(self) -> None:
+        self.handler.hooks = _make_hooks_with_description_predicates(
+            {"t": lambda actor: "per-actor description"}
+        )
+        self.assertEqual(self._description_for("t"), "per-actor description")
+
+    def test_predicate_none_falls_back_to_static(self) -> None:
+        self.handler.hooks = _make_hooks_with_description_predicates(
+            {"t": lambda actor: None}
+        )
+        self.assertEqual(self._description_for("t"), "static t")
+
+    def test_predicate_exception_falls_back_to_static(self) -> None:
+        def boom(actor):
+            raise RuntimeError("kaboom")
+
+        self.handler.hooks = _make_hooks_with_description_predicates({"t": boom})
+        self.assertEqual(self._description_for("t"), "static t")
+
+    def test_no_predicate_uses_static_description(self) -> None:
+        hooks = HookRegistry()
+
+        @mcp_tool(description="legacy desc")
+        def legacy(actor, action_name, data):
+            return {}
+
+        hooks.register_action_hook("legacy_tool", legacy)
+        self.handler.hooks = hooks
+        self.assertEqual(self._description_for("legacy_tool"), "legacy desc")
+
+    def test_predicate_takes_precedence_over_client_descriptions(self) -> None:
+        hooks = HookRegistry()
+
+        @mcp_tool(
+            description="static",
+            client_descriptions={"claude": "claude-specific"},
+            description_predicate=lambda actor: "predicate wins",
+        )
+        def hook(actor, action_name, data):
+            return {}
+
+        hooks.register_action_hook("t", hook)
+        self.handler.hooks = hooks
+        # Even with a matching client_type, the predicate should win.
+        with patch.object(
+            MCPHandler, "authenticate_and_get_actor_cached", return_value=self.actor
+        ), patch("actingweb.handlers.mcp.RuntimeContext") as mock_rc, patch.object(
+            self.handler, "_get_client_type", return_value="claude", create=True
+        ):
+            mock_mcp_context = Mock()
+            mock_mcp_context.peer_id = None
+            mock_rc.return_value.get_mcp_context.return_value = mock_mcp_context
+            resp = self.handler.post(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "1",
+                    "method": "tools/list",
+                    "params": {},
+                }
+            )
+        tools = resp.get("result", {}).get("tools", [])
+        self.assertEqual(tools[0]["description"], "predicate wins")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add `visibility_predicate(actor) -> bool` to `@mcp_tool` to omit tools from `tools/list` per actor (fail-closed on errors)
- Add `description_predicate(actor) -> str | None` to `@mcp_tool` to override tool descriptions per actor; takes precedence over `client_descriptions` and the static `description`
- Bump version to `3.10.2b2` and update `CHANGELOG.rst`

Both predicates are applied in the legacy MCP handler (`actingweb/handlers/mcp.py`) and the SDK server path (`actingweb/mcp/sdk_server.py`).

## Test plan
- [ ] `make test-all-parallel` passes
- [ ] `poetry run pyright actingweb tests` reports 0 errors
- [ ] `poetry run ruff check actingweb tests` passes
- [ ] New `tests/test_mcp_tool_visibility.py` cases cover visibility filtering and description override (including fail-closed behavior on predicate exceptions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)