### PR TITLE
Pre-release v3.10.2b4: Configurable MCP server instructions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ CHANGELOG
 Unreleased
 ----------
 
+v3.10.2b4: May 26, 2026
+------------------------
+
+ADDED
+~~~~~
+
+- **Configurable MCP server instructions**: ``ActingWebApp.with_mcp(instructions="...")`` sets the server-level orientation string surfaced on the MCP ``InitializeResult.instructions`` field. Clients display it to the LLM on initial connection — useful for pointing new LLMs at an entry-point tool (e.g. ``how_to_use()``). ``get_server_manager()``, ``MCPServerManager`` and ``ActingWebMCPServer`` also accept an ``instructions`` parameter for direct use. Like ``server_name``, the first ``with_mcp()`` call wins for the process-wide singleton.
+
 v3.10.2b3: May 23, 2026
 ------------------------
 

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.10.2b3"
+__version__ = "3.10.2b4"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/config.py
+++ b/actingweb/config.py
@@ -319,6 +319,7 @@ class Config:
             base_supported.append("mcp")
 
         self.mcp_server_name = kwargs.get("mcp_server_name", "actingweb")
+        self.mcp_instructions: str | None = kwargs.get("mcp_instructions", None)
 
         self.aw_supported = ",".join(base_supported)
 

--- a/actingweb/handlers/mcp.py
+++ b/actingweb/handlers/mcp.py
@@ -69,7 +69,8 @@ class MCPHandler(BaseHandler):
     ) -> None:
         super().__init__(webobj, config, hooks)
         self.server_manager = get_server_manager(
-            server_name=getattr(config, "mcp_server_name", "actingweb")
+            server_name=getattr(config, "mcp_server_name", "actingweb"),
+            instructions=getattr(config, "mcp_instructions", None),
         )
 
     def _cleanup_expired_cache_entries(self) -> None:

--- a/actingweb/interface/app.py
+++ b/actingweb/interface/app.py
@@ -68,6 +68,7 @@ class ActingWebApp:
         self._force_email_prop_as_creator = False
         self._enable_mcp = True  # MCP enabled by default
         self._mcp_server_name = "actingweb"
