### PR TITLE
Docs overhaul, out-of-the-box web UI templates, and two MCP correctness fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,13 @@ FIXED
   attached empty explicit metadata that shadowed the MCP metadata. Hook metadata
   resolution now merges per field: explicit non-empty values win, otherwise the
   ``@mcp_tool`` metadata (then auto-generated schemas) is used.
+- **Built-in factory templates now honor a URL path prefix.** The sign-in form
+  action and the post-creation "Go to dashboard"/"Back to start" links in the
+  bundled factory templates hardcoded root-relative ``/`` URLs, so a deployment
+  mounted under a prefix (``config.root`` like ``https://host/base/``) posted to
+  and linked at the domain root instead of the mounted app. The factory handler
+  now passes a ``base_path`` (derived from ``config.root``) into the template
+  context and the templates prepend it.
 
 DOCUMENTATION
 ~~~~~~~~~~~~~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,48 @@ CHANGELOG
 Unreleased
 ----------
 
+ADDED
+~~~~~
+
+- **Built-in default web-UI templates.** The library now ships a minimal set of
+  templates (factory/sign-in page, actor dashboard, properties, trust, OAuth2
+  consent, email/verification pages), so ``with_web_ui(True)`` renders a working
+  web UI out of the box with no app-supplied templates. Application templates of
+  the same name still take precedence (Flask: a template-only blueprint; FastAPI:
+  the app ``templates_dir`` is searched first). Both integrations also register a
+  ``/login`` route that renders the sign-in page.
+
+FIXED
+~~~~~
+
+- **``with_mcp(server_name=..., instructions=..., enable=...)`` were silently
+  ignored.** ``ActingWebApp.__init__`` builds the ``Config`` eagerly (permission
+  warmup), and the runtime config-sync did not re-apply the MCP fields, so
+  builder-set MCP options never reached ``Config``. ``config.mcp`` is now a
+  first-class attribute, kept in sync (including the advertised ``/meta``
+  capability tag).
+- **``@mcp_tool`` metadata no longer appears blank in ``GET /<id>/actions``.**
+  Stacking the required ``@app.action_hook("name")`` decorator over ``@mcp_tool``
+  attached empty explicit metadata that shadowed the MCP metadata. Hook metadata
+  resolution now merges per field: explicit non-empty values win, otherwise the
+  ``@mcp_tool`` metadata (then auto-generated schemas) is used.
+
+DOCUMENTATION
+~~~~~~~~~~~~~
+
+- Rewrote ``README.rst`` to reflect the current framework (AI/MCP + web/SPA +
+  native-mobile clients over one backend).
+- Corrected a range of API-reference inaccuracies verified against the code:
+  ``TrustManager``/``SubscriptionManager``/``PropertyStore`` method names and
+  signatures, ``AwProxy`` usage, ``ActorInterface`` attributes, authenticated
+  views, and the ``ActorInterface.create(hooks=app.hooks)`` requirement for
+  lifecycle hooks to fire. Stopped recommending ``actor.is_owner()`` (a
+  placeholder that always returns ``True``) as an access guard.
+- Fixed quickstart friction found by a cold-build usability pass: DynamoDB Local
+  prerequisites, the ``migrate_db.py`` download URL (``master`` branch), MCP
+  endpoint auth (no dev bypass), scalar-property stringification, ``templates_dir``
+  being optional, and Basic-auth vs OAuth for ``/www``.
+
 v3.11.0: July 4, 2026
 ---------------------
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-======================================================
-README - actingweb - an ActingWeb Library
-======================================================
+====================================================================
+ActingWeb — a Python framework for AI-ready, per-user micro-services
+====================================================================
 
 .. image:: https://github.com/actingweb/actingweb/actions/workflows/tests.yml/badge.svg
    :target: https://github.com/actingweb/actingweb/actions/workflows/tests.yml
@@ -18,337 +18,313 @@ README - actingweb - an ActingWeb Library
    :target: https://actingweb.readthedocs.io/en/latest/?badge=latest
    :alt: Documentation Status
 
-This is a python library implementation showcasing the REST-based `ActingWeb <http://actingweb.org>`_
-distributed micro-services model. A typical use case is bot to bot communication on a peer to peer level.
-It serves as the reference implementation for the `ActingWeb REST protocol
-specification <http://actingweb.readthedocs.io/en/release/>`_ for
-how such micro-services interact.
+**ActingWeb** is a Python framework for building secure, per-user services where
+each user gets their own isolated instance — an *actor* — with a unique URL, its
+own data, and its own set of relationships. It is the reference implementation of
+the `ActingWeb REST protocol <https://actingweb.readthedocs.io/>`_ for
+distributed micro-services, and it has grown into a full application framework for
+shipping the same backend to three kinds of clients at once:
 
-Repository and documentation
-----------------------------
+- **AI clients** over the `Model Context Protocol (MCP) <https://modelcontextprotocol.io>`_ —
+  expose per-user tools, prompts, and resources to ChatGPT, Claude, and other LLM
+  hosts, with OAuth2 authentication and per-user data isolation built in.
+- **Web apps** — a built-in server-rendered Web UI for simple deployments, or a
+  first-class **SPA mode** with a hardened token/refresh-token session flow for
+  React/Vue/Svelte front-ends.
+- **Native mobile apps** — iOS, Android, and Capacitor apps sign in with Apple,
+  Google, or GitHub using native OAuth flows (RFC 8252 code exchange, RFC 7523
+  JWT-bearer, and single-use deep-link tickets).
 
-The library is available as a PYPI library and installed with `pip install actingweb`. Project home is at
-`https://pypi.org/project/actingweb/ <https://pypi.org/project/actingweb/>`_.
+The same actor, the same properties, and the same trust and permission model back
+all three. You write your business logic once as hooks and it is reachable from an
+LLM tool call, a browser, a mobile app, or another ActingWeb service over REST.
 
-The git repository for this library can be found at
-`https://github.com/gregertw/actingweb <https://github.com/gregertw/actingweb>`_.
+Why ActingWeb?
+--------------
 
-The latest documentation for the released version (release branch) of this library can be found at 
-`http://actingweb.readthedocs.io/ <http://actingweb.readthedocs.io/>`_.
+ActingWeb is well suited to applications where **each individual user's data needs
+a high degree of security and privacy** *and* a high degree of controlled
+interaction with the outside world — personal AI assistants and memory services,
+IoT "things" that act on a user's behalf, and bot-to-bot / service-to-service
+data sharing where the user stays in control of who sees what.
 
-The master branch of the library has the latest features and bug fixes and the updated documentation can be found at
-`http://actingweb.readthedocs.io/en/master <http://actingweb.readthedocs.io/en/master>`_.
+Its defining constraint is that there is no way to query across users. Getting
+``xyz``'s data is a request to ``/{xyz}/...``; there is no endpoint that returns
+``xyz`` and ``yyz`` together. Sharing between users happens **only** through
+explicit, per-user trust relationships and the standardized ActingWeb REST
+protocol. This makes accidental data leakage structurally hard and makes granular,
+revocable sharing the default rather than an afterthought.
+
+Out of the box you get:
+
+- A REST **actor** representing one user's thing, service, or agent.
+- **Properties** — granular, per-actor key/value (and nested/list) storage exposed
+  over REST with per-property access hooks.
+- A **trust** system for per-user relationships with fine-grained permissions.
+- A **subscription** system so one actor can subscribe to another actor's changes.
+- **OAuth2 authentication** (Google, GitHub, Apple) for both humans and AI clients.
+- **MCP**, **Web UI / SPA**, and **native-mobile** front-ends over one backend.
+- Pluggable persistence: **DynamoDB** (serverless) or **PostgreSQL** (SQL).
+
+Quick example
+-------------
+
+.. code-block:: python
+
+    from actingweb.interface import ActingWebApp, ActorInterface
+    from actingweb.mcp import mcp_tool
+
+    app = (
+        ActingWebApp(
+            aw_type="urn:actingweb:example.com:myapp",
+            database="dynamodb",        # or "postgresql"
+            fqdn="myapp.example.com",
+        )
+        .with_oauth(client_id="...", client_secret="...")  # Google by default
+        .with_web_ui(enable=True)       # server-rendered UI (False for pure SPA)
+        .with_mcp(enable=True, server_name="myapp")         # AI clients over /mcp
+    )
+
+    # Lifecycle hook: initialize each new actor
+    @app.lifecycle_hook("actor_created")
+    def on_actor_created(actor: ActorInterface, **kwargs):
+        actor.properties.email = actor.creator
+
+    # Per-property access control
+    @app.property_hook("email")
+    def handle_email(actor, operation, value, path):
+        if operation == "get":
+            return None                 # hide email from external reads
+        return value
+
+    # An MCP tool — the same callable is reachable at GET/POST /<actor_id>/actions
+    @app.action_hook("search")
+    @mcp_tool(description="Search this actor's properties")
+    def search(actor: ActorInterface, action_name: str, data: dict):
+        q = str(data.get("query", "")).lower()
+        return "\n".join(f"{k}: {v}" for k, v in actor.properties.items()
+                         if q in k.lower() or q in str(v).lower())
+
+    # Wire into your web framework of choice
+    from fastapi import FastAPI
+    api = FastAPI()
+    app.integrate_fastapi(api)          # or app.integrate_flask(flask_app)
+
+The fluent ``ActingWebApp`` builder auto-generates every protocol route
+(``/properties``, ``/trust``, ``/subscriptions``, ``/callbacks``, ``/meta``,
+``/actions``, ``/methods``, the OAuth2 endpoints, and ``/mcp``) and wires your
+hooks in. You supply configuration and business logic; the framework supplies the
+protocol, auth, storage, and client surfaces.
+
+Installation
+------------
+
+ActingWeb requires **Python 3.11+**. Install from PyPI with the extras you need:
+
+.. code-block:: bash
+
+    # Minimal (no database backend or web framework)
+    pip install actingweb
+
+    # Pick a database backend
+    pip install 'actingweb[dynamodb]'
+    pip install 'actingweb[postgresql]'
+
+    # Pick a web framework integration
+    pip install 'actingweb[flask]'
+    pip install 'actingweb[fastapi]'
+
+    # Combine as needed
+    pip install 'actingweb[fastapi,postgresql]'
+
+    # Everything (both backends, both frameworks, MCP)
+    pip install 'actingweb[all]'
+
+Key capabilities
+----------------
+
+Fluent application builder
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``ActingWebApp`` configures the whole application through chained ``with_*``
+builders — OAuth providers, Web UI/SPA, MCP, database backend, indexed properties,
+subscription processing, peer caching, and more — then integrates with Flask or
+FastAPI in one call. Decorator-based hooks (``@app.lifecycle_hook``,
+``@app.property_hook``, ``@app.action_hook``, ``@app.method_hook``,
+``@app.subscription_hook``, ``@app.callback_hook``) replace the boilerplate
+subclassing of older ActingWeb apps.
+
+AI / MCP support
+^^^^^^^^^^^^^^^^
+
+``.with_mcp()`` exposes an authenticated MCP server at ``/mcp``. Action and method
+hooks annotated with ``@mcp_tool`` / ``@mcp_prompt`` become per-user MCP **tools**
+and **prompts**, with safety annotations and input schemas surfaced to the client.
+Because each MCP session is bound to an authenticated actor, an LLM only ever sees
+and mutates that one user's data. See ``docs/guides/mcp-applications.rst`` and
+``docs/guides/mcp-quickstart.rst``.
+
+Authentication: web, SPA, and native mobile
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+OAuth2 with Google, GitHub, and **Sign in with Apple** is built in, with email
+validation, encrypted-state CSRF protection, and login-hint support. Beyond the
+server-rendered login, ActingWeb ships a hardened session layer for rich clients:
+
+- **SPA mode** — ``/oauth/spa/*`` endpoints issue short-lived access tokens and
+  rotating refresh tokens with reuse detection, scoped chain revocation, bounded
+  retention, and a self-contained expiry purge (no cron/Lambda required).
+  ``with_spa_redirect_origins()`` / ``with_spa_cors_origins()`` support
+  split-domain deployments.
+- **Native mobile** — RFC 8252 authorization-code exchange, RFC 7523 JWT-bearer
+  grants (``with_google_native()``, ``with_apple_sign_in()``), and single-use
+  deep-link ``mobile_ticket`` grants (``with_github()`` and Apple-on-Android) so no
+  IdP code or ActingWeb token ever rides a deep link.
+
+See ``docs/guides/authentication.rst``, ``docs/guides/spa-authentication.rst``, and
+``docs/guides/apple-sign-in.rst``.
+
+Trust, permissions, and subscriptions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Per-user trust relationships carry fine-grained permissions that govern what a peer
+(or an AI client) may read, write, or call. Subscriptions let one actor be notified
+of another's changes, with sync or async callback delivery — use
+``.with_sync_callbacks()`` on Lambda/serverless so callbacks complete before the
+function freezes. See ``docs/guides/trust-relationships.rst``,
+``docs/guides/access-control.rst``, and ``docs/guides/subscriptions.rst``.
+
+Pluggable persistence
+^^^^^^^^^^^^^^^^^^^^^^
+
+Two production-ready backends behind a common protocol:
+
+- **DynamoDB** (default) — AWS-managed, auto-scaling, native TTL; ideal for
+  serverless. Uses PynamoDB / boto3.
+- **PostgreSQL** — PostgreSQL 12+ with Alembic migrations and connection pooling.
+  Install with the ``postgresql`` extra.
+
+Select with ``database="postgresql"`` or the ``DATABASE_BACKEND`` environment
+variable. Optional **property reverse-lookup tables** (``with_indexed_properties``)
+enable find-actor-by-property-value without GSI size limits. See
+``docs/reference/database-backends.rst``.
+
+The ActingWeb model
+-------------------
+
+The ActingWeb micro-services model defines bot-to-bot and
+service-to-service communication that allows extreme distribution of data and
+functionality — well suited to holding small pieces of sensitive data on behalf of
+a user or "thing" and sharing them in a granular, revocable way.
+
+The micro-services model
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The programming model focuses on representing exactly **one small set of
+functionality for exactly one user or entity**. The only way to reach that
+functionality is through the user's actor and its REST interface — for example
+``GET https://mini-app-url/{actor_id}/properties/location``. There is no
+cross-actor query, and the security model enforces access per actor: holding a
+token for one actor grants nothing on another. Any cross-actor behavior (``xyz``
+sharing location with ``yyz``) happens through the standardized ActingWeb REST
+protocol, so **any** service that speaks the protocol can interoperate.
+
+The REST protocol
+^^^^^^^^^^^^^^^^^
+
+Each actor exposes a set of standard endpoints under its root URL
+``https://mini-app-url/{actor_id}``:
+
+- ``/properties`` — attribute/value pairs (flat or nested JSON) to store the
+  actor's data.
+- ``/meta`` — a public structure so actors can discover each other's capabilities.
+- ``/trust`` — request, approve, and manage trust relationships with other actors.
+- ``/subscriptions`` — establish and manage subscriptions to another actor's paths
+  once a trust relationship exists.
+- ``/callbacks`` — verification during trust/subscription setup, subscription
+  delivery, and a hook for 3rd-party webhooks.
+- ``/resources`` — a skeleton for exposing arbitrary resources where
+  ``/properties`` does not fit.
+- ``/actions`` and ``/methods`` — application-defined operations (also surfaced as
+  MCP tools/prompts).
+- ``/oauth`` and ``/oauth/spa/*`` — OAuth2 flows tying an actor to an identity
+  provider for web, SPA, and native-mobile clients.
+
+The security model
+^^^^^^^^^^^^^^^^^^
+
+Trust is between **actors**, not applications. Each instance holding a user's
+sensitive data must be connected by a trust relationship to another actor — which
+need not be the same type of application. A location-sharing actor could, for
+example, establish trust with an emergency-services actor so responders can always
+locate the user, while every other relationship remains untouched and independently
+revocable.
+
+Trust is established either through an explicit OAuth flow (tying an actor to an
+account at Google, GitHub, Apple, etc.) or through a trust-request flow where one
+actor requests a relationship that another approves — interactively or
+programmatically over REST. The modern OAuth2 layer adds email validation,
+encrypted-state CSRF protection, provider auto-detection, and the SPA/native-mobile
+session hardening described above.
+
+See `https://actingweb.org/ <https://actingweb.org/>`_ for the model in depth.
+
+Documentation
+-------------
+
+Comprehensive documentation lives in ``docs/`` and is published at
+`https://actingweb.readthedocs.io/ <https://actingweb.readthedocs.io/>`_
+(``/en/master`` for the latest ``master`` branch).
+
+============================================  =========================================
+Topic                                         Location
+============================================  =========================================
+Quickstart & getting started                  ``docs/quickstart/``
+Configuration reference                       ``docs/quickstart/configuration.rst``
+Authentication & OAuth2                        ``docs/guides/authentication.rst``
+SPA authentication                             ``docs/guides/spa-authentication.rst``
+Sign in with Apple                             ``docs/guides/apple-sign-in.rst``
+Building MCP applications                      ``docs/guides/mcp-applications.rst``
+Web UI & routing                               ``docs/guides/web-ui.rst``, ``docs/reference/routing-overview.rst``
+Hooks reference                                ``docs/reference/hooks-reference.rst``
+Trust, access control, subscriptions           ``docs/guides/``
+Database backends                              ``docs/reference/database-backends.rst``
+SDK & developer API                            ``docs/sdk/``
+============================================  =========================================
+
+Repository and links
+---------------------
+
+- **PyPI**: `https://pypi.org/project/actingweb/ <https://pypi.org/project/actingweb/>`_ (``pip install actingweb``)
+- **Source**: `https://github.com/actingweb/actingweb <https://github.com/actingweb/actingweb>`_
+- **Docs**: `https://actingweb.readthedocs.io/ <https://actingweb.readthedocs.io/>`_
+- **Protocol & project home**: `https://actingweb.org/ <https://actingweb.org/>`_
+- **Example application**: `https://github.com/actingweb/actingwebdemo <https://github.com/actingweb/actingwebdemo>`_ —
+  a full reference app (MCP + Web/SPA + OAuth2) to develop against.
 
 Contributing
 ------------
 
-See ``CONTRIBUTING.rst`` for local setup, dev workflow, testing, coding standards, and devtest endpoint usage.
+See ``CONTRIBUTING.rst`` for local setup, the development workflow, testing, and
+coding standards. In short:
 
-Public Demo Application
------------------------
+.. code-block:: bash
 
-For a full example application and reference while developing, see the public demo repo:
-https://github.com/actingweb/actingwebdemo
+    poetry install --extras all      # install with all optional backends/integrations
+    poetry run pyright actingweb tests   # type checking — must be 0 errors
+    poetry run ruff check actingweb tests # linting — must pass
+    make test-all-parallel               # run the full test suite (900+ tests)
 
+ActingWeb holds a zero-tolerance quality standard: type hints on all functions,
+Pyright clean, Ruff clean, and 100% of tests passing before merge.
 
-Why use actingweb?
----------------------
-ActingWeb is well suited for applications where each individual user's data and functionality both needs high degree
-of security and privacy AND high degree of interactions with the outside world. Typical use cases are Internet of Things
-where each user's "Thing" becomes a bot that interacts with the outside world, as well as bot to bot
-communication where each user can get a dedicated, controllable bot talking to other user's bots.
+Releases are decoupled from PRs — PRs merge to ``master`` without version bumps,
+and maintainers cut releases by tagging (``vX.Y.Z``), which triggers CI to publish
+to PyPI. See ``CLAUDE.md`` and ``CHANGELOG.rst`` for the release process and history.
 
-As a developer, you get a set of out of the box functionality from the ActingWeb library:
+License
+-------
 
-- an out-of-the-box REST bot representing each user's thing, service, or functionality (your choice)
-- a way to store and expose data over REST in a very granular way using properties
-- a trust system that allows creation of relationships the user's bot on the user level
-- a subscription system that allows one bot (user) to subscribe to another bot's (user's) changes
-- an oauth framework to tie the bot to any other API service and thus allow user to user communication using
-    individual user's data from the API service
-
-There is a high degree of configurability in what to expose, and although the ActingWeb specification specifies
-a protocol set to allow bots from different developers to talk to each other, not all functionality needs to be
-exposed.`
-
-Each user's indvidual bot is called an ``actor`` and this actor has its own root URL where its data and services are
-exposed. See below for further details.
-
-Features of actingweb library
-----------------------------------
-The latest code in master is at all times deployed to
-`https://actingwebdemo.greger.io/ <https://actingwebdemo.greger.io/>`_
-It has implemented a simple sign-up page as a front-end to a REST-based factory URL that will instantiate a
-new actor with a guid to identify the actor. The guid is then embedded in the actor's root URL, e.g.
-``https://actingwebdemo.greger.io/9f1c331a3e3b5cf38d4c3600a2ab5d54``.
-
-**Modern Interface (v3.2+)**
-
-The library now provides a modern fluent API interface that simplifies application development:
-
-::
-
-    from actingweb.interface import ActingWebApp, ActorInterface
-
-    # Modern fluent configuration API
-    app = (
-        ActingWebApp(
-            aw_type="urn:actingweb:example.com:myapp",
-            database="postgresql",  # or "dynamodb" (default)
-            fqdn="myapp.example.com"
-        )
-        .with_oauth(
-            client_id="your-oauth-client-id",
-            client_secret="your-oauth-client-secret"
-        )
-        .with_web_ui(enable=True)
-        .with_mcp(enable=True)  # Enable Model Context Protocol
-    )
-
-    # Decorator-based hooks instead of classes
-    @app.lifecycle_hook("actor_created")
-    def on_actor_created(actor: ActorInterface, **kwargs):
-        # Initialize new actors
-        actor.properties.email = actor.creator
-
-    @app.property_hook("email")
-    def handle_email_property(actor, operation, value, path):
-        if operation == "get":
-            return None  # Hide email from external access
-        return value
-
-    # Automatic Flask/FastAPI integration
-    from flask import Flask
-    flask_app = Flask(__name__)
-    app.integrate_flask(flask_app)  # Auto-generates all routes
-
-**Key Modern Features:**
-- **Multiple Database Backends**: Choose between DynamoDB (serverless, auto-scaling) or PostgreSQL (SQL, cost-effective)
-- **OAuth2 Authentication**: Modern OAuth2 with Google/GitHub support, email validation, and CSRF protection
-- **Flask/FastAPI Integration**: Automatic route generation with async support for FastAPI
-- **MCP Support**: Model Context Protocol integration for AI language model interactions
-- **Content Negotiation**: Automatic JSON/HTML responses based on client preferences
-- **Type Safety**: Comprehensive type hints and mypy support
-- **90% Less Boilerplate**: Fluent API eliminates repetitive configuration code
-
-If you try to create an actor, you will get to a simple web front-end where you can set the actor's data
-(properties) and delete the actor. You can later access the actor (both /www and REST) by using the Creator
-you set as username and the passphrase you get when creating the actor and log in.
-
-**acting-web-gae-library** is a close to complete implementation of the full ActingWeb specification where all
-functionality can be accessed through the actor's root URL (e.g.
-``https://actingwebdemo.greger.io/9f1c331a3e3b5cf38d4c3600a2ab5d54``):
-
-- ``/properties``: attributed/value pairs as flat or nested json can be set, accessed, and deleted to store this actor's data
-- ``/meta``: a publicly available json structure allowing actor's to discover each other's capabilities
-- ``/trust``: access to requesting, approving, and managing trust relationships with other actors of either the same type or any other actor "talking actingweb"
-- ``/subscriptions``: once a trust relationship is set up, this path allows access to establishing, retrieving, and managing subscriptions that are based on paths and identified with target, sub-target, and resource, e.g. ``/resources/folders/12345``
-- ``/callbacks``: used for verification when establishing trust/subscriptions, to receive callbacks on subscriptions, as well as a programming hook to process webhooks from 3rd party services
-- ``/resources``: a skeleton to simplify exposure of any type of resource (where /properties is not suited)
-- ``/oauth``: used to initiate a www-based oauth flow to tie the actor to a specific OAuth user and service. Available if OAuth is turned on and a 3rd party OAuth service has been configured. The modern interface supports both legacy OAuth and OAuth2 with enhanced security features including email validation and CSRF protection
-
-**Sidenote**: The **actingweb  library** also implements a simple mechanism for protecting the /www path with oauth
-(not in the specification). On successful OAuth authorisation, it will set a browser cookie to the oauth
-token. This is not used in the inline demo and requires also that the identity of the user authorising OAuth
-access is the same user already tied to the instantiated actor. There is a programming hook that allows such
-verification as part of the OAuth flow, but it is not enabled in the actingwebdemo mini-application.
-
-Other applications using the actingweb library
----------------------------------------------------
-There is also another demo application available for `Cisco Webex Teams <http://https://www.webex.com/products/teams>`_
-. It uses the actingweb library to implement a Webex Teams bot and integration. If you have signed up as a
-Cisco Webex Teams user, you can try it out by sending a message to armyknife@webex.bot.
-
-More details about the Army Knife can be found on `this blog <http://stuff.ttwedel.no/tag/spark>`_
-.
-
-The ActingWeb Model
--------------------
-The ActingWeb micro-services model and protocol defines a bot-to-bot and micro-service-to-micro-service
-communication that allows extreme distribution of data and functionality. This makes it very suitable for
-holding small pieces of sensitive data on behalf of a user or "things" (as in Internet of Things).
-These sensitive data can then be used and shared in a very granular and controlled way through the secure
-and distributed ActingWeb REST protocol. This allows you to expose e.g. your location data from your phone
-directly on the Internet (protected by a security framework) and to be used by other services **on your choosing**.
-You can at any time revoke access to your data for one particular service without influencing anything else.
-
-The ActingWeb Micro-Services Model
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The programming model in ActingWeb is based on an extreme focus on only representing one small set of functionality
-and for only one user or entity. This is achieved by not allowing any other way of calling the service
-(in ActingWeb called a "mini-application") than through a user and the mini-app's REST interface (a user's
-instance of a mini-application is called an *actor* in ActingWeb). From a practical point of view, getting xyz's
-location through the REST protocol is as simple as doing a GET ``http://mini-app-url/xyz/properties/location``.
-
-There is absolutely no way of getting xyz's and yyz's location information in one request, and the security model
-enforces access based on user (i.e. actor), so even if you have access to
-``http://mini-app-url/xyz/properties/location``, you may not have access to
-``http://mini-app-url/yyz/properties/location``.
-
-Any functionality desired across actors, for example xyz sharing location information with yyz
-**MUST** be done through the ActingWeb REST protocol. However, since the ActingWeb service-to-service
-REST protocol is standardised, **any** service implementing the protocol can easily share data with other services.
-
-The ActingWeb REST Protocol
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The ActingWeb REST protocol specifies a set of default endpoints (like ``/properties``, ``/trust``,
-``/subscriptions`` etc) that are used to implement the service-to-service communication, as well as a set of
-suggested endpoints (like ``/resources``, ``/actions`` etc) where the mini-applications can expose their own
-functionality. All exchanges are based on REST principles and a set of flows are built into the protocol that
-support exchanging data, establishing trust between actors (per actor, not per mini-application), as well as
-subscribing to changes.
-
-The ActingWeb Security Model
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-The security model is based on trust between actors, not mini-applications. This means that each instance of the
-mini-application holding the sensitive data for one particular person or thing **must** be connected through a trust
-relationship to another ActingWeb actor, but it doesn't have to be a mini-application of the same type (like location
-sharing), but could be a location sharing actor establishing a trust relationship with 911 authorities to
-allow emergency services to always be able to look you up.
-
-There are currently two ways of establishing trust between actors: either through an explicit OAuth flow where an
-actor is tied to somebody's account somewhere else (like Google, GitHub, Box.com, etc) or through a flow where one actor
-requests a trust relationship with another, which then needs to be approved either interactively by a user or
-programatically through the REST interface.
-
-**Enhanced OAuth2 Security (v3.2+):**
-The modern interface includes an enhanced OAuth2 system with additional security measures:
-
-- **Email Validation**: Prevents identity confusion attacks by validating that the OAuth2 email matches the form input
-- **State Parameter Encryption**: CSRF protection through encrypted state parameters
-- **Login Hint Support**: Improved user experience by pre-selecting the correct account during OAuth2 flow
-- **Provider Auto-detection**: Supports Google and GitHub with automatic configuration
-
-See `http://actingweb.org/ <http://actingweb.org/>`_ for more information.
-
-Requirements
-------------
-
-**Python 3.11+**
-
-The actingweb library requires Python 3.11 or higher and uses modern Python features including:
-
-- Type hints with union syntax (``str | None``)
-- F-string formatting
-- Modern enum classes for constants
-- Enhanced error handling with custom exception hierarchies
-
-**Database Backends:**
-
-ActingWeb supports two production-ready database backends:
-
-- **DynamoDB** (default) - AWS DynamoDB with auto-scaling and global tables support
-- **PostgreSQL** - PostgreSQL 12+ with Alembic migrations and connection pooling
-
-Core dependencies:
-
-- ``requests`` - HTTP client library
-
-Backend-specific dependencies (installed via extras):
-
-- **DynamoDB**: ``pynamodb`` (DynamoDB ORM), ``boto3`` (AWS SDK)
-- **PostgreSQL**: ``psycopg`` (PostgreSQL driver with connection pool), ``sqlalchemy`` (for Alembic), ``alembic`` (database migrations)
-
-Development dependencies:
-
-- ``pytest`` - Testing framework
-- ``mypy`` - Static type checker
-- ``black`` - Code formatter
-- ``ruff`` - Fast Python linter
-
-Building and installing
-------------------------
-
-::
-
-    # Install from PyPI (minimal, no database backend):
-    pip install actingweb
-
-    # Install with DynamoDB backend:
-    pip install 'actingweb[dynamodb]'
-
-    # Install with PostgreSQL backend:
-    pip install 'actingweb[postgresql]'
-
-    # Install with Flask/FastAPI integration:
-    pip install 'actingweb[flask,postgresql]'
-    pip install 'actingweb[fastapi,dynamodb]'
-
-    # Install all backends and integrations:
-    pip install 'actingweb[all]'
-
-    # For development with Poetry:
-    poetry install
-    poetry install --with dev,docs --extras all
-
-    # Build source and binary distributions:
-    poetry build
-
-    # Upload to test server:
-    poetry publish --repository pypitest --username=__token__ --password=<your-pypi-token>
-
-    # Upload to production server:
-    poetry publish --username=__token__ --password=<your-pypi-token>
-
-Version Bumping
-^^^^^^^^^^^^^^^
-
-When releasing a new version, update the version string in **three files**:
-
-1. ``pyproject.toml`` - ``version = "X.Y.Z"``
-2. ``actingweb/__init__.py`` - ``__version__ = "X.Y.Z"``
-3. ``CHANGELOG.rst`` - Add new version entry at the top
-
-Development
------------
-
-The library uses modern Python development practices with Poetry:
-
-::
-
-    # Install development dependencies:
-    poetry install --with dev,docs
-
-    # Install git hooks (recommended for contributors):
-    bash scripts/install-git-hooks.sh
-
-    # Run tests:
-    poetry run pytest
-
-    # Type checking:
-    poetry run mypy actingweb
-
-    # Code formatting:
-    poetry run black actingweb tests
-
-    # Linting:
-    poetry run ruff check actingweb tests
-
-    # Activate virtual environment:
-    poetry shell
-
-Git Hooks
-^^^^^^^^^
-
-The repository includes a pre-commit hook that automatically regenerates ``docs/requirements.txt``
-when ``pyproject.toml`` is modified. This ensures ReadTheDocs can build documentation with the
-correct dependencies.
-
-**Install the hook:**
-
-::
-
-    bash scripts/install-git-hooks.sh
-
-**What it does:**
-
-- Detects when ``pyproject.toml`` is changed in a commit
-- Runs ``poetry export --with docs --without-hashes -o docs/requirements.txt``
-- Automatically stages the updated ``docs/requirements.txt``
-- Fails the commit if export fails
-
-**Manual regeneration:**
-
-::
-
-    poetry export --with docs --without-hashes -o docs/requirements.txt
+BSD. See ``LICENSE``.
+</content>
+</invoke>

--- a/actingweb/config.py
+++ b/actingweb/config.py
@@ -327,7 +327,8 @@ class Config:
         if self._check_trust_permissions_available():
             base_supported.append("trustpermissions")
 
-        if kwargs.get("mcp", False):
+        self.mcp: bool = kwargs.get("mcp", False)
+        if self.mcp:
             base_supported.append("mcp")
 
         self.mcp_server_name = kwargs.get("mcp_server_name", "actingweb")
@@ -383,6 +384,14 @@ class Config:
         """
         # Parse existing options into a set
         current_options = set(self.aw_supported.split(","))
+
+        # Keep the "mcp" capability tag in sync with the enable flag so that
+        # toggling MCP via the builder after Config construction is reflected in
+        # the advertised /meta capabilities.
+        if getattr(self, "mcp", False):
+            current_options.add("mcp")
+        else:
+            current_options.discard("mcp")
 
         # Add permission-related option tags if peer permissions caching is enabled
         if getattr(self, "peer_permissions_caching", False):

--- a/actingweb/handlers/factory.py
+++ b/actingweb/handlers/factory.py
@@ -9,6 +9,21 @@ logger = logging.getLogger(__name__)
 
 
 class RootFactoryHandler(base_handler.BaseHandler):
+    def _base_path(self) -> str:
+        """Return the URL path prefix the app is mounted under, e.g. "/base" or "".
+
+        Derived from ``config.root`` (which may be ``https://host/base/``) so the
+        built-in factory templates keep working behind a path prefix.
+        """
+        try:
+            from urllib.parse import urlparse
+
+            if self.config and getattr(self.config, "root", None):
+                return urlparse(self.config.root).path.rstrip("/")
+        except (ValueError, AttributeError):
+            pass
+        return ""
+
     def _wants_json(self) -> bool:
         """Check if client prefers JSON response."""
         # Check Accept header
@@ -176,6 +191,7 @@ class RootFactoryHandler(base_handler.BaseHandler):
                 "oauth_urls": oauth_urls,  # Dict: {'google': url, 'github': url}
                 "oauth_providers": oauth_providers,  # List of dicts with name, display_name, url
                 "oauth_enabled": bool(oauth_urls),
+                "base_path": self._base_path(),
             }
         else:
             self.response.set_status(404)
@@ -253,6 +269,7 @@ class RootFactoryHandler(base_handler.BaseHandler):
 
             # Generic creation failure
             self.response.set_status(400, "Not created")
+            self.response.template_values = {"base_path": self._base_path()}
             logger.warning(
                 "Was not able to create new Actor("
                 + str(self.request.url)
@@ -273,7 +290,7 @@ class RootFactoryHandler(base_handler.BaseHandler):
         if trustee_root and isinstance(trustee_root, str) and len(trustee_root) > 0:
             pair["trustee_root"] = trustee_root
         if self.config.ui and not is_json:
-            self.response.template_values = pair
+            self.response.template_values = {**pair, "base_path": self._base_path()}
             return
         out = json.dumps(pair)
         self.response.write(out)

--- a/actingweb/interface/app.py
+++ b/actingweb/interface/app.py
@@ -157,6 +157,13 @@ class ActingWebApp:
         self._config.www_auth = self._www_auth
         self._config.unique_creator = self._unique_creator
         self._config.force_email_prop_as_creator = self._force_email_prop_as_creator
+        # MCP configuration. Must be re-applied here because __init__ builds the
+        # Config eagerly (via _initialize_permission_system) before with_mcp()
+        # runs; without this, with_mcp(enable=..., server_name=..., instructions=)
+        # would be silently ignored on the cached config.
+        self._config.mcp = self._enable_mcp
+        self._config.mcp_server_name = self._mcp_server_name
+        self._config.mcp_instructions = self._mcp_instructions
         # OAuth configuration — multi-provider support
         if self._oauth_configs:
             # Build named providers (skip the empty-string default key)

--- a/actingweb/interface/hooks.py
+++ b/actingweb/interface/hooks.py
@@ -267,24 +267,34 @@ def get_hook_metadata(func: Callable[..., Any]) -> HookMetadata:
     # Get auto-generated schemas from type hints (used as fallback)
     auto_input, auto_output = _get_auto_schemas(func)
 
+    # MCP metadata from @mcp_tool / @mcp_prompt, if the hook also carries it.
+    mcp_meta: dict[str, Any] = getattr(func, "_mcp_metadata", None) or {}
+
     # Check for explicit hook metadata
     if hasattr(func, "_hook_metadata"):
         metadata: HookMetadata = getattr(func, "_hook_metadata")  # noqa: B009
-        # Fill in auto-generated schemas if not explicitly provided
+        # Explicit @action_hook / @method_hook metadata takes precedence, but
+        # fall back to @mcp_tool metadata for any field the explicit decorator
+        # left unset. This matters because the mandatory registration decorator
+        # ``@app.action_hook("name")`` attaches an *empty* HookMetadata
+        # (description="", schemas=None); without this merge that empty metadata
+        # would shadow the populated @mcp_tool metadata and leave GET /actions
+        # blank for MCP tools.
         return HookMetadata(
-            description=metadata.description,
+            description=metadata.description or mcp_meta.get("description", "") or "",
             input_schema=metadata.input_schema
             if metadata.input_schema is not None
-            else auto_input,
+            else (mcp_meta.get("input_schema") or auto_input),
             output_schema=metadata.output_schema
             if metadata.output_schema is not None
-            else auto_output,
-            annotations=metadata.annotations,
+            else (mcp_meta.get("output_schema") or auto_output),
+            annotations=metadata.annotations
+            if metadata.annotations is not None
+            else mcp_meta.get("annotations"),
         )
 
     # Fall back to MCP metadata if available
-    if hasattr(func, "_mcp_metadata"):
-        mcp_meta = getattr(func, "_mcp_metadata")  # noqa: B009
+    if mcp_meta:
         return HookMetadata(
             description=mcp_meta.get("description", "") or "",
             input_schema=mcp_meta.get("input_schema") or auto_input,

--- a/actingweb/interface/integrations/base_integration.py
+++ b/actingweb/interface/integrations/base_integration.py
@@ -5,12 +5,27 @@ This module contains common handler selection logic, utility methods, and
 patterns used by both Flask and FastAPI integrations.
 """
 
+import os
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ...config import Config
     from ...handlers import base_handler
     from ..app import ActingWebApp
+
+
+def default_templates_dir() -> str:
+    """Absolute path to the library's built-in default web-UI templates.
+
+    ActingWeb ships a minimal set of templates (factory/create page, actor
+    dashboard, properties, trust, OAuth2 consent, ...) so that
+    ``with_web_ui(True)`` renders a working web UI out of the box. Applications
+    that provide their own template with the same filename always take
+    precedence over these defaults (see the loader wiring in each integration).
+    """
+    return os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "templates")
+    )
 
 
 class BaseActingWebIntegration:

--- a/actingweb/interface/integrations/fastapi_integration.py
+++ b/actingweb/interface/integrations/fastapi_integration.py
@@ -25,7 +25,7 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from ... import request_context
 from ...aw_web_request import AWWebObj
 from ...handlers import bot, factory, services
-from .base_integration import BaseActingWebIntegration
+from .base_integration import BaseActingWebIntegration, default_templates_dir
 
 if TYPE_CHECKING:
     from ..app import ActingWebApp
@@ -514,9 +514,15 @@ class FastAPIIntegration(BaseActingWebIntegration):
     ):
         super().__init__(aw_app)
         self.fastapi_app = fastapi_app
-        self.templates = (
-            Jinja2Templates(directory=templates_dir) if templates_dir else None
-        )
+        # Always configure templates: the app-supplied directory (if any) is
+        # searched first so app templates override the library defaults, and the
+        # built-in defaults fill in the rest so with_web_ui(True) works out of
+        # the box.
+        template_dirs: list[str] = []
+        if templates_dir:
+            template_dirs.append(templates_dir)
+        template_dirs.append(default_templates_dir())
+        self.templates = Jinja2Templates(directory=template_dirs)
         self.logger = logging.getLogger(__name__)
         # Thread pool for running synchronous ActingWeb handlers
         # Size is configurable via ActingWebApp.with_thread_pool_workers()
@@ -598,6 +604,13 @@ class FastAPIIntegration(BaseActingWebIntegration):
         @self.fastapi_app.get("/")
         async def app_root_get(request: Request) -> Response:  # pyright: ignore[reportUnusedFunction]
             # GET requests don't require authentication - show email form
+            return await self._handle_factory_get_request(request)
+
+        # Login page - unauthenticated browsers are redirected here. Renders the
+        # same factory/sign-in page as "/" so the built-in web UI works out of
+        # the box.
+        @self.fastapi_app.get("/login")
+        async def app_login_get(request: Request) -> Response:  # pyright: ignore[reportUnusedFunction]
             return await self._handle_factory_get_request(request)
 
         @self.fastapi_app.post("/")

--- a/actingweb/interface/integrations/flask_integration.py
+++ b/actingweb/interface/integrations/flask_integration.py
@@ -14,7 +14,7 @@ from werkzeug.wrappers import Response as WerkzeugResponse
 from ... import request_context
 from ...aw_web_request import AWWebObj
 from ...handlers import bot, factory, mcp, services
-from .base_integration import BaseActingWebIntegration
+from .base_integration import BaseActingWebIntegration, default_templates_dir
 
 if TYPE_CHECKING:
     from ..app import ActingWebApp
@@ -33,7 +33,33 @@ class FlaskIntegration(BaseActingWebIntegration):
     def __init__(self, aw_app: "ActingWebApp", flask_app: Flask):
         super().__init__(aw_app)
         self.flask_app = flask_app
+        self._install_default_templates()
         self._setup_context_hooks()
+
+    def _install_default_templates(self) -> None:
+        """Register the library's built-in templates as a fallback source.
+
+        Flask's template loader searches the application's own ``templates/``
+        directory first and blueprint template folders afterwards, so any
+        app-provided template overrides the library default of the same name.
+        The library defaults fill in whatever the app does not supply, making
+        ``with_web_ui(True)`` work out of the box. Registering a template-only
+        Blueprint (no routes) is the idiomatic, precedence-correct way to do
+        this. It is a no-op if already registered (e.g. re-integration).
+        """
+        from flask import Blueprint
+
+        blueprint = Blueprint(
+            "actingweb_default_templates",
+            __name__,
+            template_folder=default_templates_dir(),
+        )
+        try:
+            self.flask_app.register_blueprint(blueprint)
+        except ValueError:
+            # Already registered (e.g. the app was integrated twice); the
+            # default templates are already available, so nothing to do.
+            pass
 
     def _setup_context_hooks(self) -> None:
         """
@@ -113,6 +139,13 @@ class FlaskIntegration(BaseActingWebIntegration):
             else:
                 # For web form requests, extract email and redirect to OAuth2 with email hint
                 return self._handle_factory_post_with_oauth_redirect()
+
+        # Login page - unauthenticated browsers are redirected here (see
+        # _handle_actor_request). Renders the same factory/sign-in page as "/"
+        # so the built-in web UI works out of the box.
+        @self.flask_app.route("/login", methods=["GET"])
+        def app_login_get() -> Response | WerkzeugResponse | str:  # pyright: ignore[reportUnusedFunction]
+            return self._handle_factory_get_request()
 
         # OAuth2 callback - handles both ActingWeb and MCP OAuth2 flows
         @self.flask_app.route("/oauth/callback", methods=["GET"])

--- a/actingweb/templates/aw-actor-www-init.html
+++ b/actingweb/templates/aw-actor-www-init.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block title %}Actor initialized - ActingWeb{% endblock %}
+{% block content %}
+<div class="aw-card">
+  <h1>Actor initialized</h1>
+  <p>Your actor <code>{{ id|default('') }}</code> is ready.</p>
+  <div class="aw-nav">
+    <a class="aw-btn" href="{{ actor_www|default('') }}">Go to dashboard</a>
+    <a class="aw-btn aw-btn-secondary" href="{{ actor_root|default('') }}">Actor root</a>
+  </div>
+</div>
+{% endblock %}

--- a/actingweb/templates/aw-actor-www-properties.html
+++ b/actingweb/templates/aw-actor-www-properties.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% block title %}Properties - ActingWeb{% endblock %}
+{% block content %}
+<div class="aw-card">
+  <div class="aw-nav">
+    <a href="{{ actor_www|default('') }}">&larr; Dashboard</a>
+  </div>
+  <h1>Properties</h1>
+
+  {% if properties %}
+    <div class="aw-table-wrap">
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Value</th><th></th></tr>
+      </thead>
+      <tbody>
+        {% for name, value in properties.items() %}
+          {% set is_read_only = name in read_only_properties %}
+          {% set is_list = name in list_properties %}
+          <tr>
+            <td>
+              <a href="{{ actor_www|default('') }}/properties/{{ name }}">{{ name }}</a>
+              {% if is_read_only %}<span class="aw-badge">read-only</span>{% endif %}
+              {% if is_list %}<span class="aw-badge">list</span>{% endif %}
+            </td>
+            <td><code>{{ value|default('') }}</code></td>
+            <td>
+              {% if not is_read_only %}
+                <form class="aw-inline" method="get" action="{{ actor_www|default('') }}/properties/{{ name }}"
+                      onsubmit="return confirm('Delete property {{ name }}?');">
+                  <input type="hidden" name="_method" value="DELETE">
+                  <button type="submit" class="aw-btn aw-btn-danger">Delete</button>
+                </form>
+              {% endif %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    </div>
+  {% else %}
+    <p class="aw-muted">No properties yet.</p>
+  {% endif %}
+
+  <h2>Add property</h2>
+  <form method="post" action="{{ actor_www|default('') }}/properties">
+    <input type="hidden" name="property_type" value="simple">
+    <label for="property_name">Name</label>
+    <input type="text" id="property_name" name="property_name" required>
+    <label for="property_value">Value</label>
+    <input type="text" id="property_value" name="property_value" required>
+    <p></p>
+    <input type="submit" value="Save property">
+  </form>
+</div>
+{% endblock %}

--- a/actingweb/templates/aw-actor-www-property.html
+++ b/actingweb/templates/aw-actor-www-property.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% block title %}{{ property|default('Property') }} - ActingWeb{% endblock %}
+{% block content %}
+<div class="aw-card">
+  <div class="aw-nav">
+    <a href="{{ actor_www|default('') }}/properties">&larr; Properties</a>
+  </div>
+  <h1>
+    {{ property|default('Property') }}
+    {% if is_read_only %}<span class="aw-badge">read-only</span>{% endif %}
+    {% if is_list_property %}<span class="aw-badge">list</span>{% endif %}
+  </h1>
+
+  {% if qual == 'n' %}
+    <p class="aw-muted">Property not found.</p>
+    <p><a class="aw-btn aw-btn-secondary" href="{{ actor_www|default('') }}/properties">Back to properties</a></p>
+
+  {% elif is_list_property %}
+    {% if list_description %}<p>{{ list_description }}</p>{% endif %}
+    {% if list_explanation %}<p class="aw-muted">{{ list_explanation }}</p>{% endif %}
+    {% if list_items %}
+      <div class="aw-table-wrap">
+      <table>
+        <thead><tr><th>#</th><th>Item</th></tr></thead>
+        <tbody>
+          {% for item in list_items %}
+            <tr><td>{{ loop.index0 }}</td><td><code>{{ item }}</code></td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      </div>
+    {% else %}
+      <p class="aw-muted">This list is empty.</p>
+    {% endif %}
+
+  {% else %}
+    <h2>Value</h2>
+    <pre>{{ value|default('') }}</pre>
+
+    {% if not is_read_only %}
+      <h2>Edit</h2>
+      <form method="post" action="{{ actor_www|default('') }}/properties/{{ property|default('') }}">
+        <label for="value">New value</label>
+        <input type="text" id="value" name="value" value="{{ raw_value|default('') }}">
+        <p></p>
+        <input type="submit" value="Update">
+      </form>
+
+      <h2>Delete</h2>
+      <form method="get" action="{{ actor_www|default('') }}/properties/{{ property|default('') }}"
+            onsubmit="return confirm('Delete property {{ property|default('') }}?');">
+        <input type="hidden" name="_method" value="DELETE">
+        <button type="submit" class="aw-btn aw-btn-danger">Delete property</button>
+      </form>
+    {% endif %}
+  {% endif %}
+</div>
+{% endblock %}

--- a/actingweb/templates/aw-actor-www-root.html
+++ b/actingweb/templates/aw-actor-www-root.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}Dashboard - ActingWeb{% endblock %}
+{% block content %}
+<div class="aw-card">
+  <h1>Actor dashboard</h1>
+  <table>
+    <tr><th>Actor ID</th><td><code>{{ id|default('') }}</code></td></tr>
+    {% if creator %}<tr><th>Creator</th><td><code>{{ creator }}</code></td></tr>{% endif %}
+  </table>
+
+  <h2>Manage</h2>
+  <div class="aw-nav">
+    <a class="aw-btn" href="{{ actor_www|default('') }}/properties">Properties</a>
+    <a class="aw-btn" href="{{ actor_www|default('') }}/trust">Trust</a>
+    <a class="aw-btn aw-btn-secondary" href="{{ actor_root|default('') }}">Actor root</a>
+  </div>
+</div>
+{% endblock %}

--- a/actingweb/templates/aw-actor-www-trust-new.html
+++ b/actingweb/templates/aw-actor-www-trust-new.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% block title %}New trust - ActingWeb{% endblock %}
+{% block content %}
+<div class="aw-card">
+  <div class="aw-nav">
+    <a href="{{ actor_www|default('') }}/trust">&larr; Trust</a>
+  </div>
+  <h1>New trust relationship</h1>
+
+  {% if error %}<div class="aw-error">{{ error }}</div>{% endif %}
+
+  <form action="{{ form_action|default('') }}" method="{{ form_method|default('POST') }}">
+    <label for="peer_url">Peer URL</label>
+    <input type="url" id="peer_url" name="peer_url" placeholder="https://peer.example.com/actor-id" required>
+
+    <label for="trust_type">Relationship / trust type</label>
+    <select id="trust_type" name="trust_type" required>
+      {% if trust_types %}
+        {% for tt in trust_types %}
+          {% set ttname = tt.get('name', '') if tt is mapping else '' %}
+          {% set ttlabel = (tt.get('display_name') or tt.get('name') or '') if tt is mapping else '' %}
+          <option value="{{ ttname }}"{% if ttname and ttname == default_relationship %} selected{% endif %}>
+            {{ ttlabel }}{% if tt is mapping and tt.get('description') %} &ndash; {{ tt.get('description') }}{% endif %}
+          </option>
+        {% endfor %}
+      {% elif default_relationship %}
+        <option value="{{ default_relationship }}" selected>{{ default_relationship }}</option>
+      {% endif %}
+    </select>
+
+    <label for="description">Description (optional)</label>
+    <input type="text" id="description" name="description">
+
+    <p></p>
+    <input type="submit" value="Create trust">
+  </form>
+</div>
+{% endblock %}

--- a/actingweb/templates/aw-actor-www-trust.html
+++ b/actingweb/templates/aw-actor-www-trust.html
@@ -1,0 +1,119 @@
+{% extends "base.html" %}
+{% block title %}Trust - ActingWeb{% endblock %}
+{% block content %}
+<div class="aw-card">
+  <div class="aw-nav">
+    <a href="{{ actor_www|default('') }}">&larr; Dashboard</a>
+  </div>
+  <h1>Trust relationships</h1>
+  <p><a class="aw-btn" href="{{ actor_www|default('') }}/trust/new">New trust</a></p>
+
+  {% if trusts %}
+    <div class="aw-table-wrap">
+    <table>
+      <thead>
+        <tr><th>Peer</th><th>Relationship</th><th>Status</th><th></th></tr>
+      </thead>
+      <tbody>
+        {% for t in trusts %}
+          {% set peerid = t.get('peerid', '') if t is mapping else '' %}
+          {% set rel = t.get('relationship', '') if t is mapping else '' %}
+          {% set approved = t.get('approved') if t is mapping else None %}
+          {% set verified = t.get('verified') if t is mapping else None %}
+          {% set approveuri = t.get('approveuri', '') if t is mapping else '' %}
+          {% set peer_uri = (t.get('baseuri') or t.get('peer_identifier') or '') if t is mapping else '' %}
+          {% set client_name = t.get('client_name') if t is mapping else None %}
+          {% set desc = t.get('desc') if t is mapping else None %}
+          <tr>
+            <td>
+              <code>{{ peerid }}</code>
+              {% if client_name %}<div class="aw-muted">{{ client_name }}</div>{% endif %}
+              {% if peer_uri %}<div class="aw-muted">{{ peer_uri }}</div>{% endif %}
+              {% if desc %}<div class="aw-muted">{{ desc }}</div>{% endif %}
+            </td>
+            <td>
+              {{ rel }}
+              {% if t is mapping and t.get('has_custom_permissions') %}<span class="aw-badge">custom perms</span>{% endif %}
+            </td>
+            <td>
+              {% if approved %}<span class="aw-badge">approved</span>{% else %}<span class="aw-badge">pending</span>{% endif %}
+              {% if verified %}<span class="aw-badge">verified</span>{% endif %}
+            </td>
+            <td>
+              <div class="aw-actions">
+                {% if not approved and approveuri %}
+                  <form class="aw-inline" method="get" action="{{ approveuri }}">
+                    <input type="hidden" name="_method" value="PUT">
+                    <input type="hidden" name="approved" value="true">
+                    <button type="submit" class="aw-btn">Approve</button>
+                  </form>
+                {% endif %}
+                {% if approveuri %}
+                  <form class="aw-inline" method="get" action="{{ approveuri }}"
+                        onsubmit="return confirm('Delete trust with {{ peerid }}?');">
+                    <input type="hidden" name="_method" value="DELETE">
+                    <button type="submit" class="aw-btn aw-btn-danger">Delete</button>
+                  </form>
+                {% endif %}
+              </div>
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    </div>
+  {% else %}
+    <p class="aw-muted">No trust relationships yet.</p>
+  {% endif %}
+</div>
+
+{% if oauth_clients %}
+<div class="aw-card">
+  <h2>OAuth2 clients</h2>
+  <div class="aw-table-wrap">
+  <table>
+    <thead><tr><th>Client</th><th>Type</th><th>Created</th><th>Status</th></tr></thead>
+    <tbody>
+      {% for c in oauth_clients %}
+        <tr>
+          <td>
+            {{ c.get('client_name', '') if c is mapping else '' }}
+            <div class="aw-muted"><code>{{ c.get('client_id', '') if c is mapping else '' }}</code></div>
+          </td>
+          <td>{{ c.get('trust_type', '') if c is mapping else '' }}</td>
+          <td>{{ c.get('created_at', '') if c is mapping else '' }}</td>
+          <td>{{ c.get('status', '') if c is mapping else '' }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  </div>
+</div>
+{% endif %}
+
+{% if trust_connections %}
+<div class="aw-card">
+  <h2>Connections</h2>
+  <div class="aw-table-wrap">
+  <table>
+    <thead><tr><th>Peer</th><th>Established via</th><th>Created</th><th>Last connected</th></tr></thead>
+    <tbody>
+      {% for conn in trust_connections %}
+        <tr>
+          <td><code>{{ conn.get('peerid', '') if conn is mapping else '' }}</code></td>
+          <td>{{ conn.get('established_via', '') if conn is mapping else '' }}</td>
+          <td>{{ conn.get('created_at', '') if conn is mapping else '' }}</td>
+          <td>
+            {{ conn.get('last_connected_at', '') if conn is mapping else '' }}
+            {% if conn is mapping and conn.get('last_connected_via') %}
+              <span class="aw-muted">({{ conn.get('last_connected_via') }})</span>
+            {% endif %}
+          </td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  </div>
+</div>
+{% endif %}
+{% endblock %}

--- a/actingweb/templates/aw-oauth-authorization-form.html
+++ b/actingweb/templates/aw-oauth-authorization-form.html
@@ -1,0 +1,49 @@
+{% extends "base.html" %}
+{% block title %}Authorize access - ActingWeb{% endblock %}
+{% block content %}
+<div class="aw-card">
+  <h1>Authorize access</h1>
+  <p>{{ message|default('An application is requesting access to your ActingWeb data.') }}</p>
+  {% if client_name %}<p><strong>{{ client_name }}</strong>{% if client_id %} <span class="aw-muted">(<code>{{ client_id }}</code>)</span>{% endif %}</p>{% endif %}
+
+  <form action="{{ form_action|default('/oauth/authorize') }}" method="{{ form_method|default('POST') }}">
+    <input type="hidden" name="client_id" value="{{ client_id|default('') }}">
+    <input type="hidden" name="redirect_uri" value="{{ redirect_uri|default('') }}">
+    <input type="hidden" name="state" value="{{ state|default('') }}">
+    <input type="hidden" name="response_type" value="{{ response_type|default('code') }}">
+    <input type="hidden" name="scope" value="{{ scope|default('') }}">
+    <input type="hidden" name="code_challenge" value="{{ code_challenge|default('') }}">
+    <input type="hidden" name="code_challenge_method" value="{{ code_challenge_method|default('') }}">
+
+    {% if oauth2_trust_control_enabled and trust_types %}
+      <label for="trust_type">Access level</label>
+      <select id="trust_type" name="trust_type">
+        {% for tt in trust_types %}
+          {% set ttname = tt.get('name', '') if tt is mapping else '' %}
+          {% set ttlabel = (tt.get('display_name') or tt.get('name') or '') if tt is mapping else '' %}
+          <option value="{{ ttname }}"{% if ttname and ttname == default_trust_type %} selected{% endif %}>
+            {{ ttlabel }}{% if tt is mapping and tt.get('description') %} &ndash; {{ tt.get('description') }}{% endif %}
+          </option>
+        {% endfor %}
+      </select>
+    {% elif default_trust_type %}
+      <input type="hidden" name="trust_type" value="{{ default_trust_type }}">
+    {% endif %}
+
+    <p></p>
+    <input type="submit" value="Authorize">
+  </form>
+
+  {% if oauth_providers %}
+    <h2>Or sign in with</h2>
+    <div class="aw-nav">
+      {% for provider in oauth_providers %}
+        {% set purl = provider.get('url') if provider is mapping else '' %}
+        {% if purl %}
+          <a class="aw-btn aw-btn-secondary" href="{{ purl }}">{{ (provider.get('display_name') or provider.get('name') or 'provider') if provider is mapping else 'provider' }}</a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/actingweb/templates/aw-oauth-email.html
+++ b/actingweb/templates/aw-oauth-email.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+{% block title %}Enter your email - ActingWeb{% endblock %}
+{% block content %}
+<div class="aw-card">
+  <h1>Enter your email</h1>
+  {% if error %}<div class="aw-error">{{ error }}</div>{% endif %}
+  <p>{{ message|default('Please enter your email address to continue.') }}</p>
+  {% if provider_display %}<p class="aw-muted">Signing in with {{ provider_display }}.</p>{% endif %}
+
+  <form action="{{ action|default('/oauth/email') }}" method="{{ method|default('POST') }}">
+    <input type="hidden" name="session" value="{{ session_id|default('') }}">
+    <label for="email">Email</label>
+    <input type="email" id="email" name="email" placeholder="you@example.com" autocomplete="email" required>
+    <p></p>
+    <input type="submit" value="Continue">
+  </form>
+</div>
+{% endblock %}

--- a/actingweb/templates/aw-root-created.html
+++ b/actingweb/templates/aw-root-created.html
@@ -14,9 +14,9 @@
   </table>
 
   {% if id %}
-    <p><a class="aw-btn" href="/{{ id }}/www">Go to dashboard</a></p>
+    <p><a class="aw-btn" href="{{ base_path|default('') }}/{{ id }}/www">Go to dashboard</a></p>
   {% else %}
-    <p><a class="aw-btn aw-btn-secondary" href="/">Back to start</a></p>
+    <p><a class="aw-btn aw-btn-secondary" href="{{ base_path|default('') }}/">Back to start</a></p>
   {% endif %}
 </div>
 {% endblock %}

--- a/actingweb/templates/aw-root-created.html
+++ b/actingweb/templates/aw-root-created.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block title %}Actor created - ActingWeb{% endblock %}
+{% block content %}
+<div class="aw-card">
+  <h1>Actor created</h1>
+  <p>Your actor has been created. Save the passphrase below &mdash; it is your
+     credential and will not be shown again.</p>
+
+  <table>
+    <tr><th>Actor ID</th><td><code>{{ id|default('') }}</code></td></tr>
+    <tr><th>Creator</th><td><code>{{ creator|default('') }}</code></td></tr>
+    <tr><th>Passphrase</th><td><code>{{ passphrase|default('') }}</code></td></tr>
+    {% if trustee_root %}<tr><th>Trustee root</th><td><code>{{ trustee_root }}</code></td></tr>{% endif %}
+  </table>
+
+  {% if id %}
+    <p><a class="aw-btn" href="/{{ id }}/www">Go to dashboard</a></p>
+  {% else %}
+    <p><a class="aw-btn aw-btn-secondary" href="/">Back to start</a></p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/actingweb/templates/aw-root-factory.html
+++ b/actingweb/templates/aw-root-factory.html
@@ -1,0 +1,34 @@
+{% extends "base.html" %}
+{% block title %}Sign in - ActingWeb{% endblock %}
+{% block content %}
+<div class="aw-card">
+  <h1>Sign in</h1>
+  {% if error %}<div class="aw-error">{{ error }}</div>{% endif %}
+
+  {% if oauth_enabled and oauth_providers %}
+    <p class="aw-muted">Continue with an identity provider:</p>
+    <div class="aw-nav">
+      {% for provider in oauth_providers %}
+        {% set purl = provider.get('url') if provider is mapping else '' %}
+        {% if purl %}
+          <a class="aw-btn" href="{{ purl }}">Sign in with {{ (provider.get('display_name') or provider.get('name') or 'provider') if provider is mapping else 'provider' }}</a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  {% elif oauth_urls %}
+    <div class="aw-nav">
+      {% for name, purl in oauth_urls.items() %}
+        {% if purl %}<a class="aw-btn" href="{{ purl }}">Sign in with {{ name }}</a>{% endif %}
+      {% endfor %}
+    </div>
+  {% endif %}
+
+  <h2>Or continue with your email</h2>
+  <form action="/" method="post">
+    <label for="creator">Email</label>
+    <input type="email" id="creator" name="creator" placeholder="you@example.com" autocomplete="email" required>
+    <p></p>
+    <input type="submit" value="Continue">
+  </form>
+</div>
+{% endblock %}

--- a/actingweb/templates/aw-root-factory.html
+++ b/actingweb/templates/aw-root-factory.html
@@ -24,7 +24,7 @@
   {% endif %}
 
   <h2>Or continue with your email</h2>
-  <form action="/" method="post">
+  <form action="{{ base_path|default('') }}/" method="post">
     <label for="creator">Email</label>
     <input type="email" id="creator" name="creator" placeholder="you@example.com" autocomplete="email" required>
     <p></p>

--- a/actingweb/templates/aw-root-failed.html
+++ b/actingweb/templates/aw-root-failed.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+{% block title %}Something went wrong - ActingWeb{% endblock %}
+{% block content %}
+<div class="aw-card">
+  <h1>Something went wrong</h1>
+  <div class="aw-error">{{ error|default('The actor could not be created. Please try again.') }}</div>
+  <p><a class="aw-btn aw-btn-secondary" href="/">Back to start</a></p>
+</div>
+{% endblock %}

--- a/actingweb/templates/aw-root-failed.html
+++ b/actingweb/templates/aw-root-failed.html
@@ -4,6 +4,6 @@
 <div class="aw-card">
   <h1>Something went wrong</h1>
   <div class="aw-error">{{ error|default('The actor could not be created. Please try again.') }}</div>
-  <p><a class="aw-btn aw-btn-secondary" href="/">Back to start</a></p>
+  <p><a class="aw-btn aw-btn-secondary" href="{{ base_path|default('') }}/">Back to start</a></p>
 </div>
 {% endblock %}

--- a/actingweb/templates/aw-verify-email.html
+++ b/actingweb/templates/aw-verify-email.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block title %}Email verification - ActingWeb{% endblock %}
+{% block content %}
+<div class="aw-card">
+  {% if status in ['success', 'verified', 'already_verified'] %}
+    <h1>Email verified</h1>
+  {% else %}
+    <h1>Email verification</h1>
+  {% endif %}
+
+  {% if status not in ['success', 'verified', 'already_verified'] and status %}
+    <div class="aw-error">{{ message|default(status) }}</div>
+  {% else %}
+    <p>{{ message|default('Your email address has been verified.') }}</p>
+  {% endif %}
+
+  {% if email %}<p class="aw-muted">{{ email }}</p>{% endif %}
+
+  {% if redirect_url %}
+    <p><a class="aw-btn" href="{{ redirect_url }}">Continue</a></p>
+  {% elif actor_id %}
+    <p><a class="aw-btn" href="/{{ actor_id }}/www">Continue</a></p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/actingweb/templates/base.html
+++ b/actingweb/templates/base.html
@@ -1,0 +1,141 @@
+{#
+  ActingWeb built-in default web UI - shared base template.
+  Neutral, self-contained (no external assets). All child templates
+  extend this and fill the `title` and `content` blocks.
+  Context is passed as a flat dict; every variable is treated as optional.
+#}<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content="noindex, nofollow">
+  <title>{% block title %}ActingWeb{% endblock %}</title>
+  <style>
+    :root {
+      --fg: #1f2933;
+      --muted: #6b7280;
+      --border: #e2e5e9;
+      --bg: #f6f7f9;
+      --card: #ffffff;
+      --accent: #2563eb;
+      --accent-fg: #ffffff;
+      --danger: #b91c1c;
+      --code-bg: #f0f2f4;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      line-height: 1.5;
+      color: var(--fg);
+      background: var(--bg);
+    }
+    .aw-container {
+      max-width: 820px;
+      margin: 0 auto;
+      padding: 24px 16px 48px;
+    }
+    .aw-card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+    }
+    h1 { font-size: 1.5rem; margin: 0 0 16px; }
+    h2 { font-size: 1.15rem; margin: 24px 0 12px; }
+    a { color: var(--accent); }
+    p { margin: 0 0 12px; }
+    .aw-muted { color: var(--muted); font-size: 0.9rem; }
+    .aw-nav { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 20px; }
+    .aw-nav a { text-decoration: none; }
+    label { display: block; margin: 12px 0 4px; font-weight: 600; font-size: 0.9rem; }
+    input[type=text], input[type=email], input[type=url], input[type=password],
+    textarea, select {
+      width: 100%;
+      padding: 8px 10px;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      font-size: 1rem;
+      background: #fff;
+      color: var(--fg);
+    }
+    textarea { min-height: 70px; }
+    .aw-btn, button, input[type=submit] {
+      display: inline-block;
+      padding: 8px 16px;
+      border: 1px solid var(--accent);
+      border-radius: 6px;
+      background: var(--accent);
+      color: var(--accent-fg);
+      font-size: 0.95rem;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    .aw-btn-secondary {
+      background: #fff;
+      color: var(--fg);
+      border-color: var(--border);
+    }
+    .aw-btn-danger {
+      background: #fff;
+      color: var(--danger);
+      border-color: var(--danger);
+    }
+    .aw-inline { display: inline; }
+    table { width: 100%; border-collapse: collapse; margin: 8px 0 16px; }
+    th, td {
+      text-align: left;
+      padding: 8px 10px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: top;
+      font-size: 0.95rem;
+    }
+    th { color: var(--muted); font-weight: 600; }
+    .aw-table-wrap { overflow-x: auto; }
+    code, pre {
+      background: var(--code-bg);
+      border-radius: 4px;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+      font-size: 0.9em;
+    }
+    code { padding: 1px 5px; }
+    pre { padding: 12px; overflow-x: auto; }
+    .aw-badge {
+      display: inline-block;
+      padding: 1px 8px;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      background: var(--code-bg);
+      color: var(--muted);
+    }
+    .aw-error {
+      border: 1px solid var(--danger);
+      color: var(--danger);
+      background: #fef2f2;
+      border-radius: 6px;
+      padding: 10px 12px;
+      margin-bottom: 16px;
+    }
+    .aw-actions { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --fg: #e5e7eb;
+        --muted: #9ca3af;
+        --border: #374151;
+        --bg: #111418;
+        --card: #1b1f24;
+        --code-bg: #23272e;
+      }
+      input, textarea, select { background: #23272e; }
+      .aw-btn-secondary, .aw-btn-danger { background: #23272e; }
+      .aw-error { background: #2a1414; }
+    }
+  </style>
+</head>
+<body>
+  <div class="aw-container">
+    {% block content %}{% endblock %}
+  </div>
+</body>
+</html>

--- a/docs/guides/async-hooks-migration.rst
+++ b/docs/guides/async-hooks-migration.rst
@@ -201,43 +201,46 @@ Example 3: Peer Communication with AwProxy
 
 **Before (Synchronous)**::
 
-   from actingweb.interface import AwProxy
+   from actingweb.aw_proxy import AwProxy
 
    @app.action_hook("notify_peers")
    def notify(actor, action_name, data):
-       proxy = AwProxy(config)
+       peers = actor.trust.relationships
 
-       for peer in actor.trust.get_peers():
+       for peer in peers:
+           proxy = AwProxy(
+               peer_target={"id": actor.id, "peerid": peer.peerid},
+               config=actor.config,
+           )
            # Blocks on each request
-           proxy.send_message(
-               peer_url=peer.url,
-               message=data["message"],
-               secret=peer.secret
+           proxy.create_resource(
+               path="callbacks/notification",
+               params={"message": data["message"]},
            )
 
-       return {"notified": len(actor.trust.get_peers())}
+       return {"notified": len(peers)}
 
 **After (Asynchronous)**::
 
-   from actingweb.interface import AwProxy
+   from actingweb.aw_proxy import AwProxy
    import asyncio
 
    @app.action_hook("notify_peers")
    async def notify(actor, action_name, data):
-       proxy = AwProxy(config)
-       peers = actor.trust.get_peers()
+       peers = actor.trust.relationships
 
-       # Send all messages concurrently
-       tasks = [
-           proxy.send_message_async(
-               peer_url=peer.url,
-               message=data["message"],
-               secret=peer.secret
+       async def notify_peer(peer):
+           proxy = AwProxy(
+               peer_target={"id": actor.id, "peerid": peer.peerid},
+               config=actor.config,
            )
-           for peer in peers
-       ]
+           return await proxy.create_resource_async(
+               path="callbacks/notification",
+               data={"message": data["message"]},
+           )
 
-       results = await asyncio.gather(*tasks)
+       # Send all notifications concurrently
+       results = await asyncio.gather(*[notify_peer(p) for p in peers])
        return {"notified": len([r for r in results if r is not None])}
 
 Mixed Sync and Async

--- a/docs/guides/hooks.rst
+++ b/docs/guides/hooks.rst
@@ -21,10 +21,18 @@ Property Hooks
    @app.property_hook("email")
    def handle_email(actor, operation, value, path):
        if operation == "get":
-           return value if actor.is_owner() else None  # hide from others
+           return value  # allow reads / transform here
        if operation in ("put", "post"):
            return value.lower() if "@" in value else None
        return value
+
+.. note::
+
+   Property hooks run for **every** accessor and cannot distinguish the owner
+   from a peer or client on their own. To restrict what a peer/client may read
+   or write, use the permission system and authenticated views
+   (:doc:`../sdk/authenticated-views`), not ``actor.is_owner()`` (a placeholder
+   that always returns ``True``).
 
 Method Hooks
 ------------

--- a/docs/guides/mcp-quickstart.rst
+++ b/docs/guides/mcp-quickstart.rst
@@ -104,22 +104,32 @@ Call initialize (no auth required):
      -H 'Content-Type: application/json' \
      -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"curl"}}}'
 
-List tools and prompts (requires auth in production; open in dev):
+Every other method — ``tools/list``, ``prompts/list``, ``tools/call``, etc. —
+**requires an OAuth2 bearer token** (only ``initialize`` and
+``notifications/initialized`` are unauthenticated). There is **no dev bypass**;
+``with_devtest(True)`` does not open the MCP endpoint. Sending these without a
+token returns HTTP 401 with a ``WWW-Authenticate: Bearer`` header:
 
 .. code-block:: bash
 
-   curl -s http://localhost:5000/mcp -H 'Content-Type: application/json' \
+   # 401 without a bearer token — obtain one via the OAuth2 flow first, then:
+   curl -s http://localhost:5000/mcp \
+     -H 'Content-Type: application/json' \
+     -H 'Authorization: Bearer <token>' \
      -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
 
-   curl -s http://localhost:5000/mcp -H 'Content-Type: application/json' \
-     -d '{"jsonrpc":"2.0","id":3,"method":"prompts/list"}'
-
-Call the tool:
-
-.. code-block:: bash
-
-   curl -s http://localhost:5000/mcp -H 'Content-Type: application/json' \
+   curl -s http://localhost:5000/mcp \
+     -H 'Content-Type: application/json' \
+     -H 'Authorization: Bearer <token>' \
      -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"create_note","arguments":{"title":"Hello","content":"World"}}}'
+
+.. tip::
+
+   To test tool/prompt *logic* without standing up an OAuth2 client, call the
+   hooks directly in a unit test rather than over HTTP — e.g.
+   ``app.hooks.execute_action_hooks("create_note", actor, {...})``. Real MCP
+   clients (ChatGPT, Claude) perform the OAuth2 flow and send the bearer token
+   automatically.
 
 Tool Safety Annotations
 -----------------------

--- a/docs/quickstart/getting-started.rst
+++ b/docs/quickstart/getting-started.rst
@@ -31,7 +31,10 @@ Create a basic ActingWeb application:
     @app.property_hook("email")
     def handle_email(actor, operation, value, path):
         if operation == "put":
-            return value.lower() if "@" in value else None
+            # value may be non-string or None on delete — guard before using it
+            if isinstance(value, str) and "@" in value:
+                return value.lower()
+            return None
         return value
 
     # Run the application
@@ -88,8 +91,11 @@ If you prefer FastAPI and do not need MCP features:
     # Explicitly disable MCP exposure for this app
     aw.with_mcp(enable=False)
 
-    # Auto-generate all ActingWeb routes under the FastAPI app
-    aw.integrate_fastapi(app, templates_dir="templates")
+    # Auto-generate all ActingWeb routes under the FastAPI app.
+    # templates_dir is optional — ActingWeb ships default web-UI templates, so
+    # the UI works out of the box. Pass templates_dir="templates" only to
+    # override individual templates with your own.
+    aw.integrate_fastapi(app)
 
     # Run with: uvicorn main:app --reload
 
@@ -107,8 +113,15 @@ Creating and managing actors is straightforward:
 
 .. code-block:: python
 
-    # Create a new actor
-    actor = ActorInterface.create(creator="user@example.com", config=config)
+    # Create a new actor (config comes from your ActingWebApp instance).
+    # Pass hooks=app.hooks so lifecycle hooks (e.g. "actor_created") fire on
+    # creation — without it, ActorInterface.create() creates the actor but runs
+    # no lifecycle hooks. (Creating over HTTP via the factory endpoint always
+    # runs the hooks.)
+    config = app.get_config()
+    actor = ActorInterface.create(
+        creator="user@example.com", config=config, hooks=app.hooks
+    )
 
     # Access properties
     actor.properties.email = "user@example.com"
@@ -131,6 +144,14 @@ Creating and managing actors is straightforward:
         target="properties",
         data={"status": "active"}
     )
+
+.. note::
+
+   Actors can also be created over REST via the factory endpoint
+   (``POST /`` with a JSON ``{"creator": "..."}`` body), which is how a browser
+   sign-up flow or an external client creates them. See
+   :doc:`overview` for the HTTP request/response. The factory path runs the
+   ``actor_created`` lifecycle hook automatically.
 
 Configuration
 -------------
@@ -194,11 +215,15 @@ Handle property access and validation:
     @app.property_hook("email")
     def handle_email_property(actor, operation, value, path):
         if operation == "get":
-            # Control who can see the email
-            return value if actor.is_owner() else None
+            # Reads/transforms happen here (runs for every accessor).
+            # Restrict who may read via the permission system / authenticated
+            # views, not from inside the hook — see the SDK docs.
+            return value
         elif operation == "put":
-            # Validate email format
-            return value.lower() if "@" in value else None
+            # Validate email format (value may be non-string or None)
+            if isinstance(value, str) and "@" in value:
+                return value.lower()
+            return None
         return value
 
     @app.property_hook("settings")
@@ -297,17 +322,23 @@ The modern hook system provides better organization, type safety, and testing ca
 Database Configuration
 -----------------------
 
-ActingWeb currently supports DynamoDB as the database backend. For local development, you can use DynamoDB Local:
+ActingWeb supports two production-ready database backends: **DynamoDB** (default)
+and **PostgreSQL**. Select one with the ``database`` argument (or the
+``DATABASE_BACKEND`` environment variable, which takes precedence):
 
 .. code-block:: python
 
     app = ActingWebApp(
         aw_type="urn:actingweb:example.com:myapp",
-        database="dynamodb",
+        database="dynamodb",   # or "postgresql"
         fqdn="localhost:5000"
     )
 
-For production, ensure your AWS credentials are properly configured and DynamoDB tables are created with the appropriate permissions.
+For the full backend comparison, PostgreSQL setup, and migration guidance, see
+:doc:`configuration` and :doc:`../reference/database-backends`.
+
+For production with DynamoDB, ensure your AWS credentials are properly configured
+and DynamoDB tables are created with the appropriate permissions.
 
 For DynamoDB Local, set the following environment variables before running your app:
 

--- a/docs/quickstart/local-dev-setup.rst
+++ b/docs/quickstart/local-dev-setup.rst
@@ -53,6 +53,11 @@ Launch DynamoDB Local and configure environment:
 Notes:
 
 - The library auto-creates tables on first access through its PynamoDB models.
+  Table names are prefixed (default ``demo_actingweb``, e.g.
+  ``demo_actingweb_actors``; override with the ``AWS_DB_PREFIX`` environment
+  variable). During startup you may see benign ``DEBUG`` log lines about a
+  not-yet-existent table (e.g. ``demo_actingweb_subscription_suspensions``) as
+  each table is created lazily on first use — these are harmless.
 - For production, configure IAM and real AWS hosts (do not set ``AWS_DB_HOST``).
 
 Option 2: PostgreSQL (Recommended for New Projects)
@@ -83,7 +88,7 @@ Option 2: PostgreSQL (Recommended for New Projects)
 
    # 3. Download migration helper script (one-time setup)
    mkdir -p scripts
-   curl -o scripts/migrate_db.py https://raw.githubusercontent.com/actingweb/actingweb/main/scripts/migrate_db.py
+   curl -o scripts/migrate_db.py https://raw.githubusercontent.com/actingweb/actingweb/master/scripts/migrate_db.py
 
    # 4. Run migrations (REQUIRED before first use)
    python scripts/migrate_db.py upgrade head

--- a/docs/quickstart/overview.rst
+++ b/docs/quickstart/overview.rst
@@ -19,8 +19,35 @@ Install
     # Everything (incl. MCP)
     pip install 'actingweb[all]'
 
-1) Minimal app (choose one)
+1) Start a database
+===================
+
+ActingWeb needs a database backend. For local development the quickest option is
+**DynamoDB Local** in Docker:
+
+.. code-block:: bash
+
+    docker run -p 8000:8000 amazon/dynamodb-local
+
+    # Point ActingWeb at it (dummy AWS creds are fine for the local emulator)
+    export AWS_DB_HOST=http://localhost:8000
+    export AWS_ACCESS_KEY_ID=local
+    export AWS_SECRET_ACCESS_KEY=local
+    export AWS_DEFAULT_REGION=us-east-1
+
+Prefer PostgreSQL? Set ``database="postgresql"`` (or ``DATABASE_BACKEND=postgresql``)
+and see :doc:`local-dev-setup` and :doc:`../reference/database-backends`. ActingWeb
+creates the tables it needs on first use.
+
+2) Minimal app (choose one)
 ===========================
+
+Both apps enable the built-in web UI with ``with_web_ui(True)``. ActingWeb ships
+default templates, so the sign-in/factory page, actor dashboard, properties, and
+trust pages render **out of the box** — no templates required. To customise the
+look, drop a same-named template into your app's ``templates/`` directory (Flask)
+or the ``templates_dir`` you pass to ``integrate_fastapi`` (FastAPI); yours
+overrides the library default.
 
 Flask
 -----
@@ -61,23 +88,26 @@ FastAPI
         fqdn="localhost:5000",
     ).with_web_ui(True)
 
-    aw.integrate_fastapi(api, templates_dir="templates")
+    aw.integrate_fastapi(api)  # add templates_dir="templates" to override defaults
 
     # Run with: uvicorn app_fastapi:api --reload --port 5000
 
-2) Create an actor
+3) Create an actor
 ==================
 
-Use the root factory page in the browser and follow the form, or create via API:
+Open ``http://localhost:5000/`` in a browser and use the built-in sign-in/factory
+page, or create one via the API:
 
 .. code-block:: bash
 
     # Create new actor (no auth in dev)
-    curl -X POST http://localhost:5000/
+    curl -X POST http://localhost:5000/ \
+      -H 'Content-Type: application/json' \
+      -d '{"creator": "you@example.com"}'
 
 The response contains the new actor ID. The actor root is ``http://localhost:5000/<actor_id>``.
 
-3) Explore
+4) Explore
 ==========
 
 - Web UI: ``/<actor_id>/www`` — dashboard, properties, and trust management

--- a/docs/reference/hooks-reference.rst
+++ b/docs/reference/hooks-reference.rst
@@ -29,7 +29,18 @@ Example:
     def email_guard(actor, operation, value, path):
         if operation in ("put", "post", "delete"):
             return None  # read-only
-        return value if actor.is_owner() else None  # hide from non-owner
+        return value  # allow reads / transform here
+
+.. warning::
+
+   Property hooks fire for **every** access to the property, regardless of who
+   is making the request — they cannot by themselves distinguish the owner from
+   a peer or an OAuth2/MCP client. Do **not** use ``actor.is_owner()`` as an
+   access guard: it is a placeholder that currently always returns ``True``. To
+   restrict what a peer or client may read or write, use the permission system
+   and the permission-enforcing authenticated views (:doc:`../sdk/authenticated-views`,
+   ``actor.as_peer()`` / ``actor.as_client()``), which evaluate per-accessor
+   permissions before the property hook runs.
 
 Callback Hooks
 ==============
@@ -235,7 +246,9 @@ Event Details
         def on_subscription_deleted(actor, peer_id, subscription_id, subscription_data, initiated_by_peer):
             if initiated_by_peer:
                 # Peer unsubscribed from us - revoke their permissions
-                actor.trust.update_permissions(peer_id, [])
+                from actingweb.trust_permissions import get_trust_permission_store
+                store = get_trust_permission_store(actor.config)
+                store.update_permissions(actor.id, peer_id, {"properties": []})
                 notify_user(actor, f"{peer_id} unsubscribed from your data")
 
 ``email_verification_required``
@@ -409,7 +422,7 @@ Use ``async def`` for hooks that need to call async services:
 - **Async HTTP clients** (aiohttp, httpx)
 - **Async database operations** (asyncpg, motor)
 - **Async AWS services** (aioboto3, async AWS Bedrock)
-- **Async AwProxy methods** (``send_message_async()``, ``fetch_property_async()``)
+- **Async AwProxy methods** (``get_resource_async()``, ``create_resource_async()``, ``change_resource_async()``, ``delete_resource_async()``)
 - **Any async I/O operations**
 
 Performance Benefits
@@ -439,18 +452,20 @@ Async Action Hooks
 
 .. code-block:: python
 
-    from actingweb.interface import AwProxy
+    from actingweb.aw_proxy import AwProxy
 
     @app.action_hook("send_notification")
     async def async_notify(actor, action_name, data):
         """Async action hook using AwProxy."""
-        proxy = AwProxy(config)
+        proxy = AwProxy(
+            peer_target={"id": actor.id, "peerid": data["peer_id"]},
+            config=actor.config,
+        )
 
         # Use async methods for peer communication
-        result = await proxy.send_message_async(
-            peer_url=data["peer_url"],
-            message=data["message"],
-            secret=actor.get_trust_secret(data["peer_id"])
+        result = await proxy.create_resource_async(
+            path="callbacks/notification",
+            data={"message": data["message"]},
         )
 
         return {"sent": result is not None}

--- a/docs/reference/routing-overview.rst
+++ b/docs/reference/routing-overview.rst
@@ -116,6 +116,15 @@ and the ``with_web_ui()`` configuration:
 2. **Authenticated browsers** redirect to the appropriate UI endpoint based on
    whether the traditional web UI (``/www``) or SPA mode (``/app``) is configured.
 
+.. note::
+
+   "Authenticated" for the browser UI means an **OAuth2 browser session**. HTTP
+   **Basic auth** (creator + passphrase) authenticates the JSON API
+   (``/properties``, ``/trust``, ``/actions``, ...) but is **not** a browser
+   session: a Basic-auth request to ``/www`` is still redirected to ``/login`` /
+   OAuth. To view the web UI you must complete the OAuth flow, so a working
+   OAuth provider must be configured (``with_oauth(...)``).
+
 OAuth Callback Redirect Behavior
 --------------------------------
 

--- a/docs/sdk/actor-interface.rst
+++ b/docs/sdk/actor-interface.rst
@@ -38,8 +38,12 @@ Creating and Loading Actors
 
 .. code-block:: python
 
-   # Create
-   actor = ActorInterface.create(creator="user@example.com", config=app.get_config())
+   # Create. Pass hooks=app.hooks so lifecycle hooks (e.g. "actor_created")
+   # fire on creation; omit it and the actor is created but no lifecycle hook
+   # runs. (Creating over REST via the factory endpoint always runs the hooks.)
+   actor = ActorInterface.create(
+       creator="user@example.com", config=app.get_config(), hooks=app.hooks
+   )
 
    # Load by id
    actor2 = ActorInterface.get_by_id(actor.id, config=app.get_config())

--- a/docs/sdk/async-operations.rst
+++ b/docs/sdk/async-operations.rst
@@ -23,36 +23,38 @@ The core ``Actor`` class provides these async methods:
 
     class Actor:
         # Peer information
-        async def get_peer_info_async(self, peer_id: str) -> Optional[Dict]
+        async def get_peer_info_async(self, url: str) -> Optional[Dict]
 
         # Trust operations
         async def modify_trust_and_notify_async(
-            self, peer_id: str, relationship: str, ...
+            self, relationship=None, peerid=None, baseuri="", ...
         ) -> bool
 
         async def create_reciprocal_trust_async(
-            self, peer_id: str, relationship: str, baseuri: str, ...
+            self, url, secret=None, desc="", relationship="", trust_type="",
         ) -> Optional[Dict]
 
         async def create_verified_trust_async(
-            self, peer_id: str, relationship: str, baseuri: str, verify_token: str, ...
+            self, baseuri="", peerid=None, approved=False, secret=None,
+            verification_token=None, trust_type=None, peer_approved=None,
+            relationship=None, desc="",
         ) -> Optional[Dict]
 
         async def delete_reciprocal_trust_async(
-            self, peer_id: str, ...
+            self, peerid=None, delete_peer=False,
         ) -> bool
 
         # Subscription operations
         async def create_remote_subscription_async(
-            self, peer_id: str, baseuri: str, callback_path: str, ...
+            self, peerid=None, target=None, subtarget=None, ...
         ) -> Optional[Dict]
 
         async def delete_remote_subscription_async(
-            self, peer_id: str, ...
+            self, peerid=None, subid=None,
         ) -> bool
 
         async def callback_subscription_async(
-            self, peer_id: str, diff_data: Dict, ...
+            self, peerid=None, sub_obj=None, sub=None, diff=None, blob=None,
         ) -> bool
 
 TrustManager Async Methods
@@ -63,21 +65,16 @@ The ``TrustManager`` wraps these for easier use:
 .. code-block:: python
 
     class TrustManager:
-        async def create_reciprocal_trust_async(
-            self, peer_id: str, relationship: str, baseuri: str
+        async def create_relationship_async(
+            self, peer_url: str, relationship: str = "friend",
+            secret: str = "", description: str = "",
         ) -> Optional[TrustRelationship]
 
-        async def create_verified_trust_async(
-            self, peer_id: str, relationship: str, baseuri: str, verify_token: str
-        ) -> Optional[TrustRelationship]
+        async def approve_relationship_async(self, peer_id: str) -> bool
 
-        async def modify_and_notify_async(
-            self, peer_id: str, relationship: str
-        ) -> bool
+        async def delete_relationship_async(self, peer_id: str) -> bool
 
-        async def delete_peer_trust_async(
-            self, peer_id: str
-        ) -> bool
+        async def delete_all_relationships_async(self) -> bool
 
 SubscriptionManager Async Methods
 ---------------------------------
@@ -140,12 +137,10 @@ FastAPI Route with Async Trust Creation
         actor = get_actor(actor_id)
         actor_interface = ActorInterface(actor)
 
-        # Non-blocking peer communication
-        trust = await actor_interface.trust.create_verified_trust_async(
-            peer_id="new_peer",
+        # Non-blocking peer communication (initiates the reciprocal handshake)
+        trust = await actor_interface.trust.create_relationship_async(
+            peer_url=peer_baseuri,
             relationship="friend",
-            baseuri=peer_baseuri,
-            verify_token=generate_token()
         )
 
         if not trust:
@@ -163,11 +158,11 @@ Concurrent Peer Operations
     async def notify_all_peers(actor: ActorInterface, message: Dict):
         """Notify all trusted peers concurrently."""
 
-        peers = actor.trust.get_all_relationships()
+        peers = actor.trust.relationships
 
         async def notify_peer(peer):
             proxy = AwProxy(
-                peer_target={"id": actor.id, "peerid": peer["peerid"]},
+                peer_target={"id": actor.id, "peerid": peer.peerid},
                 config=actor.config
             )
             return await proxy.create_resource_async(
@@ -192,10 +187,9 @@ Async Subscription with Callback
         """Subscribe to a remote service."""
 
         # Create trust first
-        trust = await actor.trust.create_reciprocal_trust_async(
-            peer_id="service",
+        trust = await actor.trust.create_relationship_async(
+            peer_url=service_uri,
             relationship="service",
-            baseuri=service_uri
         )
 
         if not trust:
@@ -203,7 +197,7 @@ Async Subscription with Callback
 
         # Then subscribe (includes automatic baseline sync)
         subscription_url = await actor.subscriptions.subscribe_to_peer_async(
-            peer_id="service",
+            peer_id=trust.peer_id,
             target="properties",
             granularity="high"
         )
@@ -236,16 +230,14 @@ Async methods use ``httpx`` for non-blocking HTTP:
 Async via asyncio.to_thread
 ---------------------------
 
-Some methods wrap synchronous code with ``asyncio.to_thread``:
+Some async methods wrap synchronous code with ``asyncio.to_thread`` so that
+blocking work runs off the event loop:
 
 .. code-block:: python
 
-    async def create_verified_trust_async(self, ...):
-        # Runs sync method in thread pool
-        return await asyncio.to_thread(
-            self.create_verified_trust,
-            peer_id, relationship, baseuri, verify_token, ...
-        )
+    async def some_operation_async(self, *args):
+        # Runs the sync implementation in a thread pool
+        return await asyncio.to_thread(self.some_operation, *args)
 
 Timeout Handling
 ----------------
@@ -271,10 +263,10 @@ Best Practices
    .. code-block:: python
 
        # Good - non-blocking
-       trust = await actor.trust.create_reciprocal_trust_async(...)
+       trust = await actor.trust.create_relationship_async(peer_url=...)
 
        # Avoid in async context - blocks event loop
-       trust = actor.trust.create_reciprocal_trust(...)
+       trust = actor.trust.create_relationship(peer_url=...)
 
 2. **Use asyncio.gather for Concurrent Operations**
 
@@ -294,7 +286,7 @@ Best Practices
 
        try:
            result = await asyncio.wait_for(
-               actor.trust.create_verified_trust_async(...),
+               actor.trust.create_relationship_async(peer_url=...),
                timeout=60.0
            )
        except asyncio.TimeoutError:
@@ -307,11 +299,11 @@ Best Practices
 
        # In async function - use async variant
        async def handler():
-           trust = await actor.trust.create_reciprocal_trust_async(...)
+           trust = await actor.trust.create_relationship_async(peer_url=...)
 
        # In sync function - use sync variant
        def handler():
-           trust = actor.trust.create_reciprocal_trust(...)
+           trust = actor.trust.create_relationship(peer_url=...)
 
 5. **Consider Connection Pooling**
 

--- a/docs/sdk/authenticated-views.rst
+++ b/docs/sdk/authenticated-views.rst
@@ -75,26 +75,28 @@ The ``AuthenticatedActorView`` class wraps an ``ActorInterface`` and enforces pe
 Creating Views
 --------------
 
+Prefer the ``actor.as_peer()`` / ``actor.as_client()`` factory methods shown
+above. They build the view for you and are the supported API. If you need to
+construct a view directly, pass an ``AuthContext`` (the accessor is a ``peer_id``
+**or** a ``client_id``, never both):
+
 .. code-block:: python
 
-    from actingweb.interface.authenticated_views import AuthenticatedActorView
-
-    # Create peer view
-    peer_view = AuthenticatedActorView(
-        actor_interface=actor,
-        accessor_id="peer123",
-        trust_relationship=trust_record,
-        is_peer=True,
-        is_client=False
+    from actingweb.interface.authenticated_views import (
+        AuthContext,
+        AuthenticatedActorView,
     )
 
-    # Create client view
+    # Peer view
+    peer_view = AuthenticatedActorView(
+        actor,
+        AuthContext(peer_id="peer123", trust_relationship=trust_record),
+    )
+
+    # Client view (OAuth2 / MCP)
     client_view = AuthenticatedActorView(
-        actor_interface=actor,
-        accessor_id="mcp_client_123",
-        trust_relationship=trust_record,
-        is_peer=False,
-        is_client=True
+        actor,
+        AuthContext(client_id="mcp_client_123", trust_relationship=trust_record),
     )
 
 Properties Access
@@ -231,8 +233,10 @@ The ``AuthenticatedActorView`` provides context about the accessor:
         # OAuth2/MCP client access
         pass
 
-    # Access underlying actor interface
-    core_actor = auth_view.actor_interface
+    # Identity of the accessor and the actor being viewed
+    accessor = auth_view.accessor_id     # peer_id or client_id
+    actor_id = auth_view.id
+    ctx = auth_view.auth_context
 
 Best Practices
 ==============
@@ -270,11 +274,11 @@ Best Practices
 
    .. code-block:: python
 
-       trust = actor.trust.get_relationship_by_peerid(peer_id)
-       if not trust or not trust.get("approved"):
+       trust = actor.trust.get_relationship(peer_id)
+       if not trust or not trust.approved:
            return self._unauthorized("No trust relationship")
 
-       auth_view = actor.as_peer(peer_id, trust)
+       auth_view = actor.as_peer(peer_id, trust.to_dict())
 
 See Also
 ========

--- a/docs/sdk/developer-api.rst
+++ b/docs/sdk/developer-api.rst
@@ -42,10 +42,10 @@ In hook functions, you receive an ``ActorInterface`` instance:
         status = actor.properties.get("status")
 
         # Work with trust relationships
-        friends = actor.trust.get_relationships_by_type("friend")
+        friends = actor.trust.get_peers_by_relationship("friend")
 
         # Access subscriptions
-        subs = actor.subscriptions.list_subscriptions()
+        subs = actor.subscriptions.all_subscriptions
 
         return {"results": [...]}
 
@@ -57,13 +57,15 @@ The ``ActorInterface`` exposes several useful properties:
 .. code-block:: python
 
     actor.id              # Actor ID string
-    actor.type            # Actor type (urn:...)
     actor.creator         # Creator email/identifier
     actor.passphrase      # Actor passphrase
+    actor.url             # Actor root URL
     actor.config          # ActingWeb configuration object
     actor.properties      # PropertyStore instance
+    actor.property_lists  # ListPropertyStore instance (list-valued properties)
     actor.trust           # TrustManager instance
     actor.subscriptions   # SubscriptionManager instance
+    actor.services        # ServiceRegistry (third-party OAuth2 services)
 
 PropertyStore
 =============
@@ -117,11 +119,12 @@ When properties change, ActingWeb automatically:
     # This automatically generates a diff and notifies subscribers
     actor.properties["status"] = "active"
 
-To suppress notification for a specific change:
+To suppress notification for a specific change, use
+``set_without_notification()`` (``set()`` always notifies):
 
 .. code-block:: python
 
-    actor.properties.set("internal_flag", True, notify=False)
+    actor.properties.set_without_notification("internal_flag", True)
 
 JSON Serialization
 ------------------
@@ -135,10 +138,13 @@ PropertyStore automatically handles JSON serialization for non-string values:
     actor.properties["tags"] = ["python", "actingweb"]
     actor.properties["count"] = 42
 
-    # Retrieved as original types
+    # Structured values (dict/list) round-trip as their original type
     config = actor.properties.get("config")  # Returns dict
     tags = actor.properties.get("tags")      # Returns list
-    count = actor.properties.get("count")    # Returns int
+
+    # NOTE: bare scalars are stored and returned as strings — a stored int comes
+    # back as a str. Cast on read if you need the numeric type:
+    count = int(actor.properties.get("count", 0))
 
 TrustManager
 ============
@@ -150,60 +156,79 @@ Getting Trust Relationships
 
 .. code-block:: python
 
-    # Get all trust relationships
-    all_trusts = actor.trust.get_all_relationships()
+    # Get all trust relationships (property, not a method)
+    all_trusts = actor.trust.relationships
 
-    # Get by peer ID
-    trust = actor.trust.get_relationship_by_peerid("peer123")
+    # Only active / only pending relationships
+    active = actor.trust.active_relationships
+    pending = actor.trust.pending_relationships
+
+    # Get by peer ID (returns None if not found)
+    trust = actor.trust.get_relationship("peer123")
 
     # Get by relationship type
-    friends = actor.trust.get_relationships_by_type("friend")
-    colleagues = actor.trust.get_relationships_by_type("colleague")
+    friends = actor.trust.get_peers_by_relationship("friend")
+    colleagues = actor.trust.get_peers_by_relationship("colleague")
+
+    # Membership checks
+    if actor.trust.has_relationship_with("peer123"):
+        ...
 
 Creating Trust Relationships
 -----------------------------
 
+Use ``create_relationship()`` to initiate an outgoing trust with another actor.
+It performs the reciprocal handshake with the peer (an HTTP call), so prefer the
+``_async`` variant in async contexts (FastAPI):
+
 .. code-block:: python
 
-    # Create simple trust (local only)
+    # Create trust (initiates the reciprocal handshake with the peer)
     trust = actor.trust.create_relationship(
-        peer_id="peer123",
-        relationship_type="friend",
-        baseuri="https://peer.example.com/peer123",
-        desc="Alice's actor"
+        peer_url="https://peer.example.com/peer123",
+        relationship="friend",       # defaults to "friend"
+        secret="",                    # auto-generated if omitted
+        description="Alice's actor",
     )
 
-    # Create with peer notification
-    trust = await actor.trust.create_reciprocal_trust_async(
-        peer_id="peer123",
-        relationship_type="friend",
-        baseuri="https://peer.example.com/peer123"
+    # Async variant (non-blocking; use in FastAPI handlers)
+    trust = await actor.trust.create_relationship_async(
+        peer_url="https://peer.example.com/peer123",
+        relationship="friend",
     )
 
-    # Create verified trust (handshake protocol)
-    trust = await actor.trust.create_verified_trust_async(
-        peer_id="peer123",
-        relationship_type="friend",
-        baseuri="https://peer.example.com/peer123",
-        verify_token="secret-token-from-peer"
-    )
-
-Modifying Trust Relationships
-------------------------------
+To *accept* an incoming trust request initiated by another actor (the peer POSTs
+the trust details to you), use the synchronous ``create_verified_trust()``:
 
 .. code-block:: python
 
-    # Update relationship type
-    updated = actor.trust.modify_relationship(
+    trust = actor.trust.create_verified_trust(
+        baseuri="https://peer.example.com/peer123",
         peer_id="peer123",
-        relationship_type="colleague"  # Changed from "friend"
+        approved=True,
+        secret="shared-secret",
+        verification_token="token-from-peer",
+        trust_type="friend",
+        peer_approved=True,
+        relationship="friend",
     )
 
-    # Modify with peer notification
-    updated = await actor.trust.modify_and_notify_async(
+Approving and Modifying Trust Relationships
+--------------------------------------------
+
+.. code-block:: python
+
+    # Approve a pending incoming relationship
+    actor.trust.approve_relationship("peer123")          # or approve_relationship_async
+
+    # Change relationship attributes and notify the peer
+    updated = actor.trust.modify_and_notify(
         peer_id="peer123",
-        relationship_type="colleague"
+        relationship="colleague",
     )
+
+    # Local-only modification (no peer notification)
+    actor.trust.modify_trust(peer_id="peer123", relationship="colleague")
 
 Deleting Trust Relationships
 -----------------------------
@@ -213,24 +238,27 @@ Deleting Trust Relationships
     # Delete local trust only
     success = actor.trust.delete_relationship("peer123")
 
-    # Delete with peer notification
-    success = await actor.trust.delete_peer_trust_async("peer123")
+    # Delete and notify the peer (default notify_peer=True)
+    success = actor.trust.delete_peer_trust("peer123")
+
+    # Async local delete
+    success = await actor.trust.delete_relationship_async("peer123")
 
 Permission Checking
 -------------------
 
-Trust relationships include permission checking based on relationship type:
+Per-peer permissions are managed through the trust permission store rather than
+on the ``TrustManager`` itself. For read/write access decisions in application
+code, prefer the permission-enforcing :doc:`authenticated-views` (``as_peer`` /
+``as_client``), which evaluate permissions for you. To inspect or update the
+stored permissions directly:
 
 .. code-block:: python
 
-    # Check if peer can access a property
-    trust = actor.trust.get_relationship_by_peerid("peer123")
-    if trust:
-        can_read = actor.trust.check_property_permission(
-            trust,
-            "user_profile",
-            "read"
-        )
+    from actingweb.trust_permissions import get_trust_permission_store
+
+    store = get_trust_permission_store(actor.config)
+    perms = store.get_permissions(actor.id, "peer123")
 
 SubscriptionManager
 ===================
@@ -370,7 +398,9 @@ The ``subscription_deleted`` lifecycle hook fires when inbound subscriptions are
             logger.info(f"Revoked {peer_id}'s subscription")
 
         # Common cleanup: revoke permissions, clear cached data, etc.
-        actor.trust.update_permissions(peer_id, [])
+        from actingweb.trust_permissions import get_trust_permission_store
+        store = get_trust_permission_store(actor.config)
+        store.update_permissions(actor.id, peer_id, {"properties": []})
 
 See :doc:`../reference/hooks-reference` for full hook documentation.
 
@@ -398,10 +428,10 @@ Best Practices
    .. code-block:: python
 
        # Good - async, non-blocking
-       trust = await actor.trust.create_verified_trust_async(...)
+       trust = await actor.trust.create_relationship_async(peer_url=...)
 
-       # Avoid - sync, may block for seconds
-       trust = actor.trust.create_verified_trust(...)
+       # Avoid in async contexts - sync, may block for seconds
+       trust = actor.trust.create_relationship(peer_url=...)
 
 3. **Let PropertyStore Handle Serialization**
 
@@ -426,7 +456,7 @@ Best Practices
        actor.properties["status"] = "active"
 
        # Only suppress for internal state
-       actor.properties.set("_internal_flag", True, notify=False)
+       actor.properties.set_without_notification("_internal_flag", True)
 
 5. **Check Trust Before Accessing**
 
@@ -434,7 +464,7 @@ Best Practices
 
    .. code-block:: python
 
-       trust = actor.trust.get_relationship_by_peerid(peer_id)
+       trust = actor.trust.get_relationship(peer_id)
        if not trust:
            return {"error": "No trust relationship"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 name = "actingweb"
 version = "3.11.0"
 description = "The official ActingWeb library"
-authors = ["Greger Wedel <support@greger.io>"]
-maintainers = ["Greger Wedel <support@greger.io>"]
+authors = ["Greger Wedel <support@actingweb.io>"]
+maintainers = ["Greger Wedel <support@actingweb.io>"]
 license = "BSD"
 readme = "README.rst"
 homepage = "http://actingweb.org"
@@ -22,6 +22,9 @@ classifiers = [
     "Topic :: Internet :: WWW/HTTP :: HTTP Servers",
 ]
 packages = [{ include = "actingweb" }]
+include = [
+    { path = "actingweb/templates/**/*", format = ["sdist", "wheel"] },
+]
 
 [tool.poetry.dependencies]
 python = "^3.11"

