### PR TITLE
Pre-release v3.10.2b7: MCP tools/list title/outputSchema + Mcp-Session-Id cache key

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ CHANGELOG
 Unreleased
 ----------
 
+v3.10.2b7: May 28, 2026
+------------------------
+
+FIXED
+~~~~~
+
+- **MCP ``tools/list`` now surfaces ``title`` and ``outputSchema``**: ``@mcp_tool`` has long accepted ``title`` and ``output_schema`` parameters, but the ``/mcp`` ``tools/list`` builder dropped both fields when constructing the tool definition. Hosts that key on the MCP 2025-11-25 ``Tool.title`` (e.g. Claude Code's tool-permission dialog) therefore saw only the internal ``name``, and clients supporting structured output had no schema to validate against. ``tool_def`` now includes ``title`` and ``outputSchema`` when set on the decorator.
+
 v3.10.2b6: May 28, 2026
 ------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ FIXED
 ~~~~~
 
 - **MCP ``tools/list`` now surfaces ``title`` and ``outputSchema``**: ``@mcp_tool`` has long accepted ``title`` and ``output_schema`` parameters, but the ``/mcp`` ``tools/list`` builder dropped both fields when constructing the tool definition. Hosts that key on the MCP 2025-11-25 ``Tool.title`` (e.g. Claude Code's tool-permission dialog) therefore saw only the internal ``name``, and clients supporting structured output had no schema to validate against. ``tool_def`` now includes ``title`` and ``outputSchema`` when set on the decorator.
+- **``_get_session_key()`` now prefers the ``Mcp-Session-Id`` header**: the in-memory ``client_info`` cache key was derived from ``client_ip + hash(user_agent[:50])``, so two MCP clients sharing one OAuth2 credential through the same proxy (same IP, near-identical UA prefix) collided on the cache key. The second client's ``initialize`` then silently overwrote the first client's cached identity. ``_get_session_key()`` now uses the spec's ``Mcp-Session-Id`` header (case-insensitive, ``mcp-session:`` prefixed for namespacing) as the canonical per-connection identifier and only falls back to IP+UA when the header is absent. ``_resolve_transport_session_id()`` returns the raw header value (without the cache prefix) for surfacing on ``MCPContext.transport_session_id``.
 
 v3.10.2b6: May 28, 2026
 ------------------------

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.10.2b6"
+__version__ = "3.10.2b7"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/handlers/mcp.py
+++ b/actingweb/handlers/mcp.py
@@ -1162,7 +1162,14 @@ class MCPHandler(BaseHandler):
         return None
 
     def _resolve_transport_session_id(self) -> str | None:
-        """Per-MCP-connection id: ``Mcp-Session-Id`` header, else ``_get_session_key()``."""
+        """Per-MCP-connection id: ``Mcp-Session-Id`` header, else ``_get_session_key()``.
+
+        Returns just the session-id value when the header is present
+        (without the ``mcp-session:`` prefix that ``_get_session_key()``
+        adds for cache-namespacing), so the value can be persisted on
+        ``MCPContext.transport_session_id`` and surfaced to callers as
+        the raw MCP-protocol identifier.
+        """
         try:
             headers = getattr(self.request, "headers", None)
             if headers is not None:
@@ -1794,10 +1801,37 @@ class MCPHandler(BaseHandler):
             del _mcp_client_info_cache[key]
 
     def _get_session_key(self) -> str:
-        """Generate a session key based on request characteristics."""
-        # Use client IP as primary identifier
+        """Generate a session key for the in-memory client_info cache.
+
+        Prefers the MCP HTTP-streamable spec's ``Mcp-Session-Id`` header,
+        which is the canonical per-MCP-connection identifier and is
+        distinct across concurrent sessions that share one OAuth2
+        credential. Falls back to ``client_ip + user_agent[:50]`` hash
+        only when the header is genuinely absent.
+
+        Why this matters: the same key stores ``client_info`` at
+        ``initialize`` time and looks it up on every subsequent request.
+        The pure IP+UA fallback collided when two clients on one
+        credential happened to share IP plus the first 50 chars of UA
+        (e.g. both proxied through the same backend), so a second
+        client's ``initialize`` silently overwrote the first client's
+        cached identity — the symptom captured as eval round-11
+        Finding X.
+        """
+        try:
+            headers = getattr(self.request, "headers", None)
+            if headers is not None:
+                session_id = headers.get("Mcp-Session-Id")
+                if not session_id and isinstance(headers, dict):
+                    for k, v in headers.items():
+                        if isinstance(k, str) and k.lower() == "mcp-session-id":
+                            session_id = v
+                            break
+                if session_id:
+                    return f"mcp-session:{session_id}"
+        except Exception:
+            logger.debug("Mcp-Session-Id header lookup failed", exc_info=True)
         client_ip = getattr(self.request, "remote_addr", "unknown")
-        # Add user agent for additional uniqueness
         user_agent = getattr(self.request, "headers", {}).get("User-Agent", "")[:50]
         return f"{client_ip}:{hash(user_agent)}"
 

--- a/actingweb/handlers/mcp.py
+++ b/actingweb/handlers/mcp.py
@@ -565,9 +565,22 @@ class MCPHandler(BaseHandler):
                         "description": description,
                     }
 
+                    # ``title`` and ``outputSchema`` were previously accepted
+                    # by the ``@mcp_tool`` decorator but dropped here — hosts
+                    # that key on the MCP 2025-11-25 ``Tool.title`` (e.g.
+                    # Claude Code's tool-permission dialog) saw only the
+                    # internal ``name``. Serialise them now when set.
+                    title = metadata.get("title")
+                    if title:
+                        tool_def["title"] = title
+
                     input_schema = metadata.get("input_schema")
                     if input_schema:
                         tool_def["inputSchema"] = input_schema
+
+                    output_schema = metadata.get("output_schema")
+                    if output_schema:
+                        tool_def["outputSchema"] = output_schema
 
                     # Add annotations if present (for ChatGPT safety evaluation)
                     annotations = metadata.get("annotations")

--- a/actingweb/handlers/mcp.py
+++ b/actingweb/handlers/mcp.py
@@ -565,11 +565,6 @@ class MCPHandler(BaseHandler):
                         "description": description,
                     }
 
