### PR TITLE
Pre-release v3.10.2b3: Configurable MCP server name

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ CHANGELOG
 Unreleased
 ----------
 
+v3.10.2b3: May 23, 2026
+------------------------
+
+ADDED
+~~~~~
+
+- **Configurable MCP server name**: ``get_server_manager()``, ``MCPServerManager`` and ``ActingWebMCPServer`` accept a ``server_name`` parameter so embedding apps can announce a canonical name (e.g. ``"emm"``) in the MCP initialise handshake. Some clients use this as the default tool prefix (``emm:search`` vs ``actingweb:search``).
+
+CHANGED
+~~~~~~~
+
+- **MCP server name no longer includes actor_id**: The announced MCP server name defaults to ``"actingweb"`` instead of ``"actingweb-{actor_id}"``. Each MCP connection is already per-actor, so disambiguation in the name was unnecessary and made client-side tool prefixes noisy.
+
 v3.10.2b2: May 1, 2026
 -----------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,8 @@ v3.10.2b3: May 23, 2026
 ADDED
 ~~~~~
 
-- **Configurable MCP server name**: ``get_server_manager()``, ``MCPServerManager`` and ``ActingWebMCPServer`` accept a ``server_name`` parameter so embedding apps can announce a canonical name (e.g. ``"emm"``) in the MCP initialise handshake. Some clients use this as the default tool prefix (``emm:search`` vs ``actingweb:search``).
+- **Configurable MCP server name via the fluent API**: ``ActingWebApp.with_mcp(server_name="myapp")`` sets the name announced in the MCP initialise handshake. Some clients use this as the default tool prefix (``myapp:search`` vs ``actingweb:search``). The underlying ``get_server_manager()``, ``MCPServerManager`` and ``ActingWebMCPServer`` also accept a ``server_name`` parameter for direct use.
+- **Singleton conflict warning**: ``get_server_manager()`` now logs a warning when called with a ``server_name`` that differs from the existing singleton's name, since the late name is silently ignored.
 
 CHANGED
 ~~~~~~~

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.10.2b2"
+__version__ = "3.10.2b3"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/config.py
+++ b/actingweb/config.py
@@ -318,6 +318,8 @@ class Config:
         if kwargs.get("mcp", False):
             base_supported.append("mcp")
 
+        self.mcp_server_name = kwargs.get("mcp_server_name", "actingweb")
+
         self.aw_supported = ",".join(base_supported)
 
         # These are the supported formats

--- a/actingweb/handlers/mcp.py
+++ b/actingweb/handlers/mcp.py
@@ -68,7 +68,9 @@ class MCPHandler(BaseHandler):
         hooks: HookRegistry | None = None,
     ) -> None:
         super().__init__(webobj, config, hooks)
-        self.server_manager = get_server_manager()
+        self.server_manager = get_server_manager(
+            server_name=getattr(config, "mcp_server_name", "actingweb")
+        )
 
     def _cleanup_expired_cache_entries(self) -> None:
         """Remove expired entries from all caches."""

--- a/actingweb/interface/app.py
+++ b/actingweb/interface/app.py
@@ -67,6 +67,7 @@ class ActingWebApp:
         self._unique_creator = False
         self._force_email_prop_as_creator = False
         self._enable_mcp = True  # MCP enabled by default