--- a/tests/test_fastapi_template_response.py
+++ b/tests/test_fastapi_template_response.py
@@ -79,10 +79,10 @@ class TestTemplateResponseWithContext:
 
 
 class TestTemplateResponseWithoutTemplates:
-    """Verify fallback when no templates directory is configured."""
+    """Verify the built-in default templates render when the app supplies none."""
 
-    def test_factory_get_returns_inline_html(self) -> None:
-        """GET / without templates_dir should return inline HTML fallback."""
+    def test_factory_get_renders_default_template(self) -> None:
+        """GET / without templates_dir renders the library's default factory page."""
         aw_app = (
             ActingWebApp(
                 aw_type="urn:actingweb:test",
@@ -94,10 +94,12 @@ class TestTemplateResponseWithoutTemplates:
             .with_devtest(enable=True)
         )
         app = FastAPI()
-        aw_app.integrate_fastapi(app)  # No templates_dir
+        aw_app.integrate_fastapi(app)  # No templates_dir -> library defaults
         client = TestClient(app)
 
         response = client.get("/")
         assert response.status_code == 200
         assert "text/html" in response.headers["content-type"]
-        assert "Welcome to ActingWeb" in response.text
+        # The built-in default factory/sign-in template renders out of the box
+        assert "<form" in response.text
+        assert "Sign in - ActingWeb" in response.text

--- a/tests/test_hook_metadata.py
+++ b/tests/test_hook_metadata.py
@@ -114,6 +114,52 @@ class TestGetHookMetadata:
         result = get_hook_metadata(sample_hook)
         assert result.description == "Hook description"
 
+    def test_empty_hook_metadata_falls_back_to_mcp(self) -> None:
+        """Regression: an EMPTY _hook_metadata must not shadow _mcp_metadata.
+
+        ``@app.action_hook("name")`` (the mandatory registration decorator, no
+        metadata args) attaches a HookMetadata with description="" / schemas
+        None. When stacked with @mcp_tool this must not blank out the MCP
+        metadata in GET /actions — each unset field falls back to MCP.
+        """
+
+        def sample_hook(actor, name, data):
+            return {"result": "ok"}
+
+        # Empty explicit metadata, as produced by @app.action_hook("name")
+        sample_hook._hook_metadata = HookMetadata()  # type: ignore[attr-defined]
+        sample_hook._mcp_metadata = {  # type: ignore[attr-defined]
+            "description": "Search notes",
+            "input_schema": {"type": "object"},
+            "annotations": {"readOnlyHint": True},
+        }
+
+        result = get_hook_metadata(sample_hook)
+        assert result.description == "Search notes"
+        assert result.input_schema == {"type": "object"}
+        assert result.annotations == {"readOnlyHint": True}
+
+    def test_partial_hook_metadata_merges_with_mcp(self) -> None:
+        """Explicit non-empty fields win; unset fields fall back to MCP."""
+
+        def sample_hook(actor, name, data):
+            return {"result": "ok"}
+
+        # Explicit description only; schema/annotations unset
+        sample_hook._hook_metadata = HookMetadata(  # type: ignore[attr-defined]
+            description="Explicit desc"
+        )
+        sample_hook._mcp_metadata = {  # type: ignore[attr-defined]
+            "description": "MCP desc",
+            "input_schema": {"type": "object"},
+            "annotations": {"readOnlyHint": True},
+        }
+
+        result = get_hook_metadata(sample_hook)
+        assert result.description == "Explicit desc"  # explicit wins
+        assert result.input_schema == {"type": "object"}  # fell back to MCP
+        assert result.annotations == {"readOnlyHint": True}  # fell back to MCP
+
     def test_returns_default_when_no_metadata(self) -> None:
         """Test get_hook_metadata returns defaults when no metadata."""
 

--- a/tests/test_mcp_server_name.py
+++ b/tests/test_mcp_server_name.py
@@ -42,3 +42,36 @@ class TestInstructionsInInitialize:
             make_mcp_config(server_name="emm", instructions="Call how_to_use() first")
         )["result"]
         assert result["instructions"] == "Call how_to_use() first"