+        self._mcp_instructions: str | None = None
         self._sync_subscription_callbacks = False  # Async by default
         self._thread_pool_workers = (
             10  # Default thread pool size for FastAPI integration
@@ -354,7 +355,10 @@ class ActingWebApp:
         return self
 
     def with_mcp(
-        self, enable: bool = True, server_name: str = "actingweb"
+        self,
+        enable: bool = True,
+        server_name: str = "actingweb",
+        instructions: str | None = None,
     ) -> "ActingWebApp":
         """Enable or disable MCP (Model Context Protocol) functionality.
 
@@ -366,9 +370,16 @@ class ActingWebApp:
                 ``"actingweb"``. The first ``with_mcp()`` call sets the
                 process-wide singleton name; subsequent re-configuration
                 does not rename existing per-actor servers.
+            instructions: Optional server-level orientation string
+                surfaced on the MCP ``InitializeResult.instructions``
+                field per protocol. Clients display it to the LLM on
+                initial connection. Use it to point new LLMs at an
+                entry-point tool (e.g. ``how_to_use()``). Like
+                ``server_name``, the first call wins for the singleton.
         """
         self._enable_mcp = enable
         self._mcp_server_name = server_name
+        self._mcp_instructions = instructions
         # Note: aw_supported is computed in Config.__init__. We keep this minimal
         # to avoid touching unrelated features; OAuth fix does not require recompute.
         return self
@@ -888,6 +899,7 @@ class ActingWebApp:
                 oauth=self._get_default_oauth_config(),
                 mcp=self._enable_mcp,
                 mcp_server_name=self._mcp_server_name,
+                mcp_instructions=self._mcp_instructions,
                 indexed_properties=self._indexed_properties,
                 sync_subscription_callbacks=self._sync_subscription_callbacks,
                 use_lookup_table=self._use_lookup_table,

--- a/actingweb/mcp/sdk_server.py
+++ b/actingweb/mcp/sdk_server.py
@@ -712,7 +712,8 @@ def get_server_manager(
         _server_manager = MCPServerManager(
             server_name=server_name, instructions=instructions
         )
-    elif server_name != _server_manager._server_name:
+        return _server_manager
+    if server_name != _server_manager._server_name:
         logger.warning(
             "get_server_manager() called with server_name=%r but the singleton "
             "was already created with server_name=%r — keeping the existing name. "
@@ -720,6 +721,16 @@ def get_server_manager(
             "(server_name=...)) before any MCP request is handled.",
             server_name,
             _server_manager._server_name,
+        )
+    if instructions is not None and instructions != _server_manager._instructions:
+        logger.warning(
+            "get_server_manager() called with instructions=%r but the singleton "
+            "was already created with instructions=%r — keeping the existing "
+            "instructions. Configure them on the first call (e.g. via "
+            "ActingWebApp.with_mcp(instructions=...)) before any MCP request is "
+            "handled.",
+            instructions,
+            _server_manager._instructions,
         )
     return _server_manager
 

--- a/actingweb/mcp/sdk_server.py
+++ b/actingweb/mcp/sdk_server.py
@@ -90,6 +90,7 @@ class ActingWebMCPServer:
         hooks: HookRegistry,
         actor: ActorInterface,
         server_name: str = "actingweb",
+        instructions: str | None = None,
     ):
         """
         Args:
@@ -101,6 +102,10 @@ class ActingWebMCPServer:
                 ("emm:search" vs "actingweb:search"). The actor_id is
                 intentionally NOT folded in — each MCP connection is
                 already per-actor, so the name doesn't need disambiguation.
+            instructions: Optional server-level orientation string,
+                surfaced on the MCP ``InitializeResult.instructions``
+                field. Clients display it to the LLM on initial
+                connection.
         """
         if not MCP_AVAILABLE:
             raise ImportError(
@@ -111,7 +116,8 @@ class ActingWebMCPServer:
         self.hooks = hooks
         self.actor = actor
         self.server_name = server_name
-        self.server = Server(server_name)
+        self.instructions = instructions
+        self.server = Server(server_name, instructions=instructions)
 
         # Set up MCP handlers
         self._setup_handlers()
@@ -638,9 +644,14 @@ class MCPServerManager:
     ensuring efficient resource usage and proper isolation between actors.
     """
 
-    def __init__(self, server_name: str = "actingweb") -> None:
+    def __init__(
+        self,
+        server_name: str = "actingweb",
+        instructions: str | None = None,
+    ) -> None:
         self._servers: dict[str, ActingWebMCPServer] = {}
         self._server_name = server_name
+        self._instructions = instructions
 
     def get_server(
         self, actor_id: str, hook_registry: HookRegistry, actor: ActorInterface
@@ -658,7 +669,11 @@ class MCPServerManager:
         """
         if actor_id not in self._servers:
             self._servers[actor_id] = ActingWebMCPServer(
-                actor_id, hook_registry, actor, server_name=self._server_name,
+                actor_id,
+                hook_registry,
+                actor,
+                server_name=self._server_name,
+                instructions=self._instructions,
             )
             logger.debug(f"Created MCP server for actor {actor_id}")
 
@@ -679,18 +694,24 @@ class MCPServerManager:
 _server_manager: MCPServerManager | None = None
 
 
-def get_server_manager(server_name: str = "actingweb") -> MCPServerManager:
+def get_server_manager(
+    server_name: str = "actingweb",
+    instructions: str | None = None,
+) -> MCPServerManager:
     """Get or create the global MCP server manager instance.
 
-    On first call ``server_name`` sets the announced server name for
-    every per-actor MCP server the manager creates. Subsequent calls
-    return the same singleton — passing a different name later won't
-    rename existing servers. Apps embedding ActingWeb call this once
-    at startup with their canonical name (e.g. ``"emm"``).
+    On first call ``server_name`` and ``instructions`` set the values
+    announced by every per-actor MCP server the manager creates.
+    Subsequent calls return the same singleton — passing different
+    values later won't update existing servers. Apps embedding
+    ActingWeb call this once at startup with their canonical values
+    (e.g. ``"emm"`` and a pointer to ``how_to_use()``).
     """
     global _server_manager
     if _server_manager is None:
-        _server_manager = MCPServerManager(server_name=server_name)
+        _server_manager = MCPServerManager(
+            server_name=server_name, instructions=instructions
+        )
     elif server_name != _server_manager._server_name:
         logger.warning(
             "get_server_manager() called with server_name=%r but the singleton "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.10.2b3"
+version = "3.10.2b4"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@greger.io>"]
 maintainers = ["Greger Wedel <support@greger.io>"]

--- a/tests/test_actingweb_app.py
+++ b/tests/test_actingweb_app.py
@@ -145,6 +145,24 @@ class TestFeatureToggles:
 
         assert app._enable_mcp is False
 
+    def test_with_mcp_default_instructions_is_none(self):
+        """with_mcp without instructions leaves _mcp_instructions as None."""
+        with patch.object(ActingWebApp, "_initialize_permission_system"):
+            app = ActingWebApp(aw_type="urn:actingweb:test:mcp")
+            app.with_mcp(enable=True, server_name="emm")
+
+        assert app._mcp_instructions is None
+
+    def test_with_mcp_stores_instructions(self):
+        """with_mcp(instructions=...) stores the string on the app builder."""
+        with patch.object(ActingWebApp, "_initialize_permission_system"):
+            app = ActingWebApp(aw_type="urn:actingweb:test:mcp")
+            app.with_mcp(
+                enable=True, server_name="emm", instructions="Call how_to_use()"
+            )
+
+        assert app._mcp_instructions == "Call how_to_use()"
+
     def test_with_unique_creator(self):
         """Test with_unique_creator enables unique creator constraint."""
         with patch.object(ActingWebApp, "_initialize_permission_system"):

--- a/tests/test_mcp_server_name.py
+++ b/tests/test_mcp_server_name.py
@@ -132,6 +132,26 @@ class TestMCPInstructionsPropagation(unittest.TestCase):
         manager = get_server_manager(server_name="emm", instructions="Hello LLM")
         self.assertEqual(manager._instructions, "Hello LLM")
 
+    def test_get_server_manager_singleton_warns_on_instructions_conflict(self) -> None:
+        get_server_manager(server_name="emm", instructions="Hello LLM")
+        with patch.object(sdk_server.logger, "warning") as mock_warn:
+            again = get_server_manager(server_name="emm", instructions="Goodbye LLM")
+            self.assertTrue(mock_warn.called)
+            # The original instructions are kept; the late value is ignored.
+            self.assertEqual(again._instructions, "Hello LLM")
+
+    def test_get_server_manager_singleton_silent_when_instructions_omitted(self) -> None:
+        get_server_manager(server_name="emm", instructions="Hello LLM")
+        with patch.object(sdk_server.logger, "warning") as mock_warn:
+            get_server_manager(server_name="emm")
+            mock_warn.assert_not_called()
+
+    def test_get_server_manager_singleton_silent_when_instructions_match(self) -> None:
+        get_server_manager(server_name="emm", instructions="Hello LLM")
+        with patch.object(sdk_server.logger, "warning") as mock_warn:
+            get_server_manager(server_name="emm", instructions="Hello LLM")
+            mock_warn.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_mcp_server_name.py
+++ b/tests/test_mcp_server_name.py
@@ -80,5 +80,58 @@ class TestMCPServerNamePropagation(unittest.TestCase):
             mock_warn.assert_not_called()
 
 
+class TestMCPInstructionsPropagation(unittest.TestCase):
+    """Plumbing for the MCP protocol `InitializeResult.instructions` field."""
+
+    def setUp(self) -> None:
+        sdk_server._server_manager = None
+
+    def tearDown(self) -> None:
+        sdk_server._server_manager = None
+
+    def test_default_instructions_is_none(self) -> None:
+        manager = MCPServerManager()
+        self.assertIsNone(manager._instructions)
+
+    def test_instructions_stored_on_manager(self) -> None:
+        manager = MCPServerManager(server_name="emm", instructions="Call how_to_use()")
+        self.assertEqual(manager._instructions, "Call how_to_use()")
+
+    def test_actingweb_server_passes_instructions_to_underlying_mcp_server(
+        self,
+    ) -> None:
+        actor = Mock()
+        server = ActingWebMCPServer(
+            actor_id="actor1",
+            hooks=HookRegistry(),
+            actor=actor,
+            server_name="emm",
+            instructions="Hello LLM",
+        )
+        self.assertEqual(server.instructions, "Hello LLM")
+        # The underlying mcp.Server exposes instructions on the same attribute
+        self.assertEqual(server.server.instructions, "Hello LLM")
+
+    def test_actingweb_server_default_instructions_is_none(self) -> None:
+        actor = Mock()
+        server = ActingWebMCPServer(
+            actor_id="actor1", hooks=HookRegistry(), actor=actor
+        )
+        self.assertIsNone(server.instructions)
+        self.assertIsNone(server.server.instructions)
+
+    def test_manager_propagates_instructions_to_per_actor_servers(self) -> None:
+        manager = MCPServerManager(server_name="emm", instructions="Hello LLM")
+        hooks = HookRegistry()
+        actor = Mock()
+        server = manager.get_server("actor1", hooks, actor)
+        self.assertEqual(server.instructions, "Hello LLM")
+        self.assertEqual(server.server.instructions, "Hello LLM")
+
+    def test_get_server_manager_first_call_sets_instructions(self) -> None:
+        manager = get_server_manager(server_name="emm", instructions="Hello LLM")
+        self.assertEqual(manager._instructions, "Hello LLM")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Add an optional `instructions` parameter to `ActingWebApp.with_mcp()`, plumbed through `Config`, the MCP handler, `get_server_manager()`, `MCPServerManager`, and `ActingWebMCPServer`.
- The string is surfaced on the MCP `InitializeResult.instructions` field, so clients can display it to the LLM on initial connection (e.g. point it at an entry-point tool like `how_to_use()`).
- Like `server_name`, the first `with_mcp()` call wins for the process-wide singleton.
- Bump version to `3.10.2b4` and add a CHANGELOG entry.

## Test plan
- [x] `ruff check` passes
- [x] `pyright` clean on changed files (0 errors)
- [x] `tests/test_mcp_server_name.py` and `tests/test_actingweb_app.py` pass (57 passed)
- [ ] Full suite (`make test-all-parallel`) in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)