+        self._mcp_server_name = "actingweb"
         self._sync_subscription_callbacks = False  # Async by default
         self._thread_pool_workers = (
             10  # Default thread pool size for FastAPI integration
@@ -352,9 +353,22 @@ class ActingWebApp:
         self._apply_runtime_changes_to_config()
         return self
 
-    def with_mcp(self, enable: bool = True) -> "ActingWebApp":
-        """Enable or disable MCP (Model Context Protocol) functionality."""
+    def with_mcp(
+        self, enable: bool = True, server_name: str = "actingweb"
+    ) -> "ActingWebApp":
+        """Enable or disable MCP (Model Context Protocol) functionality.
+
+        Args:
+            enable: If True, enable MCP support.
+            server_name: Name announced in the MCP initialise handshake.
+                Some clients use this as the default tool prefix
+                (``emm:search`` vs ``actingweb:search``). Defaults to
+                ``"actingweb"``. The first ``with_mcp()`` call sets the
+                process-wide singleton name; subsequent re-configuration
+                does not rename existing per-actor servers.
+        """
         self._enable_mcp = enable
+        self._mcp_server_name = server_name
         # Note: aw_supported is computed in Config.__init__. We keep this minimal
         # to avoid touching unrelated features; OAuth fix does not require recompute.
         return self
@@ -873,6 +887,7 @@ class ActingWebApp:
                 bot=self._bot_config or {},
                 oauth=self._get_default_oauth_config(),
                 mcp=self._enable_mcp,
+                mcp_server_name=self._mcp_server_name,
                 indexed_properties=self._indexed_properties,
                 sync_subscription_callbacks=self._sync_subscription_callbacks,
                 use_lookup_table=self._use_lookup_table,

--- a/actingweb/mcp/sdk_server.py
+++ b/actingweb/mcp/sdk_server.py
@@ -84,7 +84,24 @@ class ActingWebMCPServer:
     exposing actor functionality as MCP tools, resources, and prompts.
     """
 
-    def __init__(self, actor_id: str, hooks: HookRegistry, actor: ActorInterface):
+    def __init__(
+        self,
+        actor_id: str,
+        hooks: HookRegistry,
+        actor: ActorInterface,
+        server_name: str = "actingweb",
+    ):
+        """
+        Args:
+            actor_id: Unique identifier for the actor (per-OAuth-identity).
+            hooks: The hook registry containing registered hooks.
+            actor: The actor instance.
+            server_name: The MCP server name announced in the initialise
+                handshake. Some clients use it as the tool-prefix default
+                ("emm:search" vs "actingweb:search"). The actor_id is
+                intentionally NOT folded in — each MCP connection is
+                already per-actor, so the name doesn't need disambiguation.
+        """
         if not MCP_AVAILABLE:
             raise ImportError(
                 "Official MCP SDK not available. Install with: pip install mcp"
@@ -93,7 +110,8 @@ class ActingWebMCPServer:
         self.actor_id = actor_id
         self.hooks = hooks
         self.actor = actor
-        self.server = Server(f"actingweb-{actor_id}")
+        self.server_name = server_name
+        self.server = Server(server_name)
 
         # Set up MCP handlers
         self._setup_handlers()
@@ -620,8 +638,9 @@ class MCPServerManager:
     ensuring efficient resource usage and proper isolation between actors.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, server_name: str = "actingweb") -> None:
         self._servers: dict[str, ActingWebMCPServer] = {}
+        self._server_name = server_name
 
     def get_server(
         self, actor_id: str, hook_registry: HookRegistry, actor: ActorInterface
@@ -638,7 +657,9 @@ class MCPServerManager:
             ActingWebMCPServer instance for the actor
         """
         if actor_id not in self._servers:
-            self._servers[actor_id] = ActingWebMCPServer(actor_id, hook_registry, actor)
+            self._servers[actor_id] = ActingWebMCPServer(
+                actor_id, hook_registry, actor, server_name=self._server_name,
+            )
             logger.debug(f"Created MCP server for actor {actor_id}")
 
         return self._servers[actor_id]
@@ -658,11 +679,18 @@ class MCPServerManager:
 _server_manager: MCPServerManager | None = None
 
 
-def get_server_manager() -> MCPServerManager:
-    """Get or create the global MCP server manager instance."""
+def get_server_manager(server_name: str = "actingweb") -> MCPServerManager:
+    """Get or create the global MCP server manager instance.
+
+    On first call ``server_name`` sets the announced server name for
+    every per-actor MCP server the manager creates. Subsequent calls
+    return the same singleton — passing a different name later won't
+    rename existing servers. Apps embedding ActingWeb call this once
+    at startup with their canonical name (e.g. ``"emm"``).
+    """
     global _server_manager
     if _server_manager is None:
-        _server_manager = MCPServerManager()
+        _server_manager = MCPServerManager(server_name=server_name)
     return _server_manager
 
 

--- a/actingweb/mcp/sdk_server.py
+++ b/actingweb/mcp/sdk_server.py
@@ -691,6 +691,15 @@ def get_server_manager(server_name: str = "actingweb") -> MCPServerManager:
     global _server_manager
     if _server_manager is None:
         _server_manager = MCPServerManager(server_name=server_name)
+    elif server_name != _server_manager._server_name:
+        logger.warning(
+            "get_server_manager() called with server_name=%r but the singleton "
+            "was already created with server_name=%r — keeping the existing name. "
+            "Configure the name on the first call (e.g. via ActingWebApp.with_mcp"
+            "(server_name=...)) before any MCP request is handled.",
+            server_name,
+            _server_manager._server_name,
+        )
     return _server_manager
 
 

--- a/docs/guides/mcp-applications.rst
+++ b/docs/guides/mcp-applications.rst
@@ -89,7 +89,12 @@ Basic MCP Application
     ).with_oauth(
         client_id=os.getenv("OAUTH_CLIENT_ID"),
         client_secret=os.getenv("OAUTH_CLIENT_SECRET")
-    ).with_web_ui()
+    ).with_web_ui().with_mcp(
+        # Name announced in the MCP initialise handshake. Some clients use
+        # this as the default tool prefix (e.g. "myapp:search"). Defaults to
+        # "actingweb"; set it once at startup.
+        server_name="myapp",
+    )
 
     # Register hooks
     register_property_hooks(aw_app)

--- a/docs/guides/mcp-quickstart.rst
+++ b/docs/guides/mcp-quickstart.rst
@@ -40,6 +40,10 @@ Minimal App
            fqdn=os.getenv("APP_HOST_FQDN", "localhost:5000"),
        )
        .with_web_ui(True)
+       # MCP is on by default. Optionally set the server name announced in
+       # the initialise handshake — some clients use this as the default
+       # tool prefix (e.g. "myapp:create_note").
+       .with_mcp(server_name="myapp")
        # Configure OAuth2 for real auth in production (example only)
        # .with_oauth(client_id=os.getenv("OAUTH_CLIENT_ID"), client_secret=os.getenv("OAUTH_CLIENT_SECRET"))
    )

