### PR TITLE
Pre-release v3.10.2b6: MCP per-session client identity

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ CHANGELOG
 Unreleased
 ----------
 
+v3.10.2b6: May 28, 2026
+------------------------
+
+ADDED
+~~~~~
+
+- **Per-MCP-session identity on ``MCPContext``**: new optional ``transport_session_id`` and ``client_info`` fields expose per-session identity that is distinct from ``peer_id`` / ``trust_relationship`` (which are per-OAuth2-credential and shared across concurrent sessions on the same credential). ``transport_session_id`` prefers the ``Mcp-Session-Id`` header (per the MCP HTTP streamable transport spec) and falls back to the existing ``client_ip + UA hash`` session key. ``client_info`` carries the live ``clientInfo`` captured at the current session's ``initialize`` call. Backward compatible: both fields default to ``None``.
+
+FIXED
+~~~~~
+
+- **``get_client_info_from_context()`` no longer surfaces another session's identity** when two MCP sessions share one OAuth2 credential. Previously it read ``client_name`` from the trust relationship, which is per-credential and gets overwritten by whichever session most recently registered — so concurrent sessions on one credential would see each other's name. The runtime context now prefers the live ``MCPContext.client_info`` (captured per-session at ``initialize``) and only falls back to the trust relationship's cached fields when no live info is available.
+
 v3.10.2b5: May 27, 2026
 ------------------------
 

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.10.2b5"
+__version__ = "3.10.2b6"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/handlers/mcp.py
+++ b/actingweb/handlers/mcp.py
@@ -1153,6 +1153,66 @@ class MCPHandler(BaseHandler):
         self._negotiated_version = header_value
         return None
 
