### PR TITLE
Pre-release v3.11.0b4: fix actor/trust delete infinite recursion (DB pool exhaustion)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,30 @@ CHANGELOG
 Unreleased
 ----------
 
+v3.11.0b4: June 17, 2026
+------------------------
+
+FIXED
+~~~~~
+
+- **Actor/trust deletion no longer recurses infinitely and exhausts the DB
+  connection pool.** Deleting an actor (or any OAuth2-client trust) triggered an
+  unbounded recursion: ``Trust.delete()`` called ``client_registry.delete_client()``
+  *before* removing the trust record, and ``delete_client()`` cascades back into
+  ``_delete_client_trust_relationship() -> delete_relationship() ->
+  delete_reciprocal_trust() -> Trust.delete()``. Because the trust record still
+  existed, each cascade re-discovered the same relationship and recursed until it
+  raised ``maximum recursion depth exceeded``. On the PostgreSQL backend each
+  recursion level checked out a pooled connection that was never returned, so a
+  single delete could self-deadlock the pool (``min=2, max=10``) and every
+  subsequent DB operation blocked for the full acquire timeout. The implicit
+  terminator (an early ``return False`` in ``delete_client`` when the client was
+  already gone from the global index) was removed in 3.11.0b1 (#105) to fix
+  orphaned clients, which exposed the latent cycle. ``Trust.delete()`` now deletes
+  the local trust record **first** and performs OAuth2 client cleanup afterwards,
+  so the cascade finds nothing to delete and terminates. Regression test added in
+  ``tests/test_trust_core.py``.
+
 v3.11.0b3: June 16, 2026
 ------------------------
 

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.11.0b3"
+__version__ = "3.11.0b4"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/trust.py
+++ b/actingweb/trust.py
@@ -104,9 +104,14 @@ class Trust:
         result = self.handle.delete()
 
         # If this was an OAuth2 client trust, delete the client registration
-        # (which also revokes tokens). Safe to recurse now: the trust record is
-        # already gone, so the cleanup cascade terminates immediately.
-        if oauth2_client_id and self.config:
+        # (which also revokes tokens). Only do this when the record was actually
+        # removed (result is True): the cleanup cascade re-reads the actor's trust
+        # relationships from the DB, not from the cleared in-memory self.trust, so
+        # if the physical delete failed the record is still live and the cascade
+        # would re-enter Trust.delete() and recurse without bound. Skipping
+        # cleanup on a failed delete keeps the recursion break sound and avoids
+        # revoking a client whose trust relationship still exists.
+        if result and oauth2_client_id and self.config:
             try:
                 # Pass the trust's actor_id to ensure tokens are revoked in the
                 # correct actor (the client registry lookup might otherwise

--- a/actingweb/trust.py
+++ b/actingweb/trust.py
@@ -83,29 +83,46 @@ class Trust:
         if not self.trust:
             self.get()
 
-        # If this is an OAuth2 client trust, delete the client (which also revokes tokens)
+        # Determine whether OAuth2 client cleanup is needed *before* dropping the
+        # local trust data, since both checks read from self.trust.
+        oauth2_client_id: str | None = None
         if self.config and self._is_oauth2_client_trust():
-            client_id = self._extract_client_id_from_peerid()
-            if client_id:
-                try:
-                    # Delete the client registration and revoke tokens
-                    # Pass the trust's actor_id to ensure tokens are revoked in the correct actor
-                    # (the client registry lookup might return a different actor_id)
-                    from .oauth2_server.client_registry import get_mcp_client_registry
+            oauth2_client_id = self._extract_client_id_from_peerid()
 
-                    registry = get_mcp_client_registry(self.config)
-                    registry.delete_client(client_id, actor_id=self.actor_id)
-                    logger.info(
-                        f"Deleted OAuth2 client {client_id} as part of trust deletion"
-                    )
-                except Exception as e:
-                    logger.error(
-                        f"Error deleting OAuth2 client during trust deletion: {e}"
-                    )
-                    # Continue with trust deletion even if client deletion fails
-
+        # Delete the trust record FIRST, then perform OAuth2 client cleanup.
+        #
+        # Ordering is critical to avoid unbounded recursion. delete_client()
+        # cascades into client_registry._delete_client_trust_relationship(),
+        # which re-enumerates this actor's trust relationships and calls
+        # delete_relationship() -> delete_reciprocal_trust() -> Trust.delete()
+        # again. If the trust record still existed at that point, the cascade
+        # would re-discover this very relationship and recurse without bound:
+        # a single actor delete self-deadlocks the DB connection pool and
+        # eventually raises "maximum recursion depth exceeded". Removing the
+        # record up front means the cascade finds nothing to delete and stops.
         self.trust = {}
-        return self.handle.delete()
+        result = self.handle.delete()
+
+        # If this was an OAuth2 client trust, delete the client registration
+        # (which also revokes tokens). Safe to recurse now: the trust record is
+        # already gone, so the cleanup cascade terminates immediately.
+        if oauth2_client_id and self.config:
+            try:
+                # Pass the trust's actor_id to ensure tokens are revoked in the
+                # correct actor (the client registry lookup might otherwise
+                # resolve a different actor_id).
+                from .oauth2_server.client_registry import get_mcp_client_registry
+
+                registry = get_mcp_client_registry(self.config)
+                registry.delete_client(oauth2_client_id, actor_id=self.actor_id)
+                logger.info(
+                    f"Deleted OAuth2 client {oauth2_client_id} as part of trust deletion"
+                )
+            except Exception as e:
+                logger.error(f"Error deleting OAuth2 client during trust deletion: {e}")
+                # Continue even if client deletion fails
+
+        return result
 
     def _is_oauth2_client_trust(self) -> bool:
         """Check if this trust relationship is for an OAuth2 client."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.11.0b3"
+version = "3.11.0b4"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@greger.io>"]
 maintainers = ["Greger Wedel <support@greger.io>"]

--- a/tests/test_trust_core.py
+++ b/tests/test_trust_core.py
@@ -264,6 +264,55 @@ class TestTrustCRUD:
             # OAuth2 client should be deleted
             mock_registry.delete_client.assert_called_once()
 
+    def test_trust_delete_oauth2_client_deletes_record_before_client(self):
+        """Regression: the trust record must be deleted BEFORE delete_client().
+
+        delete_client() cascades back into Trust.delete() via
+        _delete_client_trust_relationship(). If the trust record is not removed
+        first, that cascade re-discovers this same relationship and recurses
+        without bound (the actor-delete self-deadlock / "maximum recursion depth
+        exceeded" bug). Asserting the call order guards the recursion-breaking
+        invariant.
+        """
+        call_order: list[str] = []
+
+        mock_config = Mock()
+        mock_db_trust = Mock()
+        mock_trust_data = {
+            "peerid": "oauth2_client:user@example.com:mcp_client_abc123",
+            "relationship": "friend",
+        }
+        mock_db_trust.get.return_value = mock_trust_data
+        mock_db_trust.delete.side_effect = lambda *a, **k: (
+            call_order.append("record_delete") or True
+        )
+        mock_config.DbTrust.DbTrust.return_value = mock_db_trust
+
+        trust = Trust(
+            actor_id="test_actor",
+            peerid="oauth2_client:user@example.com:mcp_client_abc123",
+            config=mock_config,
+        )
+
+        with patch(
+            "actingweb.oauth2_server.client_registry.get_mcp_client_registry"
+        ) as mock_get_registry:
+            mock_registry = Mock()
+            mock_registry.delete_client.side_effect = lambda *a, **k: (
+                call_order.append("client_delete") or True
+            )
+            mock_get_registry.return_value = mock_registry
+
+            result = trust.delete()
+
+        assert result is True
+        # The local trust record must be removed before the client cleanup that
+        # cascades back into trust deletion.
+        assert call_order == ["record_delete", "client_delete"]
+        mock_registry.delete_client.assert_called_once_with(
+            "mcp_client_abc123", actor_id="test_actor"
+        )
+
 
 class TestTrustsCollection:
     """Test Trusts collection class."""

--- a/tests/test_trust_core.py
+++ b/tests/test_trust_core.py
@@ -276,6 +276,15 @@ class TestTrustCRUD:
         """
         call_order: list[str] = []
 
+        def record(label: str, retval: bool = True):
+            """Side effect that records call order and returns retval."""
+
+            def _side_effect(*_args, **_kwargs):
+                call_order.append(label)
+                return retval
+
+            return _side_effect
+
         mock_config = Mock()
         mock_db_trust = Mock()
         mock_trust_data = {
@@ -283,9 +292,7 @@ class TestTrustCRUD:
             "relationship": "friend",
         }
         mock_db_trust.get.return_value = mock_trust_data
-        mock_db_trust.delete.side_effect = lambda *a, **k: (
-            call_order.append("record_delete") or True
-        )
+        mock_db_trust.delete.side_effect = record("record_delete")
         mock_config.DbTrust.DbTrust.return_value = mock_db_trust
 
         trust = Trust(
@@ -298,9 +305,7 @@ class TestTrustCRUD:
             "actingweb.oauth2_server.client_registry.get_mcp_client_registry"
         ) as mock_get_registry:
             mock_registry = Mock()
-            mock_registry.delete_client.side_effect = lambda *a, **k: (
-                call_order.append("client_delete") or True
-            )
+            mock_registry.delete_client.side_effect = record("client_delete")
             mock_get_registry.return_value = mock_registry
 
             result = trust.delete()
@@ -312,6 +317,44 @@ class TestTrustCRUD:
         mock_registry.delete_client.assert_called_once_with(
             "mcp_client_abc123", actor_id="test_actor"
         )
+
+    def test_trust_delete_skips_client_cleanup_when_record_delete_fails(self):
+        """Regression: OAuth2 client cleanup must NOT run if the record delete fails.
+
+        The cleanup cascade re-reads trust relationships from the DB, so if the
+        physical delete returned False (record still live) running delete_client()
+        would re-enter Trust.delete() and recurse without bound. Cleanup is
+        therefore guarded on a successful delete.
+        """
+        mock_config = Mock()
+        mock_db_trust = Mock()
+        mock_trust_data = {
+            "peerid": "oauth2_client:user@example.com:mcp_client_abc123",
+            "relationship": "friend",
+        }
+        mock_db_trust.get.return_value = mock_trust_data
+        # Physical delete fails (record NOT removed)
+        mock_db_trust.delete.return_value = False
+        mock_config.DbTrust.DbTrust.return_value = mock_db_trust
+
+        trust = Trust(
+            actor_id="test_actor",
+            peerid="oauth2_client:user@example.com:mcp_client_abc123",
+            config=mock_config,
+        )
+
+        with patch(
+            "actingweb.oauth2_server.client_registry.get_mcp_client_registry"
+        ) as mock_get_registry:
+            mock_registry = Mock()
+            mock_get_registry.return_value = mock_registry
+
+            result = trust.delete()
+
+        assert result is False
+        # Cleanup must be skipped — otherwise the cascade re-enters Trust.delete().
+        mock_get_registry.assert_not_called()
+        mock_registry.delete_client.assert_not_called()
 
 
 class TestTrustsCollection:


### PR DESCRIPTION
## Summary

Fixes an unbounded recursion on the actor/trust delete path that exhausts the PostgreSQL connection pool, making actor deletion hang (~30s) and blocking all subsequent DB requests process-wide. Regression on the `3.11.0b` line (green on `3.10.2b9`).

## Root cause

The `maximum recursion depth exceeded` only *surfaces* in `peer_profile.py` — the actual fault is a mutual recursion:

```
Trust.delete()                              actingweb/trust.py
 └─ registry.delete_client(...)             ← called BEFORE the trust record is removed
     └─ _delete_client_trust_relationship() oauth2_server/client_registry.py
         └─ trust.delete_relationship()     interface/trust_manager.py
             └─ delete_reciprocal_trust()   actor.py
                 └─ dbtrust.delete() == Trust.delete()   ← back to the top
```

Because `Trust.delete()` called `delete_client()` **before** `self.handle.delete()`, the trust record still existed when the cascade re-enumerated the actor's relationships, so each level re-discovered the same relationship and recursed without bound. On PostgreSQL each level had pooled connections checked out (per-frame `attribute.Attributes(...)` accesses), so a single delete self-deadlocked the pool (`max=10`) — the connection leak is a *symptom* of the recursion.

## Why it regressed

All the cycle's edges are old, but it used to self-terminate: `delete_client()` removes the client from the global index, so `_load_client()` returns `None` on the second pass, and v3.10.2b9's `delete_client()` began with `if not client_data: return False` — short-circuiting before re-entry. **PR #105 (`687d2d6`)** removed that early return to fix orphaned clients, exposing the latent cycle. `git diff v3.10.2b9 HEAD` touches only `client_registry.py` on the entire delete path.

## Fix

`Trust.delete()` now deletes the local trust record **first**, then performs OAuth2 client cleanup. The cleanup cascade still runs but finds no matching relationship, so it terminates immediately. Fixes both entry points (actor delete and a direct admin `delete_client()`) and preserves #105's orphaned-client fix. Breaking the recursion also resolves the pool exhaustion.

## Tests

- Regression test `tests/test_trust_core.py::TestTrust::test_trust_delete_oauth2_client_deletes_record_before_client` asserts the record-before-client delete order.
- `tests/test_trust_core.py` (32) + `test_oauth2_client_manager.py` + `test_trust_oauth_integration.py` (66 total, DynamoDB-backed) pass; `pyright` and `ruff` clean.

## Release

Pre-release **v3.11.0b4** → TestPyPI. Version bumped in `pyproject.toml` + `actingweb/__init__.py`; CHANGELOG `Unreleased` → `v3.11.0b4: June 17, 2026`. Tag `v3.11.0b4` to be pushed from `master` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)