-                    # ``title`` and ``outputSchema`` were previously accepted
-                    # by the ``@mcp_tool`` decorator but dropped here — hosts
-                    # that key on the MCP 2025-11-25 ``Tool.title`` (e.g.
-                    # Claude Code's tool-permission dialog) saw only the
-                    # internal ``name``. Serialise them now when set.
                     title = metadata.get("title")
                     if title:
                         tool_def["title"] = title

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.10.2b6"
+version = "3.10.2b7"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@greger.io>"]
 maintainers = ["Greger Wedel <support@greger.io>"]

--- a/tests/test_mcp_session_key.py
+++ b/tests/test_mcp_session_key.py
@@ -1,0 +1,105 @@
+"""Tests for MCP handler session-key derivation.
+
+The ``_get_session_key()`` method is the cache key used to store
+``client_info`` from ``initialize`` and look it up on every subsequent
+request. Two clients sharing one OAuth2 credential must not collide on
+this key — otherwise the second client's ``initialize`` overwrites the
+first client's cached identity (eval round-11 Finding X).
+
+The fix: prefer the MCP HTTP-streamable ``Mcp-Session-Id`` header, with
+the legacy IP+UA hash retained as a fallback only when the header is
+genuinely absent.
+"""
+
+from tests.mcp_helpers import make_mcp_handler
+
+
+class TestSessionKeyPrefersMcpSessionIdHeader:
+    """``Mcp-Session-Id`` header is the canonical per-connection id."""
+
+    def test_distinct_session_ids_produce_distinct_keys(self) -> None:
+        a = make_mcp_handler({"Mcp-Session-Id": "session-A"})
+        b = make_mcp_handler({"Mcp-Session-Id": "session-B"})
+        key_a = a._get_session_key()
+        key_b = b._get_session_key()
+        assert key_a != key_b
+        assert "session-A" in key_a
+        assert "session-B" in key_b
+
+    def test_header_lookup_is_case_insensitive(self) -> None:
+        h_upper = make_mcp_handler({"Mcp-Session-Id": "abc"})
+        h_lower = make_mcp_handler({"mcp-session-id": "abc"})
+        assert h_upper._get_session_key() == h_lower._get_session_key()
+
+    def test_header_takes_precedence_over_ipua_fallback(self) -> None:
+        """Same IP+UA, different Mcp-Session-Id → distinct keys.
+
+        This is the Finding X regression case: two clients on one
+        credential go through the same proxy (same IP) with similar
+        UAs but get unique ``Mcp-Session-Id`` values per connection.
+        Before the fix they collided; after the fix they're distinct.
+        """
+        common = {"User-Agent": "Mozilla/5.0 shared-proxy-ua-prefix-string"}
+        a = make_mcp_handler({**common, "Mcp-Session-Id": "session-A"})
+        b = make_mcp_handler({**common, "Mcp-Session-Id": "session-B"})
+        assert a._get_session_key() != b._get_session_key()
+
+
+class TestSessionKeyFallback:
+    """Without the header, the legacy IP+UA hash still applies."""
+
+    def test_no_header_falls_back_to_ipua_hash(self) -> None:
+        h = make_mcp_handler({"User-Agent": "ua-1"})
+        key = h._get_session_key()
+        # Sanity: the fallback path runs (no ``mcp-session:`` prefix)
+        # and returns *some* deterministic string.
+        assert key
+        assert not key.startswith("mcp-session:")
+
+    def test_fallback_is_deterministic_for_same_request(self) -> None:
+        h = make_mcp_handler({"User-Agent": "ua-1"})
+        assert h._get_session_key() == h._get_session_key()
+
+
+class TestClientInfoCacheIsolation:
+    """End-to-end: storing under one session must not affect another."""
+
+    def test_distinct_sessions_get_independent_cache_entries(self) -> None:
+        from actingweb.handlers import mcp as mcp_module
+
+        # Two handlers, two distinct session ids, same IP+UA otherwise.
+        common = {"User-Agent": "shared-ua"}
+        h_a = make_mcp_handler({**common, "Mcp-Session-Id": "sess-A"})
+        h_b = make_mcp_handler({**common, "Mcp-Session-Id": "sess-B"})
+
+        # Reset the in-process cache for a clean assertion.
+        mcp_module._mcp_client_info_cache.clear()
+
+        h_a._store_mcp_client_info_temporarily({"name": "Anthropic/ClaudeAI"})
+        h_b._store_mcp_client_info_temporarily({"name": "claude-code"})
+
+        info_a = mcp_module.MCPHandler.get_stored_client_info(h_a._get_session_key())
+        info_b = mcp_module.MCPHandler.get_stored_client_info(h_b._get_session_key())
+
+        assert info_a == {"name": "Anthropic/ClaudeAI"}
+        assert info_b == {"name": "claude-code"}
+
+    def test_second_initialize_does_not_overwrite_first_session(self) -> None:
+        """The exact Finding X regression: second client's initialize
+        must not overwrite the first client's cached client_info when
+        they share IP + UA but have distinct session ids."""
+        from actingweb.handlers import mcp as mcp_module
+
+        common = {"User-Agent": "Anthropic-proxy-ua-50-chars-XXXXXXXXXXXXXXXXXXX"}
+        first = make_mcp_handler({**common, "Mcp-Session-Id": "claude-ai-sess"})
+        second = make_mcp_handler({**common, "Mcp-Session-Id": "claude-code-sess"})
+
+        mcp_module._mcp_client_info_cache.clear()
+
+        first._store_mcp_client_info_temporarily({"name": "Anthropic/ClaudeAI"})
+        second._store_mcp_client_info_temporarily({"name": "claude-code"})
+
+        # The first session's cached identity must still be intact.
+        info_first = mcp_module.MCPHandler.get_stored_client_info(first._get_session_key())
+        assert info_first is not None
+        assert info_first["name"] == "Anthropic/ClaudeAI"