+    def _resolve_transport_session_id(self) -> str | None:
+        """Identify the current MCP connection.
+
+        Two concurrent MCP sessions on the same OAuth2 credential share
+        a ``peer_id`` and a single trust relationship — they cannot be
+        told apart from credential data alone. This returns a per-MCP-
+        connection identifier suitable for tagging run records and
+        attributing self-identity in tool responses.
+
+        Preference order:
+        1. ``Mcp-Session-Id`` header (MCP HTTP streamable transport spec).
+        2. The existing ``_get_session_key()`` (``client_ip + UA hash``)
+           used internally for OAuth bootstrap correlation. Stable per
+           connecting client; discriminates the common
+           cron-vs-interactive case.
+        3. ``None`` when neither is available (legacy transports / unit
+           tests). Consumers should treat ``None`` as "ownership cannot
+           be verified" and fall back to today's behaviour.
+        """
+        try:
+            headers = getattr(self.request, "headers", None)
+            if headers is not None:
+                # Starlette/FastAPI and Flask header objects are already
+                # case-insensitive. For plain dicts (tests, mocks), scan
+                # for any casing if the direct lookup misses.
+                session_id = headers.get("Mcp-Session-Id")
+                if not session_id and isinstance(headers, dict):
+                    for k, v in headers.items():
+                        if isinstance(k, str) and k.lower() == "mcp-session-id":
+                            session_id = v
+                            break
+                if session_id:
+                    return str(session_id)
+        except Exception:
+            pass
+        try:
+            return self._get_session_key()
+        except Exception:
+            return None
+
+    def _resolve_live_client_info(self) -> dict[str, Any] | None:
+        """Live ``clientInfo`` for the current MCP session, if cached.
+
+        The library stores ``clientInfo`` from ``initialize`` keyed by
+        ``_get_session_key()`` in ``_mcp_client_info_cache``. That cache
+        is per-connection (IP + UA hash), so it discriminates concurrent
+        sessions on one OAuth2 credential — unlike the trust
+        relationship's cached ``client_name`` (which is per-credential
+        and gets overwritten by whichever session last registered).
+
+        Returns the cached client_info dict (typically with ``name`` and
+        ``version`` keys) or ``None`` if no cache entry exists.
+        """
+        try:
+            session_key = self._get_session_key()
+        except Exception:
+            return None
+        info = MCPHandler.get_stored_client_info(session_key)
+        return info if isinstance(info, dict) else None
+
     def authenticate_and_get_actor_cached(self) -> Any:
         """
         Optimized authenticate request and get actor with caching.
@@ -1219,6 +1279,8 @@ class MCPHandler(BaseHandler):
                             if trust_relationship
                             else "",
                             token_data=token_data,
+                            transport_session_id=self._resolve_transport_session_id(),
+                            client_info=self._resolve_live_client_info(),
                         )
 
                         # Log cache performance periodically
@@ -1288,6 +1350,8 @@ class MCPHandler(BaseHandler):
                 trust_relationship=trust_relationship,
                 peer_id=trust_relationship.peerid if trust_relationship else "",
                 token_data=token_data,
+                transport_session_id=self._resolve_transport_session_id(),
+                client_info=self._resolve_live_client_info(),
             )
 
             logger.debug(

--- a/actingweb/handlers/mcp.py
+++ b/actingweb/handlers/mcp.py
@@ -1154,30 +1154,12 @@ class MCPHandler(BaseHandler):
         return None
 
     def _resolve_transport_session_id(self) -> str | None:
-        """Identify the current MCP connection.
-
-        Two concurrent MCP sessions on the same OAuth2 credential share
-        a ``peer_id`` and a single trust relationship — they cannot be
-        told apart from credential data alone. This returns a per-MCP-
-        connection identifier suitable for tagging run records and
-        attributing self-identity in tool responses.
-
-        Preference order:
-        1. ``Mcp-Session-Id`` header (MCP HTTP streamable transport spec).
-        2. The existing ``_get_session_key()`` (``client_ip + UA hash``)
-           used internally for OAuth bootstrap correlation. Stable per
-           connecting client; discriminates the common
-           cron-vs-interactive case.
-        3. ``None`` when neither is available (legacy transports / unit
-           tests). Consumers should treat ``None`` as "ownership cannot
-           be verified" and fall back to today's behaviour.
-        """
+        """Per-MCP-connection id: ``Mcp-Session-Id`` header, else ``_get_session_key()``."""
         try:
             headers = getattr(self.request, "headers", None)
             if headers is not None:
-                # Starlette/FastAPI and Flask header objects are already
-                # case-insensitive. For plain dicts (tests, mocks), scan
-                # for any casing if the direct lookup misses.
+                # Flask/Starlette header objects are case-insensitive;
+                # scan keys defensively for plain-dict request stubs.
                 session_id = headers.get("Mcp-Session-Id")
                 if not session_id and isinstance(headers, dict):
                     for k, v in headers.items():
@@ -1187,31 +1169,21 @@ class MCPHandler(BaseHandler):
                 if session_id:
                     return str(session_id)
         except Exception:
-            pass
+            logger.debug("Mcp-Session-Id header lookup failed", exc_info=True)
         try:
             return self._get_session_key()
         except Exception:
+            logger.debug("_get_session_key() failed in transport id resolution", exc_info=True)
             return None
 
     def _resolve_live_client_info(self) -> dict[str, Any] | None:
-        """Live ``clientInfo`` for the current MCP session, if cached.
-
-        The library stores ``clientInfo`` from ``initialize`` keyed by
-        ``_get_session_key()`` in ``_mcp_client_info_cache``. That cache
-        is per-connection (IP + UA hash), so it discriminates concurrent
-        sessions on one OAuth2 credential — unlike the trust
-        relationship's cached ``client_name`` (which is per-credential
-        and gets overwritten by whichever session last registered).
-
-        Returns the cached client_info dict (typically with ``name`` and
-        ``version`` keys) or ``None`` if no cache entry exists.
-        """
+        """Live ``clientInfo`` from the current session's ``initialize``, if cached."""
         try:
             session_key = self._get_session_key()
         except Exception:
+            logger.debug("_get_session_key() failed in live client_info resolution", exc_info=True)
             return None
-        info = MCPHandler.get_stored_client_info(session_key)
-        return info if isinstance(info, dict) else None
+        return MCPHandler.get_stored_client_info(session_key)
 
     def authenticate_and_get_actor_cached(self) -> Any:
         """

--- a/actingweb/runtime_context.py
+++ b/actingweb/runtime_context.py
@@ -338,6 +338,9 @@ def get_client_info_from_context(actor: Any) -> dict[str, str] | None:
     if mcp_context:
         live = mcp_context.client_info if isinstance(mcp_context.client_info, dict) else None
         if live and live.get("name"):
+            # MCP ``clientInfo`` carries only name/version per spec;
+            # ``platform`` is an ActingWeb enrichment on the trust rel,
+            # so this key is normally "" on the live-info path.
             return {
                 "name": str(live.get("name") or ""),
                 "version": str(live.get("version") or ""),

--- a/actingweb/runtime_context.py
+++ b/actingweb/runtime_context.py
@@ -59,6 +59,19 @@ class MCPContext:
     trust_relationship: Any  # Trust database record with client metadata
     peer_id: str  # Normalized peer identifier for permission checking
     token_data: dict[str, Any] | None = None  # OAuth2 token metadata
+    # Per-MCP-connection identifier, distinct from ``peer_id`` (which is
+    # shared across concurrent sessions on the same OAuth2 credential).
+    # Prefer the ``Mcp-Session-Id`` header (MCP HTTP streamable spec);
+    # fall back to ``client_ip + user_agent`` hash when the header is
+    # absent. ``None`` when neither is available.
+    transport_session_id: str | None = None
+    # Live ``clientInfo`` from the active session's ``initialize`` call,
+    # when available. Distinct from ``trust_relationship.client_name``
+    # (which is a per-credential cache overwritten by whichever session
+    # last registered). Use this for self-attribution in tool responses
+    # so two concurrent sessions on one credential don't see each other's
+    # cached identity.
+    client_info: dict[str, Any] | None = None
 
 
 @dataclass
@@ -121,6 +134,8 @@ class RuntimeContext:
         trust_relationship: Any,
         peer_id: str,
         token_data: dict[str, Any] | None = None,
+        transport_session_id: str | None = None,
+        client_info: dict[str, Any] | None = None,
     ) -> None:
         """
         Set MCP context for the current request.
