### PR TITLE
Pre-release v3.10.2b8: MCP transport_session_id no synthetic fallback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ CHANGELOG
 Unreleased
 ----------
 
+v3.10.2b8: May 29, 2026
+------------------------
+
+FIXED
+~~~~~
+
+- **``_resolve_transport_session_id()`` no longer leaks a synthetic placeholder when the ``Mcp-Session-Id`` header is absent.** Previously it fell back to ``_get_session_key()``, which returns ``<client_ip>:<hash(user_agent[:50])>`` — an in-process *cache* key for the ``client_info`` store, not a real per-connection identifier. On transports that carry neither the header nor a usable ``remote_addr``/``User-Agent`` (e.g. Claude.ai web sessions in some deployments), the placeholder degenerated to ``unknown:0`` and was surfaced to MCP tool callers as ``MCPContext.transport_session_id`` — defeating the very per-connection coordination check the field exists for. The method now returns ``None`` when the header is absent; callers should treat ``None`` as "this transport doesn't expose a per-connection id; rely on the client-id guard alone."
+
 v3.10.2b7: May 28, 2026
 ------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ v3.10.2b8: May 29, 2026
 FIXED
 ~~~~~
 
-- **``_resolve_transport_session_id()`` no longer leaks a synthetic placeholder when the ``Mcp-Session-Id`` header is absent.** Previously it fell back to ``_get_session_key()``, which returns ``<client_ip>:<hash(user_agent[:50])>`` — an in-process *cache* key for the ``client_info`` store, not a real per-connection identifier. On transports that carry neither the header nor a usable ``remote_addr``/``User-Agent`` (e.g. Claude.ai web sessions in some deployments), the placeholder degenerated to ``unknown:0`` and was surfaced to MCP tool callers as ``MCPContext.transport_session_id`` — defeating the very per-connection coordination check the field exists for. The method now returns ``None`` when the header is absent; callers should treat ``None`` as "this transport doesn't expose a per-connection id; rely on the client-id guard alone."
+- **``MCPContext.transport_session_id`` no longer leaks a synthetic placeholder when the ``Mcp-Session-Id`` header is absent.** ``_resolve_transport_session_id()`` previously fell back to ``_get_session_key()``'s ``<client_ip>:<hash(UA)>`` form — an internal cache key, not a real per-connection identifier — which degenerated to the string ``"unknown:0"`` on transports lacking the header, ``remote_addr`` and ``User-Agent`` (observed for Claude.ai web sessions). The method now returns ``None`` when the header is absent; callers should treat ``None`` as "this transport has no per-connection id; rely on the client-id guard alone."
 
 v3.10.2b7: May 28, 2026
 ------------------------

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.10.2b7"
+__version__ = "3.10.2b8"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/handlers/mcp.py
+++ b/actingweb/handlers/mcp.py
@@ -1162,13 +1162,25 @@ class MCPHandler(BaseHandler):
         return None
 
     def _resolve_transport_session_id(self) -> str | None:
-        """Per-MCP-connection id: ``Mcp-Session-Id`` header, else ``_get_session_key()``.
+        """Per-MCP-connection id from the ``Mcp-Session-Id`` header, else ``None``.
 
         Returns just the session-id value when the header is present
         (without the ``mcp-session:`` prefix that ``_get_session_key()``
         adds for cache-namespacing), so the value can be persisted on
         ``MCPContext.transport_session_id`` and surfaced to callers as
         the raw MCP-protocol identifier.
+
+        Returns ``None`` when the transport doesn't carry the header.
+        Earlier revisions fell back to ``_get_session_key()``'s synthetic
+        ``<client_ip>:<hash(UA)>`` form, but that's a *cache* key for
+        the in-process ``client_info`` store — it's not a real
+        per-connection identifier and an LLM eval saw it leak as ``unknown:0`` whenever the request lacked
+        both ``Mcp-Session-Id`` AND a usable ``remote_addr`` / UA.
+        Surfacing the placeholder defeats
+        the very coordination check the field exists for. Callers
+        should treat a ``None`` result as "this transport doesn't
+        expose a per-connection id; the transport-level guard is
+        inactive — use the client-id guard alone."
         """
         try:
             headers = getattr(self.request, "headers", None)
@@ -1185,18 +1197,17 @@ class MCPHandler(BaseHandler):
                     return str(session_id)
         except Exception:
             logger.debug("Mcp-Session-Id header lookup failed", exc_info=True)
-        try:
-            return self._get_session_key()
-        except Exception:
-            logger.debug("_get_session_key() failed in transport id resolution", exc_info=True)
-            return None
+        return None
 
     def _resolve_live_client_info(self) -> dict[str, Any] | None:
         """Live ``clientInfo`` from the current session's ``initialize``, if cached."""
         try:
             session_key = self._get_session_key()
         except Exception:
-            logger.debug("_get_session_key() failed in live client_info resolution", exc_info=True)
+            logger.debug(
+                "_get_session_key() failed in live client_info resolution",
+                exc_info=True,
+            )
             return None
         return MCPHandler.get_stored_client_info(session_key)
 

--- a/actingweb/handlers/mcp.py
+++ b/actingweb/handlers/mcp.py
@@ -1164,23 +1164,17 @@ class MCPHandler(BaseHandler):
     def _resolve_transport_session_id(self) -> str | None:
         """Per-MCP-connection id from the ``Mcp-Session-Id`` header, else ``None``.
 
-        Returns just the session-id value when the header is present
-        (without the ``mcp-session:`` prefix that ``_get_session_key()``
-        adds for cache-namespacing), so the value can be persisted on
-        ``MCPContext.transport_session_id`` and surfaced to callers as
-        the raw MCP-protocol identifier.
+        Returns the raw header value (without the ``mcp-session:`` cache-namespacing
+        prefix that ``_get_session_key()`` adds) so it can be surfaced on
+        ``MCPContext.transport_session_id`` as the MCP-protocol identifier.
 
-        Returns ``None`` when the transport doesn't carry the header.
-        Earlier revisions fell back to ``_get_session_key()``'s synthetic
-        ``<client_ip>:<hash(UA)>`` form, but that's a *cache* key for
-        the in-process ``client_info`` store — it's not a real
-        per-connection identifier and an LLM eval saw it leak as ``unknown:0`` whenever the request lacked
-        both ``Mcp-Session-Id`` AND a usable ``remote_addr`` / UA.
-        Surfacing the placeholder defeats
-        the very coordination check the field exists for. Callers
-        should treat a ``None`` result as "this transport doesn't
-        expose a per-connection id; the transport-level guard is
-        inactive — use the client-id guard alone."
+        Callers should treat ``None`` as "this transport doesn't expose a
+        per-connection id; the transport-level guard is inactive — use the
+        client-id guard alone." We deliberately do NOT fall back to
+        ``_get_session_key()``: that returns an in-process cache key
+        (``<client_ip>:<hash(UA)>``), not a real per-connection identifier,
+        and degenerates to the placeholder ``"unknown:0"`` when the request
+        carries no ``Mcp-Session-Id``, no ``remote_addr`` and no ``User-Agent``.
         """
         try:
             headers = getattr(self.request, "headers", None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.10.2b7"
+version = "3.10.2b8"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@greger.io>"]
 maintainers = ["Greger Wedel <support@greger.io>"]

--- a/tests/test_mcp_session_key.py
+++ b/tests/test_mcp_session_key.py
@@ -109,13 +109,13 @@ class TestClientInfoCacheIsolation:
 
 class TestTransportSessionIdNoSynthFallback:
     """``_resolve_transport_session_id`` is the *public* per-connection id
-    surfaced to MCP tool callers (eval round 12 / Finding N5) — distinct
-    from ``_get_session_key`` which is an internal cache key. The cache
-    key happily falls back to ``<ip>:<hash(UA)>`` when the
-    ``Mcp-Session-Id`` header is absent; the public id must NOT — earlier
-    versions did, and eval round 7 / Finding T1 saw the placeholder
-    ``unknown:0`` leak into ``status().your_transport_session_id`` for
-    every Claude.ai web session (no header, no remote_addr, no UA).
+    surfaced to MCP tool callers (via ``MCPContext.transport_session_id``) and
+    is distinct from ``_get_session_key`` which is an internal cache key. The
+    cache key falls back to ``<ip>:<hash(UA)>`` when the ``Mcp-Session-Id``
+    header is absent; the public id must NOT. Earlier revisions did fall back,
+    and on transports lacking the header, ``remote_addr`` AND ``User-Agent``
+    (observed for Claude.ai web sessions) the synthetic id degenerated to the
+    string ``"unknown:0"``.
     """
 
     def test_returns_header_value_when_present(self) -> None:
@@ -125,14 +125,19 @@ class TestTransportSessionIdNoSynthFallback:
     def test_returns_none_when_header_absent(self) -> None:
         """No header → ``None``, NOT the synthetic IP+UA fallback."""
         h = make_mcp_handler({"User-Agent": "ua-1"})
-        assert h._resolve_transport_session_id() is None
+        result = h._resolve_transport_session_id()
+        assert result is None
+        # Guard against regression to the synthetic ``<ip>:<hash>`` form.
+        assert not (isinstance(result, str) and ":" in result)
 
     def test_returns_none_when_request_is_minimal(self) -> None:
         """The exact Claude.ai-web case: no header, no UA, no remote_addr.
         Previously yielded ``"unknown:0"``; now returns ``None`` so
         callers can detect "this transport has no per-connection id."""
         h = make_mcp_handler({})
-        assert h._resolve_transport_session_id() is None
+        result = h._resolve_transport_session_id()
+        assert result is None
+        assert result != "unknown:0"
 
     def test_header_lookup_is_case_insensitive(self) -> None:
         h_upper = make_mcp_handler({"Mcp-Session-Id": "abc"})

--- a/tests/test_mcp_session_key.py
+++ b/tests/test_mcp_session_key.py
@@ -100,6 +100,45 @@ class TestClientInfoCacheIsolation:
         second._store_mcp_client_info_temporarily({"name": "claude-code"})
 
         # The first session's cached identity must still be intact.
-        info_first = mcp_module.MCPHandler.get_stored_client_info(first._get_session_key())
+        info_first = mcp_module.MCPHandler.get_stored_client_info(
+            first._get_session_key()
+        )
         assert info_first is not None
         assert info_first["name"] == "Anthropic/ClaudeAI"
+
+
+class TestTransportSessionIdNoSynthFallback:
+    """``_resolve_transport_session_id`` is the *public* per-connection id
+    surfaced to MCP tool callers (eval round 12 / Finding N5) — distinct
+    from ``_get_session_key`` which is an internal cache key. The cache
+    key happily falls back to ``<ip>:<hash(UA)>`` when the
+    ``Mcp-Session-Id`` header is absent; the public id must NOT — earlier
+    versions did, and eval round 7 / Finding T1 saw the placeholder
+    ``unknown:0`` leak into ``status().your_transport_session_id`` for
+    every Claude.ai web session (no header, no remote_addr, no UA).
+    """
+
+    def test_returns_header_value_when_present(self) -> None:
+        h = make_mcp_handler({"Mcp-Session-Id": "session-xyz"})
+        assert h._resolve_transport_session_id() == "session-xyz"
+
+    def test_returns_none_when_header_absent(self) -> None:
+        """No header → ``None``, NOT the synthetic IP+UA fallback."""
+        h = make_mcp_handler({"User-Agent": "ua-1"})
+        assert h._resolve_transport_session_id() is None
+
+    def test_returns_none_when_request_is_minimal(self) -> None:
+        """The exact Claude.ai-web case: no header, no UA, no remote_addr.
+        Previously yielded ``"unknown:0"``; now returns ``None`` so
+        callers can detect "this transport has no per-connection id."""
+        h = make_mcp_handler({})
+        assert h._resolve_transport_session_id() is None
+
+    def test_header_lookup_is_case_insensitive(self) -> None:
+        h_upper = make_mcp_handler({"Mcp-Session-Id": "abc"})
+        h_lower = make_mcp_handler({"mcp-session-id": "abc"})
+        assert (
+            h_upper._resolve_transport_session_id()
+            == h_lower._resolve_transport_session_id()
+            == "abc"
+        )


### PR DESCRIPTION
## Summary

- `_resolve_transport_session_id()` now returns `None` when the `Mcp-Session-Id` header is absent instead of falling back to `_get_session_key()`'s `<client_ip>:<hash(user_agent[:50])>` cache key — that fallback degenerated to `unknown:0` on transports lacking both the header and a usable `remote_addr`/UA (e.g. some Claude.ai web sessions) and leaked through to `MCPContext.transport_session_id`, defeating the per-connection coordination check the field exists for.
- Adds `TestTransportSessionIdNoSynthFallback` (4 tests) covering header-present, header-absent, minimal-request, and case-insensitive header lookup.
- Bumps version to `3.10.2b8` and adds a `CHANGELOG.rst` entry.

Callers should treat a `None` return as "this transport has no per-connection id; rely on the client-id guard alone."

## Test plan

- [x] `poetry run pytest tests/test_mcp_session_key.py -v` (11 passed)
- [x] `poetry run pyright actingweb/handlers/mcp.py tests/test_mcp_session_key.py` (0 errors)
- [x] `poetry run ruff check` + `ruff format --check` on changed files
- [ ] GitHub Actions: full test suite green on PR
- [ ] After merge to master: tag `v3.10.2b8`, verify TestPyPI publish and GitHub pre-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)