+
+
+class TestWithMcpBuilderPropagation:
+    """with_mcp() settings must reach Config even though __init__ builds the
+    Config eagerly (via the permission-system warmup) before the fluent
+    builder methods run. Regression test for the builder->config sync gap.
+    """
+
+    def _app(self, **mcp_kwargs):
+        from actingweb.interface import ActingWebApp
+
+        return ActingWebApp(
+            aw_type="urn:actingweb:test:mcpbuild",
+            database="dynamodb",
+            fqdn="localhost:5000",
+        ).with_mcp(**mcp_kwargs)
+
+    def test_server_name_reaches_config(self) -> None:
+        cfg = self._app(enable=True, server_name="doctest").get_config()
+        assert cfg.mcp_server_name == "doctest"
+
+    def test_instructions_reach_config(self) -> None:
+        cfg = self._app(enable=True, instructions="Call how_to_use() first").get_config()
+        assert cfg.mcp_instructions == "Call how_to_use() first"
+
+    def test_enable_false_reaches_config(self) -> None:
+        cfg = self._app(enable=False).get_config()
+        assert cfg.mcp is False
+
+    def test_custom_server_name_surfaced_in_initialize_via_builder(self) -> None:
+        cfg = self._app(enable=True, server_name="doctest").get_config()
+        result = _initialize(cfg)["result"]
+        assert result["serverInfo"]["name"] == "doctest"


