### PR TITLE
Pre-release v3.11.0b6: logout clears provider token locally without revoking upstream grant

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,28 @@ CHANGELOG
 Unreleased
 ----------
 
+v3.11.0b6: June 19, 2026
+------------------------
+
+FIXED
+~~~~~
+
+- **Logout no longer revokes the upstream identity-provider grant.** On
+  ``/oauth/logout`` (and the ``/oauth/spa/*`` session-token revoke), the
+  handler called the identity provider's token-revocation endpoint for any
+  provider that advertises a ``revocation_uri``. That was acceptable for
+  Google but wrong for **Apple**: hitting ``https://appleid.apple.com/auth/revoke``
+  emails the user ("… has revoked access to sign in with your Apple account")
+  and severs the Sign in with Apple grant entirely — the next login re-prompts
+  for name/email consent and the stored refresh token is invalidated. Logout is
+  a session action, not an account disconnect. The handler now clears the
+  stored provider token locally (so the backend can no longer call provider
+  APIs on the user's behalf) without contacting the provider. Provider-side
+  revocation is reserved for an explicit account-disconnect / delete flow.
+  (Renamed the internal helper ``_revoke_provider_token_for_actor`` →
+  ``_clear_provider_token_for_actor`` in both ``oauth2_endpoints`` and
+  ``oauth2_spa``.)
+
 v3.11.0b5: June 17, 2026
 ------------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,9 @@ FIXED
   revocation is reserved for an explicit account-disconnect / delete flow.
   (Renamed the internal helper ``_revoke_provider_token_for_actor`` →
   ``_clear_provider_token_for_actor`` in both ``oauth2_endpoints`` and
-  ``oauth2_spa``.)
+  ``oauth2_spa``.) The local clear now nulls every credential field written on
+  login — ``oauth_token``, ``oauth_token_expiry`` and ``oauth_token_timestamp``
+  — leaving only ``oauth_provider`` (identity metadata, not a credential).
 
 v3.11.0b5: June 17, 2026
 ------------------------

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.11.0b5"
+__version__ = "3.11.0b6"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/handlers/oauth2_endpoints.py
+++ b/actingweb/handlers/oauth2_endpoints.py
@@ -1005,11 +1005,17 @@ class OAuth2EndpointsHandler(BaseHandler):
                 return
 
             if actor.store.oauth_token:
+                # Clear all credential fields written on login (oauth_session.py).
+                # oauth_provider is left intact: it is identity metadata, not a
+                # credential, and a subsequent login may branch on it.
                 actor.store.oauth_token = None
                 actor.store.oauth_token_expiry = None
+                actor.store.oauth_token_timestamp = None
                 logger.info(
                     f"Cleared stored provider token for actor {actor_id} on logout"
                 )
+            else:
+                logger.debug(f"No provider token to clear for actor {actor_id}")
         except Exception as e:
             logger.debug(f"Clearing provider token for actor {actor_id}: {e}")
 

--- a/actingweb/handlers/oauth2_endpoints.py
+++ b/actingweb/handlers/oauth2_endpoints.py
@@ -921,12 +921,13 @@ class OAuth2EndpointsHandler(BaseHandler):
 
     def _handle_provider_token_logout(self, token: str) -> dict[str, Any]:
         """
-        Handle logout by invalidating the ActingWeb session and revoking
-        the provider's OAuth token (for providers that support revocation).
+        Handle logout by invalidating the ActingWeb session and clearing the
+        provider's OAuth token from the actor store.
 
-        The token passed here is an ActingWeb-generated session token.
-        We look up the actor from it, then revoke the actual provider
-        token stored in actor.store with the provider's revocation endpoint.
+        The token passed here is an ActingWeb-generated session token. We look
+        up the actor from it, then clear the stored provider token locally. We
+        do NOT call the provider's revocation endpoint — logout is not an
+        account disconnect (see _clear_provider_token_for_actor).
 
         Args:
             token: ActingWeb session token
@@ -939,14 +940,14 @@ class OAuth2EndpointsHandler(BaseHandler):
 
             session_manager = get_oauth2_session_manager(self.config)
 
-            # Look up actor from the session token so we can revoke
+            # Look up actor from the session token so we can clear
             # the provider's token stored in actor.store
             try:
                 token_data = session_manager.validate_access_token(token)
                 if token_data:
                     actor_id = token_data.get("actor_id")
                     if actor_id:
-                        self._revoke_provider_token_for_actor(actor_id)
+                        self._clear_provider_token_for_actor(actor_id)
             except Exception as lookup_error:
                 logger.debug(f"Provider token lookup during logout: {lookup_error}")
 
@@ -980,55 +981,37 @@ class OAuth2EndpointsHandler(BaseHandler):
                 "redirect_url": f"{self.config.proto}{self.config.fqdn}/",
             }
 
-    def _revoke_provider_token_for_actor(self, actor_id: str) -> None:
+    def _clear_provider_token_for_actor(self, actor_id: str) -> None:
         """
-        Revoke the OAuth provider's token stored in actor.store.
+        Clear the stored OAuth provider token from the actor store on logout.
 
-        Looks up the actor, reads the provider token and provider name
-        from the store, and sends the token to the provider's revocation
-        endpoint. Only effective for providers that support revocation
-        (e.g., Google). GitHub does not support token revocation.
+        Logout ends the local ActingWeb session only; it must NOT call the
+        identity provider's token-revocation endpoint. For Apple in particular,
+        hitting ``/auth/revoke`` emails the user ("… has revoked access to sign
+        in with your Apple account") and severs the Sign in with Apple grant —
+        the next login re-prompts for name/email consent and the stored refresh
+        token is invalidated. Provider-side revocation belongs to an explicit
+        account-disconnect / delete flow, not to logout.
 
-        This is best-effort — failures are logged but do not affect logout.
+        Nulling the stored token locally is sufficient to stop the backend from
+        making further API calls on the user's behalf. Best-effort: failures are
+        logged but never block logout.
         """
         try:
             from .. import actor as actor_module
-            from ..oauth2 import create_oauth2_authenticator
 
             actor = actor_module.Actor(actor_id=actor_id, config=self.config)
             if not actor.id or not actor.store:
                 return
 
-            provider_token = actor.store.oauth_token
-            provider_name = getattr(actor.store, "oauth_provider", "") or ""
-
-            if not provider_token:
-                logger.debug(f"No provider token stored for actor {actor_id}")
-                return
-
-            authenticator = create_oauth2_authenticator(self.config, provider_name)
-
-            if not authenticator.provider.revocation_uri:
-                logger.debug(
-                    f"Provider {provider_name or 'default'} does not support "
-                    f"token revocation, skipping"
-                )
-                return
-
-            if authenticator.revoke_token(str(provider_token)):
-                logger.info(
-                    f"Revoked {provider_name or 'default'} provider token "
-                    f"for actor {actor_id}"
-                )
-                # Clear the stored provider token
+            if actor.store.oauth_token:
                 actor.store.oauth_token = None
                 actor.store.oauth_token_expiry = None
-            else:
-                logger.debug(
-                    f"Provider token revocation returned false for actor {actor_id}"
+                logger.info(
+                    f"Cleared stored provider token for actor {actor_id} on logout"
                 )
         except Exception as e:
-            logger.debug(f"Provider token revocation for actor {actor_id}: {e}")
+            logger.debug(f"Clearing provider token for actor {actor_id}: {e}")
 
     def error_response(self, status_code: int, message: str) -> dict[str, Any]:
         """Create OAuth2 error response."""

--- a/actingweb/handlers/oauth2_spa.py
+++ b/actingweb/handlers/oauth2_spa.py
@@ -1673,11 +1673,17 @@ class OAuth2SPAHandler(BaseHandler):
                 return
 
             if actor.store.oauth_token:
+                # Clear all credential fields written on login (oauth_session.py).
+                # oauth_provider is left intact: it is identity metadata, not a
+                # credential, and a subsequent login may branch on it.
                 actor.store.oauth_token = None
                 actor.store.oauth_token_expiry = None
+                actor.store.oauth_token_timestamp = None
                 logger.info(
                     f"Cleared stored provider token for actor {actor_id} on logout"
                 )
+            else:
+                logger.debug(f"No provider token to clear for actor {actor_id}")
         except Exception as e:
             logger.debug(f"Clearing provider token for actor {actor_id}: {e}")
 

--- a/actingweb/handlers/oauth2_spa.py
+++ b/actingweb/handlers/oauth2_spa.py
@@ -1406,13 +1406,13 @@ class OAuth2SPAHandler(BaseHandler):
             if token_type_hint == "refresh_token":
                 session_manager.revoke_refresh_token(token)
             else:
-                # Look up actor from session token and revoke provider token
+                # Look up actor from session token and clear provider token
                 try:
                     token_data = session_manager.validate_access_token(token)
                     if token_data:
                         actor_id = token_data.get("actor_id")
                         if actor_id:
-                            self._revoke_provider_token_for_actor(actor_id)
+                            self._clear_provider_token_for_actor(actor_id)
                 except Exception as lookup_error:
                     logger.debug(f"Provider token lookup during revoke: {lookup_error}")
                 session_manager.revoke_access_token(token)
@@ -1434,9 +1434,10 @@ class OAuth2SPAHandler(BaseHandler):
 
         POST /oauth/spa/logout
 
-        Clears all tokens and cookies. Also revokes the stored provider token
-        (e.g., Google) so the backend can no longer make API calls on behalf
-        of the user.
+        Clears all tokens and cookies. Also clears the stored provider token
+        locally so the backend can no longer make API calls on behalf of the
+        user — but does NOT call the provider's revocation endpoint (logout is
+        not an account disconnect; see _clear_provider_token_for_actor).
         """
         # Get token to revoke
         token = None
@@ -1465,7 +1466,7 @@ class OAuth2SPAHandler(BaseHandler):
                     if token_data:
                         actor_id = token_data.get("actor_id")
                         if actor_id:
-                            self._revoke_provider_token_for_actor(actor_id)
+                            self._clear_provider_token_for_actor(actor_id)
                 except Exception as lookup_error:
                     logger.debug(f"Provider token lookup during logout: {lookup_error}")
 
@@ -1647,55 +1648,38 @@ class OAuth2SPAHandler(BaseHandler):
                         secure=True,
                     )
 
-    def _revoke_provider_token_for_actor(self, actor_id: str) -> None:
+    def _clear_provider_token_for_actor(self, actor_id: str) -> None:
         """
-        Revoke the OAuth provider's token stored in actor.store.
+        Clear the stored OAuth provider token from the actor store on logout.
 
-        Looks up the actor, reads the provider token and provider name
-        from the store, and sends the token to the provider's revocation
-        endpoint. Only effective for providers that support revocation
-        (e.g., Google). GitHub does not support token revocation.
+        Logout (and session-token revocation) ends the local ActingWeb session
+        only; it must NOT call the identity provider's token-revocation
+        endpoint. For Apple in particular, hitting ``/auth/revoke`` emails the
+        user ("… has revoked access to sign in with your Apple account") and
+        severs the Sign in with Apple grant — the next login re-prompts for
+        name/email consent and the stored refresh token is invalidated.
+        Provider-side revocation belongs to an explicit account-disconnect /
+        delete flow, not to logout.
 
-        This is best-effort — failures are logged but do not affect logout.
+        Nulling the stored token locally is sufficient to stop the backend from
+        making further API calls on the user's behalf. Best-effort: failures are
+        logged but never block logout.
         """
         try:
             from .. import actor as actor_module
-            from ..oauth2 import create_oauth2_authenticator
 
             actor = actor_module.Actor(actor_id=actor_id, config=self.config)
             if not actor.id or not actor.store:
                 return
 
-            provider_token = actor.store.oauth_token
-            provider_name = getattr(actor.store, "oauth_provider", "") or ""
-
-            if not provider_token:
-                logger.debug(f"No provider token stored for actor {actor_id}")
-                return
-
-            authenticator = create_oauth2_authenticator(self.config, provider_name)
-
-            if not authenticator.provider.revocation_uri:
-                logger.debug(
-                    f"Provider {provider_name or 'default'} does not support "
-                    f"token revocation, skipping"
-                )
-                return
-
-            if authenticator.revoke_token(str(provider_token)):
-                logger.info(
-                    f"Revoked {provider_name or 'default'} provider token "
-                    f"for actor {actor_id}"
-                )
-                # Clear the stored provider token
+            if actor.store.oauth_token:
                 actor.store.oauth_token = None
                 actor.store.oauth_token_expiry = None
-            else:
-                logger.debug(
-                    f"Provider token revocation returned false for actor {actor_id}"
+                logger.info(
+                    f"Cleared stored provider token for actor {actor_id} on logout"
                 )
         except Exception as e:
-            logger.debug(f"Provider token revocation for actor {actor_id}: {e}")
+            logger.debug(f"Clearing provider token for actor {actor_id}: {e}")
 
     def _json_error(self, status_code: int, message: str) -> dict[str, Any]:
         """Create JSON error response."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.11.0b5"
+version = "3.11.0b6"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@greger.io>"]
 maintainers = ["Greger Wedel <support@greger.io>"]

--- a/tests/test_oauth2_spa.py
+++ b/tests/test_oauth2_spa.py
@@ -746,10 +746,28 @@ class TestLogoutDoesNotRevokeProviderGrant:
         store = MagicMock()
         store.oauth_token = "apple-refresh-token"
         store.oauth_token_expiry = 9999999999
+        store.oauth_token_timestamp = "1700000000"
         actor = MagicMock()
         actor.id = "actor-1"
         actor.store = store
         return actor
+
+    @staticmethod
+    def _spa_handler(mock_webobj, mock_config):
+        from actingweb.handlers.oauth2_spa import OAuth2SPAHandler
+
+        return OAuth2SPAHandler(mock_webobj, mock_config)
+
+    @staticmethod
+    def _endpoints_handler(mock_webobj, mock_config):
+        from unittest.mock import patch
+
+        with patch(
+            "actingweb.oauth2_server.oauth2_server.get_actingweb_oauth2_server"
+        ):
+            from actingweb.handlers.oauth2_endpoints import OAuth2EndpointsHandler
+
+            return OAuth2EndpointsHandler(mock_webobj, mock_config)
 
     def test_spa_logout_clears_token_without_calling_provider_revoke(
         self, mock_config, mock_webobj
@@ -768,6 +786,7 @@ class TestLogoutDoesNotRevokeProviderGrant:
         # Token cleared locally so the backend can't use it any more...
         assert fake_actor.store.oauth_token is None
         assert fake_actor.store.oauth_token_expiry is None
+        assert fake_actor.store.oauth_token_timestamp is None
         # ...but the IdP revocation endpoint was never reached.
         mk_auth.assert_not_called()
 
@@ -791,4 +810,38 @@ class TestLogoutDoesNotRevokeProviderGrant:
 
         assert fake_actor.store.oauth_token is None
         assert fake_actor.store.oauth_token_expiry is None
+        assert fake_actor.store.oauth_token_timestamp is None
+        mk_auth.assert_not_called()
+
+    def test_clear_is_noop_when_token_already_none(self, mock_config, mock_webobj):
+        """Calling the helper with no stored token is a safe no-op: it must not
+        raise and must not reach the IdP."""
+        from unittest.mock import patch
+
+        fake_actor = self._fake_actor()
+        fake_actor.store.oauth_token = None
+        handler = self._spa_handler(mock_webobj, mock_config)
+        with patch("actingweb.actor.Actor", return_value=fake_actor), patch(
+            "actingweb.oauth2.create_oauth2_authenticator"
+        ) as mk_auth:
+            handler._clear_provider_token_for_actor("actor-1")
+
+        assert fake_actor.store.oauth_token is None
+        mk_auth.assert_not_called()
+
+    def test_clear_handles_missing_actor(self, mock_config, mock_webobj):
+        """The early-return guard (no actor.id / no store) must not raise or
+        touch the IdP when the actor cannot be loaded."""
+        from unittest.mock import patch
+
+        missing_actor = MagicMock()
+        missing_actor.id = None
+        missing_actor.store = None
+        handler = self._spa_handler(mock_webobj, mock_config)
+        with patch("actingweb.actor.Actor", return_value=missing_actor), patch(
+            "actingweb.oauth2.create_oauth2_authenticator"
+        ) as mk_auth:
+            # Must not raise.
+            handler._clear_provider_token_for_actor("does-not-exist")
+
         mk_auth.assert_not_called()

--- a/tests/test_oauth2_spa.py
+++ b/tests/test_oauth2_spa.py
@@ -709,3 +709,86 @@ class TestSpaRedirectSafety:
 
         # May still error on OAuth-not-enabled, but NOT on the redirect check.
         assert result.get("message") != "Invalid redirect_uri"
+
+
+class TestLogoutDoesNotRevokeProviderGrant:
+    """Logout (and session-token revoke) must clear the stored provider token
+    locally but must NOT call the identity provider's revocation endpoint.
+
+    Regression: ``_revoke_provider_token_for_actor`` used to POST to the
+    provider's ``/auth/revoke`` on logout. For Apple that emails the user
+    ("… has revoked access to sign in with your Apple account") and severs the
+    Sign in with Apple grant (next login re-consents, refresh token dies).
+    Logout is not an account disconnect, so the IdP must not be touched.
+    """
+
+    @pytest.fixture
+    def mock_config(self):
+        config = MagicMock()
+        config.proto = "https://"
+        config.fqdn = "test.example.com"
+        config.oauth = {"client_id": "x", "client_secret": "y"}
+        config.oauth2_provider = "apple"
+        return config
+
+    @pytest.fixture
+    def mock_webobj(self):
+        webobj = MagicMock()
+        webobj.request = MagicMock()
+        webobj.request.headers = {"Accept": "application/json"}
+        webobj.request.cookies = {}
+        webobj.response = MagicMock()
+        webobj.response.headers = {}
+        return webobj
+
+    @staticmethod
+    def _fake_actor():
+        store = MagicMock()
+        store.oauth_token = "apple-refresh-token"
+        store.oauth_token_expiry = 9999999999
+        actor = MagicMock()
+        actor.id = "actor-1"
+        actor.store = store
+        return actor
+
+    def test_spa_logout_clears_token_without_calling_provider_revoke(
+        self, mock_config, mock_webobj
+    ):
+        from unittest.mock import patch
+
+        from actingweb.handlers.oauth2_spa import OAuth2SPAHandler
+
+        fake_actor = self._fake_actor()
+        handler = OAuth2SPAHandler(mock_webobj, mock_config)
+        with patch("actingweb.actor.Actor", return_value=fake_actor), patch(
+            "actingweb.oauth2.create_oauth2_authenticator"
+        ) as mk_auth:
+            handler._clear_provider_token_for_actor("actor-1")
+
+        # Token cleared locally so the backend can't use it any more...
+        assert fake_actor.store.oauth_token is None
+        assert fake_actor.store.oauth_token_expiry is None
+        # ...but the IdP revocation endpoint was never reached.
+        mk_auth.assert_not_called()
+
+    def test_endpoints_logout_clears_token_without_calling_provider_revoke(
+        self, mock_config, mock_webobj
+    ):
+        from unittest.mock import patch
+
+        with patch(
+            "actingweb.oauth2_server.oauth2_server.get_actingweb_oauth2_server"
+        ):
+            from actingweb.handlers.oauth2_endpoints import OAuth2EndpointsHandler
+
+            handler = OAuth2EndpointsHandler(mock_webobj, mock_config)
+
+        fake_actor = self._fake_actor()
+        with patch("actingweb.actor.Actor", return_value=fake_actor), patch(
+            "actingweb.oauth2.create_oauth2_authenticator"
+        ) as mk_auth:
+            handler._clear_provider_token_for_actor("actor-1")
+
+        assert fake_actor.store.oauth_token is None
+        assert fake_actor.store.oauth_token_expiry is None
+        mk_auth.assert_not_called()


### PR DESCRIPTION
## Summary

On `/oauth/logout` (and the `/oauth/spa/*` session-token revoke), the handler called the identity provider's token-revocation endpoint for any provider that advertises a `revocation_uri`. That was acceptable for Google but **wrong for Apple**: hitting `https://appleid.apple.com/auth/revoke` emails the user ("… has revoked access to sign in with your Apple account") and severs the Sign in with Apple grant entirely — the next login re-prompts for name/email consent and the stored refresh token is invalidated.

Logout is a session action, not an account disconnect. The handler now clears the stored provider token **locally** (so the backend can no longer call provider APIs on the user's behalf) without contacting the provider. Provider-side revocation is reserved for an explicit account-disconnect / delete flow.

## Changes

- Renamed `_revoke_provider_token_for_actor` → `_clear_provider_token_for_actor` in both `oauth2_endpoints.py` and `oauth2_spa.py`.
- The helper now nulls `oauth_token` / `oauth_token_expiry` in the actor store instead of calling the provider revocation endpoint.
- Updated docstrings and call sites in the logout and session-token revoke paths.
- Added test coverage in `tests/test_oauth2_spa.py`.
- Version bump to `3.11.0b6` (pre-release → TestPyPI on tag).

## Testing

- `poetry run ruff check` — passes
- `poetry run pyright` — 0 errors
- `poetry run pytest tests/test_oauth2_spa.py` — 44 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)