@@ -130,6 +145,12 @@ class RuntimeContext:
             trust_relationship: Trust database record with client metadata
             peer_id: Normalized peer identifier for permission checking
             token_data: Optional OAuth2 token metadata
+            transport_session_id: Optional per-MCP-connection identifier
+                that distinguishes concurrent sessions sharing one
+                OAuth2 credential (see ``MCPContext.transport_session_id``).
+            client_info: Optional live ``clientInfo`` dict from the
+                active session's ``initialize`` call (see
+                ``MCPContext.client_info``).
         """
         context_data = self._get_context_data()
         context_data["mcp"] = MCPContext(
@@ -137,6 +158,8 @@ class RuntimeContext:
             trust_relationship=trust_relationship,
             peer_id=peer_id,
             token_data=token_data,
+            transport_session_id=transport_session_id,
+            client_info=client_info,
         )
         # MCP context set successfully (no logging needed for routine operation)
 
@@ -305,21 +328,35 @@ def get_client_info_from_context(actor: Any) -> dict[str, str] | None:
     """
     runtime_context = RuntimeContext(actor)
 
-    # Try MCP context first
+    # Try MCP context first. Prefer the live ``client_info`` captured
+    # at the current session's ``initialize`` over the trust
+    # relationship's cached ``client_name``: the trust rel is per-OAuth2-
+    # credential and gets overwritten whenever a new session registers,
+    # so two concurrent sessions sharing one credential would otherwise
+    # see each other's identity.
     mcp_context = runtime_context.get_mcp_context()
-    if mcp_context and mcp_context.trust_relationship:
-        trust = mcp_context.trust_relationship
-        client_name = getattr(trust, "client_name", "")
-        client_version = getattr(trust, "client_version", "")
-        client_platform = getattr(trust, "client_platform", "")
-
-        if client_name:  # Only return if we have actual client info
+    if mcp_context:
+        live = mcp_context.client_info if isinstance(mcp_context.client_info, dict) else None
+        if live and live.get("name"):
             return {
-                "name": client_name,
-                "version": client_version or "",
-                "platform": client_platform or "",
+                "name": str(live.get("name") or ""),
+                "version": str(live.get("version") or ""),
+                "platform": str(live.get("platform") or ""),
                 "type": "mcp",
             }
+        if mcp_context.trust_relationship:
+            trust = mcp_context.trust_relationship
+            client_name = getattr(trust, "client_name", "")
+            client_version = getattr(trust, "client_version", "")
+            client_platform = getattr(trust, "client_platform", "")
+
+            if client_name:  # Only return if we have actual client info
+                return {
+                    "name": client_name,
+                    "version": client_version or "",
+                    "platform": client_platform or "",
+                    "type": "mcp",
+                }
 
     # Try OAuth2 context
     oauth2_context = runtime_context.get_oauth2_context()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.10.2b5"
+version = "3.10.2b6"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@greger.io>"]
 maintainers = ["Greger Wedel <support@greger.io>"]