### PR DESCRIPTION
## Summary

Result of a full documentation review (human-developer and LLM-developer perspectives) plus a cold-build usability test, where a context-free agent built a complete ActingWeb app from the docs alone. **Every finding was verified against the implementation before fixing.** Two turned out to be real code bugs (each with a regression test); the rest are documentation corrections.

## Code fixes

- **Out-of-the-box web UI.** The library now ships default templates, so `with_web_ui(True)` renders the factory/sign-in page, actor dashboard, properties, and trust pages **without the app supplying any templates** (previously the UI 500'd / returned blank). App-provided templates of the same name still take precedence — Flask via a template-only blueprint, FastAPI via the `templates_dir` being searched first. Both integrations now register a `/login` route, and the templates are bundled into the wheel.
- **`with_mcp(server_name=…, instructions=…, enable=…)` were silently ignored.** `ActingWebApp.__init__` builds the `Config` eagerly (permission warmup) before the fluent builder runs, and the runtime config-sync didn't re-apply the MCP fields. `config.mcp` is now a first-class attribute, kept in sync (including the advertised `/meta` capability tag).
- **`@mcp_tool` metadata appeared blank in `GET /<id>/actions`.** The mandatory `@app.action_hook("name")` decorator attached empty explicit metadata that shadowed the populated `@mcp_tool` metadata. Hook-metadata resolution now merges per field: explicit non-empty values win, otherwise the `@mcp_tool` metadata (then auto-generated schemas) is used.

## Documentation

- Rewrote `README.rst` for the current framework (AI/MCP + web/SPA + native-mobile clients over one backend).
- Corrected verified API-reference inaccuracies across the SDK/reference docs (`TrustManager`/`SubscriptionManager`/`PropertyStore` names & signatures, `AwProxy` usage, `ActorInterface` attributes, authenticated views, and the `ActorInterface.create(hooks=app.hooks)` requirement for lifecycle hooks to fire).
- Stopped recommending `actor.is_owner()` as an access guard — it's a placeholder that always returns `True`.
- Fixed quickstart friction: DynamoDB Local prerequisites, the `migrate_db.py` download URL (`master` branch), MCP endpoint auth (no dev bypass), scalar-property stringification, `templates_dir` being optional, and Basic-auth vs OAuth for `/www`.

## Testing

- New regression tests for both code bugs (builder→config MCP propagation; hook-metadata merge).
- Full suite: **2365 passed**. The 5 initial failures were `tests/integration/` parallel-isolation flakiness and all pass when re-run sequentially (documented as a known issue in `CLAUDE.md`). `ruff` + `pyright` clean; all touched RST validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YFMDQHuzczAMBAd3AeZPkx