--- a/tests/test_mcp_tool_schema_fields.py
+++ b/tests/test_mcp_tool_schema_fields.py
@@ -1,0 +1,118 @@
+"""Tests for ``title`` and ``outputSchema`` serialisation on tools/list.
+
+``@mcp_tool`` accepts ``title`` and ``output_schema``; both must round-trip
+through the ``/mcp`` ``tools/list`` builder. Hosts that key on the MCP
+2025-11-25 ``Tool.title`` (e.g. Claude Code's tool-permission dialog) need
+``title``, and clients supporting structured output need ``outputSchema``
+to validate against.
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+from actingweb.handlers.mcp import MCPHandler
+from actingweb.interface.hooks import HookRegistry
+from actingweb.mcp.decorators import mcp_tool
+
+
+class FakeActor:
+    def __init__(self, actor_id: str = "actor1", peer_id: str = "") -> None:
+        self.id = actor_id
+        self._mcp_trust_context = {"peer_id": peer_id} if peer_id else {}
+
+
+def _list_tools(handler: MCPHandler, actor: FakeActor) -> list:
+    with patch.object(
+        MCPHandler, "authenticate_and_get_actor_cached", return_value=actor
+    ), patch("actingweb.handlers.mcp.RuntimeContext") as mock_rc:
+        mock_mcp_context = Mock()
+        mock_mcp_context.peer_id = None
+        mock_rc.return_value.get_mcp_context.return_value = mock_mcp_context
+        resp = handler.post(
+            {
+                "jsonrpc": "2.0",
+                "id": "1",
+                "method": "tools/list",
+                "params": {},
+            }
+        )
+    return resp.get("result", {}).get("tools", [])
+
+
+class TestToolSchemaFieldSerialisation(unittest.TestCase):
+    def setUp(self) -> None:
+        self.actor = FakeActor()
+        self.handler = MCPHandler()
+
+    def test_title_and_output_schema_are_serialised(self) -> None:
+        hooks = HookRegistry()
+        output_schema = {
+            "type": "object",
+            "properties": {"result": {"type": "string"}},
+        }
+
+        @mcp_tool(
+            description="x",
+            title="Friendly Title",
+            output_schema=output_schema,
+        )
+        def hook(actor, action_name, data):
+            return {}
+
+        hooks.register_action_hook("t", hook)
+        self.handler.hooks = hooks
+
+        tools = _list_tools(self.handler, self.actor)
+        self.assertEqual(len(tools), 1)
+        tool = tools[0]
+        self.assertEqual(tool.get("title"), "Friendly Title")
+        self.assertEqual(tool.get("outputSchema"), output_schema)
+
+    def test_omitted_when_unset(self) -> None:
+        hooks = HookRegistry()
+
+        @mcp_tool(description="x")
+        def hook(actor, action_name, data):
+            return {}
+
+        hooks.register_action_hook("t", hook)
+        self.handler.hooks = hooks
+
+        tools = _list_tools(self.handler, self.actor)
+        self.assertEqual(len(tools), 1)
+        tool = tools[0]
+        self.assertNotIn("title", tool)
+        self.assertNotIn("outputSchema", tool)
+
+    def test_only_title_set(self) -> None:
+        hooks = HookRegistry()
+
+        @mcp_tool(description="x", title="T")
+        def hook(actor, action_name, data):
+            return {}
+
+        hooks.register_action_hook("t", hook)
+        self.handler.hooks = hooks
+
+        tool = _list_tools(self.handler, self.actor)[0]
+        self.assertEqual(tool.get("title"), "T")
+        self.assertNotIn("outputSchema", tool)
+
+    def test_only_output_schema_set(self) -> None:
+        hooks = HookRegistry()
+        schema = {"type": "object"}
+
+        @mcp_tool(description="x", output_schema=schema)
+        def hook(actor, action_name, data):
+            return {}
+
+        hooks.register_action_hook("t", hook)
+        self.handler.hooks = hooks
+
+        tool = _list_tools(self.handler, self.actor)[0]
+        self.assertNotIn("title", tool)
+        self.assertEqual(tool.get("outputSchema"), schema)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two MCP handler fixes bundled in v3.10.2b7 (TestPyPI pre-release).

### 1. ``tools/list`` now surfaces ``title`` and ``outputSchema``

- ``@mcp_tool`` has long accepted ``title`` and ``output_schema``, but the ``/mcp`` ``tools/list`` builder dropped both when constructing the tool definition. Hosts that key on the MCP 2025-11-25 ``Tool.title`` (e.g. Claude Code's tool-permission dialog) only saw the internal ``name``, and clients that support structured output had no schema to validate against.
- ``tool_def`` now serialises ``title`` and ``outputSchema`` when set on the decorator.
- Tests: ``tests/test_mcp_tool_schema_fields.py``.

### 2. ``_get_session_key()`` now prefers ``Mcp-Session-Id``

- The in-memory ``client_info`` cache key was derived from ``client_ip + hash(user_agent[:50])``. Two MCP clients sharing one OAuth2 credential through the same proxy (same IP, near-identical UA prefix) collided on the key, and the second client's ``initialize`` silently overwrote the first client's cached identity (eval round-11 Finding X).
- ``_get_session_key()`` now prefers the spec's ``Mcp-Session-Id`` header (case-insensitive, ``mcp-session:`` prefixed for cache namespacing) and only falls back to IP+UA when the header is absent. ``_resolve_transport_session_id()`` returns the raw header value (without the cache prefix) for ``MCPContext.transport_session_id``.
- Tests: ``tests/test_mcp_session_key.py``.

Bumps version to ``3.10.2b7``.

## Test plan

- [ ] CI green (type-check, lint, tests)
- [ ] Manual: register an ``@mcp_tool(title=..., output_schema=...)`` tool, call ``tools/list``, confirm both fields appear
- [ ] Manual: open two MCP sessions on one OAuth2 credential through the same proxy with distinct ``Mcp-Session-Id`` headers; confirm each session's ``client_info`` survives the other's ``initialize``

🤖 Generated with [Claude Code](https://claude.com/claude-code)