### PR TITLE
Pre-release v3.10.2b9: fix revoke_all_tokens dict-mutation crash

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ CHANGELOG
 Unreleased
 ----------
 
+v3.10.2b9: June 13, 2026
+------------------------
+
+FIXED
+~~~~~
+
+- **``OAuth2SessionManager.revoke_all_tokens()`` no longer crashes on the refresh-token-reuse path**: it iterated the access- and refresh-token bucket dicts with ``for token, token_attr in <bucket>.items()`` while calling ``delete_attr`` inside the loop, raising ``RuntimeError: dictionary changed size during iteration`` whenever an actor had a matching token to revoke. Because ``revoke_all_tokens`` is invoked by the SPA refresh-token reuse-detection path, reusing a rotated refresh token returned a 500 instead of cleanly revoking the actor's tokens. Both loops now snapshot ``list(<bucket>.items())`` before deleting (matching the existing ``cleanup_expired_tokens`` pattern).
+
 v3.10.2b8: May 29, 2026
 ------------------------
 

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.10.2b8"
+__version__ = "3.10.2b9"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/oauth_session.py
+++ b/actingweb/oauth_session.py
@@ -620,7 +620,10 @@ class OAuth2SessionManager:
         )
         access_tokens = access_bucket.get_bucket()
         if access_tokens:
-            for token, token_attr in access_tokens.items():
+            # Snapshot with list() — delete_attr mutates the bucket dict we're
+            # iterating (it would raise "dictionary changed size during
+            # iteration"). Mirrors cleanup_expired_tokens().
+            for token, token_attr in list(access_tokens.items()):
                 if token_attr and "data" in token_attr:
                     if token_attr["data"].get("actor_id") == actor_id:
                         access_bucket.delete_attr(name=token)
@@ -634,7 +637,7 @@ class OAuth2SessionManager:
         )
         refresh_tokens = refresh_bucket.get_bucket()
         if refresh_tokens:
-            for token, token_attr in refresh_tokens.items():
+            for token, token_attr in list(refresh_tokens.items()):
                 if token_attr and "data" in token_attr:
                     if token_attr["data"].get("actor_id") == actor_id:
                         refresh_bucket.delete_attr(name=token)

--- a/actingweb/oauth_session.py
+++ b/actingweb/oauth_session.py
@@ -637,6 +637,7 @@ class OAuth2SessionManager:
         )
         refresh_tokens = refresh_bucket.get_bucket()
         if refresh_tokens:
+            # Same snapshot needed as the access-token loop above.
             for token, token_attr in list(refresh_tokens.items()):
                 if token_attr and "data" in token_attr:
                     if token_attr["data"].get("actor_id") == actor_id:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.10.2b8"
+version = "3.10.2b9"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@greger.io>"]
 maintainers = ["Greger Wedel <support@greger.io>"]

--- a/tests/test_oauth_session.py
+++ b/tests/test_oauth_session.py
@@ -284,6 +284,48 @@ class TestOAuth2SessionManager:
         assert self.manager.get_session(session_id1) is None
         assert self.manager.get_session(session_id2) is None
 