--- a/tests/test_runtime_context_unit.py
+++ b/tests/test_runtime_context_unit.py
@@ -1,0 +1,99 @@
+"""Unit tests for :mod:`actingweb.runtime_context`.
+
+Pure-Python tests — no database, no docker. Covers the per-MCP-session
+fields added to ``MCPContext`` so two concurrent sessions sharing one
+OAuth2 credential can be told apart by tool handlers.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from actingweb.runtime_context import (
+    MCPContext,
+    RuntimeContext,
+    get_client_info_from_context,
+)
+
+
+class _Bag:
+    """Plain stand-in for an actor — RuntimeContext only needs attr access."""
+
+
+def test_mcp_context_defaults_for_new_fields():
+    ctx = MCPContext(client_id="c", trust_relationship=None, peer_id="p")
+    assert ctx.transport_session_id is None
+    assert ctx.client_info is None
+
+
+def test_set_mcp_context_round_trips_new_fields():
+    actor = _Bag()
+    rc = RuntimeContext(actor)
+    rc.set_mcp_context(
+        client_id="c",
+        trust_relationship=None,
+        peer_id="p",
+        transport_session_id="sess-abc",
+        client_info={"name": "claude-code", "version": "2.1.104"},
+    )
+    got = rc.get_mcp_context()
+    assert got is not None
+    assert got.transport_session_id == "sess-abc"
+    assert got.client_info == {"name": "claude-code", "version": "2.1.104"}
+
+
+def test_set_mcp_context_defaults_when_omitted():
+    actor = _Bag()
+    rc = RuntimeContext(actor)
+    rc.set_mcp_context(client_id="c", trust_relationship=None, peer_id="p")
+    got = rc.get_mcp_context()
+    assert got is not None
+    assert got.transport_session_id is None
+    assert got.client_info is None
+
+
+def test_get_client_info_prefers_live_over_trust_rel():
+    """``client_info`` set per-session must win over the trust rel cache.
+
+    The trust rel's ``client_name`` is shared across concurrent sessions
+    on one OAuth2 credential, so reading it would surface another
+    session's identity. The live ``client_info`` from the current
+    ``initialize`` is the correct source.
+    """
+    actor = _Bag()
+    rc = RuntimeContext(actor)
+    stale_trust = SimpleNamespace(
+        client_name="OtherClient",
+        client_version="9.9.9",
+        client_platform="other",
+    )
+    rc.set_mcp_context(
+        client_id="c",
+        trust_relationship=stale_trust,
+        peer_id="p",
+        client_info={"name": "claude-code", "version": "2.1.104"},
+    )
+    info = get_client_info_from_context(actor)
+    assert info is not None
+    assert info["name"] == "claude-code"
+    assert info["version"] == "2.1.104"
+
+
+def test_get_client_info_falls_back_to_trust_rel():
+    """When no live client_info is set, fall back to the trust rel."""
+    actor = _Bag()
+    rc = RuntimeContext(actor)
+    trust = SimpleNamespace(
+        client_name="ClaudeAI",
+        client_version="1.0.0",
+        client_platform="web",
+    )
+    rc.set_mcp_context(
+        client_id="c",
+        trust_relationship=trust,
+        peer_id="p",
+    )
+    info = get_client_info_from_context(actor)
+    assert info is not None
+    assert info["name"] == "ClaudeAI"
+    assert info["version"] == "1.0.0"


### PR DESCRIPTION
## Summary

- Add optional `MCPContext.transport_session_id` and `MCPContext.client_info` fields so tool handlers can distinguish concurrent MCP sessions sharing one OAuth2 credential (existing `peer_id` / `trust_relationship` are per-credential and shared).
- Fix `get_client_info_from_context()` to prefer the live `clientInfo` from the current session's `initialize` over the trust rel's cached `client_name`, which was overwritten by whichever session last registered — so concurrent sessions on one credential would otherwise see each other's identity.
- Bump version to `3.10.2b6` and update `CHANGELOG.rst`.

## Why

A user with multiple concurrent MCP connections on the same OAuth2 credential (e.g. an interactive Claude session + a scheduled cron job) would see tool responses mis-attributed to whichever session most recently called `initialize`, because the trust relationship's `client_name` is per-credential and overwritten on each registration. The fix scopes self-identity to the current session via the existing per-connection `_mcp_client_info_cache` (TTL-respected) and exposes a per-session transport id for follow-up work.

## Notes

- `transport_session_id` is plumbed through but not yet consumed — scaffolding for follow-up attribution work (e.g. tagging run records). Backward compatible: all new fields default to `None`.
- Header lookup for `Mcp-Session-Id` is case-insensitive via direct lookup on Flask/Starlette header objects, with a dict-key scan fallback for plain dicts (tests/mocks).
- Live `client_info` lookup goes through `MCPHandler.get_stored_client_info()`, which honors the 10-minute cache TTL and evicts stale entries.

## Test plan

- [x] `poetry run pyright actingweb/runtime_context.py actingweb/handlers/mcp.py tests/test_runtime_context_unit.py` — 0 errors
- [x] `poetry run ruff check ...` on changed files — passes
- [x] `poetry run pytest tests/test_runtime_context_unit.py -v` — 5/5 pass
- [ ] `make test-all-parallel` on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)