--- a/docs/quickstart/configuration.rst
+++ b/docs/quickstart/configuration.rst
@@ -1224,6 +1224,11 @@ MCP Capability
 
 - Toggle with ``ActingWebApp.with_mcp(enable=True|False)``.
 - When enabled, ``mcp`` appears in supported options returned by meta discovery.
+- Set the server name announced in the MCP initialise handshake with
+  ``with_mcp(server_name="emm")``. Some clients use this as the default tool
+  prefix (``emm:search`` vs ``actingweb:search``). Defaults to ``"actingweb"``.
+  The first call sets the process-wide name; later changes won't rename
+  already-created per-actor servers.
 
 Notes
 -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.10.2b2"
+version = "3.10.2b3"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@greger.io>"]
 maintainers = ["Greger Wedel <support@greger.io>"]

--- a/tests/test_mcp_server_name.py
+++ b/tests/test_mcp_server_name.py
@@ -1,0 +1,84 @@
+"""Tests for the configurable MCP server_name parameter.
+
+Covers propagation from get_server_manager() -> MCPServerManager ->
+ActingWebMCPServer -> the underlying MCP Server name, and the singleton
+warning when get_server_manager() is called again with a different name.
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from actingweb.interface.hooks import HookRegistry
+from actingweb.mcp import sdk_server
+from actingweb.mcp.sdk_server import (
+    ActingWebMCPServer,
+    MCPServerManager,
+    get_server_manager,
+)
+
+
+class TestMCPServerNamePropagation(unittest.TestCase):
+    def setUp(self) -> None:
+        # Reset the module-level singleton between tests
+        sdk_server._server_manager = None
+
+    def tearDown(self) -> None:
+        sdk_server._server_manager = None
+
+    def test_default_server_name_is_actingweb(self) -> None:
+        manager = MCPServerManager()
+        self.assertEqual(manager._server_name, "actingweb")
+
+    def test_custom_server_name_stored_on_manager(self) -> None:
+        manager = MCPServerManager(server_name="emm")
+        self.assertEqual(manager._server_name, "emm")
+
+    def test_actingweb_server_uses_provided_name(self) -> None:
+        actor = Mock()
+        server = ActingWebMCPServer(
+            actor_id="actor1",
+            hooks=HookRegistry(),
+            actor=actor,
+            server_name="emm",
+        )
+        self.assertEqual(server.server_name, "emm")
+        # The underlying mcp.Server is constructed with the same name
+        self.assertEqual(server.server.name, "emm")
+
+    def test_actingweb_server_default_name_does_not_include_actor_id(self) -> None:
+        actor = Mock()
+        server = ActingWebMCPServer(
+            actor_id="actor1", hooks=HookRegistry(), actor=actor
+        )
+        self.assertEqual(server.server_name, "actingweb")
+        self.assertEqual(server.server.name, "actingweb")
+
+    def test_manager_propagates_name_to_per_actor_servers(self) -> None:
+        manager = MCPServerManager(server_name="emm")
+        hooks = HookRegistry()
+        actor = Mock()
+        server = manager.get_server("actor1", hooks, actor)
+        self.assertEqual(server.server_name, "emm")
+        self.assertEqual(server.server.name, "emm")
+
+    def test_get_server_manager_first_call_sets_name(self) -> None:
+        manager = get_server_manager(server_name="emm")
+        self.assertEqual(manager._server_name, "emm")
+
+    def test_get_server_manager_singleton_warns_on_name_conflict(self) -> None:
+        get_server_manager(server_name="emm")
+        with patch.object(sdk_server.logger, "warning") as mock_warn:
+            again = get_server_manager(server_name="other")
+            mock_warn.assert_called_once()
+            # The existing singleton name is preserved
+            self.assertEqual(again._server_name, "emm")
+
+    def test_get_server_manager_singleton_silent_when_name_matches(self) -> None:
+        get_server_manager(server_name="emm")
+        with patch.object(sdk_server.logger, "warning") as mock_warn:
+            get_server_manager(server_name="emm")
+            mock_warn.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Make MCP server name configurable via `get_server_manager(server_name=...)`, `MCPServerManager(server_name=...)`, and `ActingWebMCPServer(server_name=...)`
- Change default server name from `actingweb-{actor_id}` to `actingweb` — each MCP connection is already per-actor, so the suffix was unnecessary and made client-side tool prefixes noisy (e.g. `actingweb:search` vs `emm:search`)
- Bump version to `3.10.2b3` and update `CHANGELOG.rst`

## Test plan
- [ ] `make test-all-parallel` passes locally
- [ ] After merge: tag `v3.10.2b3`, push tag, GitHub Actions publishes to TestPyPI
- [ ] Verify install from TestPyPI: `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ actingweb==3.10.2b3`
- [ ] Spot-check an embedding app sees the configured server name in the MCP initialise handshake

🤖 Generated with [Claude Code](https://claude.com/claude-code)