+    def test_revoke_all_tokens_does_not_crash_on_concurrent_delete(self):
+        """Regression: ``revoke_all_tokens`` deletes matching tokens while
+        iterating the bucket dict. Without snapshotting the items first, this
+        raised ``RuntimeError: dictionary changed size during iteration`` (the
+        live SPA refresh-token-reuse path hit this with a 500). Seed multiple
+        matching tokens in both buckets so a delete happens mid-iteration."""
+        from actingweb import attribute
+        from actingweb.constants import OAUTH2_SYSTEM_ACTOR
+        from actingweb.oauth_session import (
+            _ACCESS_TOKEN_BUCKET,
+            _REFRESH_TOKEN_BUCKET,
+        )
+
+        actor_id = "victim-actor"
+        access_bucket = attribute.Attributes(
+            actor_id=OAUTH2_SYSTEM_ACTOR, bucket=_ACCESS_TOKEN_BUCKET, config=self.config
+        )
+        refresh_bucket = attribute.Attributes(
+            actor_id=OAUTH2_SYSTEM_ACTOR, bucket=_REFRESH_TOKEN_BUCKET, config=self.config
+        )
+        # Several tokens for the target actor (all revoked) plus one for a
+        # different actor (must survive).
+        for i in range(3):
+            access_bucket.set_attr(name=f"at{i}", data={"actor_id": actor_id})
+            refresh_bucket.set_attr(name=f"rt{i}", data={"actor_id": actor_id})
+        access_bucket.set_attr(name="keep_at", data={"actor_id": "other-actor"})
+        refresh_bucket.set_attr(name="keep_rt", data={"actor_id": "other-actor"})
+
+        revoked = self.manager.revoke_all_tokens(actor_id)
+
+        assert revoked == 6  # 3 access + 3 refresh
+        # Read the shared backing store directly (the per-instance Attributes
+        # caches above are stale after revoke's own instances deleted).
+        access_store = self._test_storage[f"{OAUTH2_SYSTEM_ACTOR}:{_ACCESS_TOKEN_BUCKET}"]
+        refresh_store = self._test_storage[f"{OAUTH2_SYSTEM_ACTOR}:{_REFRESH_TOKEN_BUCKET}"]
+        # The other actor's tokens are untouched.
+        assert "keep_at" in access_store
+        assert "keep_rt" in refresh_store
+        # The victim's tokens are gone.
+        assert not any(k.startswith("at") for k in access_store)
+        assert not any(k.startswith("rt") for k in refresh_store)
+
     def test_multiple_sessions_independent(self):
         """Test that multiple sessions are independent."""
         session_id1 = self.manager.store_session(

--- a/tests/test_oauth_session.py
+++ b/tests/test_oauth_session.py
@@ -298,6 +298,7 @@ class TestOAuth2SessionManager:
         )
 
         actor_id = "victim-actor"
+        seeded_per_bucket = 3
         access_bucket = attribute.Attributes(
             actor_id=OAUTH2_SYSTEM_ACTOR, bucket=_ACCESS_TOKEN_BUCKET, config=self.config
         )
@@ -306,7 +307,7 @@ class TestOAuth2SessionManager:
         )
         # Several tokens for the target actor (all revoked) plus one for a
         # different actor (must survive).
-        for i in range(3):
+        for i in range(seeded_per_bucket):
             access_bucket.set_attr(name=f"at{i}", data={"actor_id": actor_id})
             refresh_bucket.set_attr(name=f"rt{i}", data={"actor_id": actor_id})
         access_bucket.set_attr(name="keep_at", data={"actor_id": "other-actor"})
@@ -314,7 +315,10 @@ class TestOAuth2SessionManager:
 
         revoked = self.manager.revoke_all_tokens(actor_id)
 
-        assert revoked == 6  # 3 access + 3 refresh
+        # Derived from what we seeded (access + refresh) rather than hardcoded.
+        # ``self._test_storage`` is isolated per test instance, so only the
+        # victim's seeded tokens are present.
+        assert revoked == seeded_per_bucket * 2
         # Read the shared backing store directly (the per-instance Attributes
         # caches above are stale after revoke's own instances deleted).
         access_store = self._test_storage[f"{OAUTH2_SYSTEM_ACTOR}:{_ACCESS_TOKEN_BUCKET}"]


### PR DESCRIPTION
## Pre-release v3.10.2b9

Publishes to TestPyPI.

### FIXED

- **`OAuth2SessionManager.revoke_all_tokens()` no longer crashes on the refresh-token-reuse path**: it iterated the access- and refresh-token bucket dicts with `for token, token_attr in <bucket>.items()` while calling `delete_attr` inside the loop, raising `RuntimeError: dictionary changed size during iteration` whenever an actor had a matching token to revoke. Because `revoke_all_tokens` is invoked by the SPA refresh-token reuse-detection path, reusing a rotated refresh token returned a 500 instead of cleanly revoking the actor's tokens. Both loops now snapshot `list(<bucket>.items())` before deleting (matching the existing `cleanup_expired_tokens` pattern).

### Version

- `pyproject.toml` and `actingweb/__init__.py` bumped to `3.10.2b9`
- New regression test added in `tests/test_oauth_session.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)