### PR TITLE
Release v3.12.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,6 +38,15 @@ FIXED
   and both methods use the injected settings instead of a throwaway ``Config``.
   Applies to both the DynamoDB and PostgreSQL backends. Env-var-based
   configuration is unchanged (constructors still fall back to the environment).
+- **DynamoDB bulk property delete could remove another actor's reverse-lookup
+  row.** The DynamoDB property lookup table is keyed on ``(property_name,
+  value)``, so when two actors share the same indexed value the row points at
+  whichever actor wrote last. ``DbPropertyList.delete()`` deleted the lookup
+  row for each of the deleted actor's indexed values unconditionally, which
+  could wipe out a *different* actor's still-valid reverse-lookup entry. The
+  bulk cleanup now verifies the row belongs to the actor being deleted before
+  removing it, matching the single-property delete path. PostgreSQL was
+  unaffected (its cleanup already scopes the delete by ``actor_id``).
 - **``with_mcp(server_name=..., instructions=..., enable=...)`` were silently
   ignored.** ``ActingWebApp.__init__`` builds the ``Config`` eagerly (permission
   warmup), and the runtime config-sync did not re-apply the MCP fields, so

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,22 @@ ADDED
 FIXED
 ~~~~~
 
+- **Programmatically-enabled property lookup tables leaked stale reverse-lookup
+  rows on bulk delete.** ``DbPropertyList.delete()`` and
+  ``DbProperty.get_actor_id_from_property()`` constructed a fresh ``Config()``
+  internally to decide whether to maintain the property lookup table. A fresh
+  ``Config()`` only reflects environment variables and defaults, so a lookup
+  table enabled through the builder (``with_indexed_properties()`` /
+  ``with_legacy_property_index(enable=False)``, which set attributes on the
+  app's ``Config`` — not env vars) read back as *disabled* inside these methods.
+  As a result, deleting all of an actor's properties (e.g. on actor deletion)
+  skipped lookup-table cleanup and left stale entries that could resolve reverse
+  lookups to a deleted actor; reverse lookup could likewise take the wrong code
+  path. ``get_property_list()`` now injects ``use_lookup_table`` /
+  ``indexed_properties`` into ``DbPropertyList`` (matching ``get_property()``),
+  and both methods use the injected settings instead of a throwaway ``Config``.
+  Applies to both the DynamoDB and PostgreSQL backends. Env-var-based
+  configuration is unchanged (constructors still fall back to the environment).
 - **``with_mcp(server_name=..., instructions=..., enable=...)`` were silently
   ignored.** ``ActingWebApp.__init__`` builds the ``Config`` eagerly (permission
   warmup), and the runtime config-sync did not re-apply the MCP fields, so

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ CHANGELOG
 Unreleased
 ----------
 
+v3.12.0: July 9, 2026
+---------------------
+
 ADDED
 ~~~~~
 

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.11.0"
+__version__ = "3.12.0"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/db/__init__.py
+++ b/actingweb/db/__init__.py
@@ -90,20 +90,27 @@ def get_property(config: "Config") -> "DbPropertyProtocol":
 
 
 def get_property_list(config: "Config") -> "DbPropertyListProtocol":
-    """Create a DbPropertyList instance for batch property operations.
+    """Create a DbPropertyList instance with configuration injected.
+
+    This ensures batch operations (e.g. deleting all of an actor's properties)
+    respect the same use_lookup_table / indexed_properties settings as
+    get_property(), so lookup table rows stay in sync on bulk delete.
 
     Args:
         config: ActingWeb configuration instance
 
     Returns:
-        DbPropertyList instance
+        DbPropertyList instance configured with indexed_properties and use_lookup_table
 
     Example:
         >>> from actingweb.db import get_property_list
         >>> db_list = get_property_list(config)
         >>> props = db_list.fetch(actor_id="abc123")
     """
-    return config.DbProperty.DbPropertyList()
+    return config.DbProperty.DbPropertyList(
+        use_lookup_table=config.use_lookup_table,
+        indexed_properties=config.indexed_properties,
+    )
 
 
 # =============================================================================

--- a/actingweb/db/dynamodb/property.py
+++ b/actingweb/db/dynamodb/property.py
@@ -149,11 +149,7 @@ class DbProperty:
         if not name or not value:
             return None
 
-        from actingweb.config import Config
-
-        config = Config()
-
-        if config.use_lookup_table and name in config.indexed_properties:
+        if self._use_lookup_table and name in self._indexed_properties:
             # Use new lookup table approach
             from actingweb.db.dynamodb.property_lookup import DbPropertyLookup
 
@@ -336,10 +332,36 @@ class DbPropertyList:
     The actor_id must always be set.
     """
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        use_lookup_table: bool | None = None,
+        indexed_properties: list[str] | None = None,
+    ) -> None:
+        """Initialize DbPropertyList.
+
+        Args:
+            use_lookup_table: Whether to use property lookup table. If None, reads from env.
+            indexed_properties: List of property names to index. If None, uses defaults.
+        """
         self.handle: Any | None = None
         self.actor_id: str | None = None
         self.props: dict[str, str] | None = None
+
+        if use_lookup_table is not None:
+            self._use_lookup_table = use_lookup_table
+        else:
+            self._use_lookup_table = (
+                os.getenv("USE_PROPERTY_LOOKUP_TABLE", "").lower() == "true"
+            )
+
+        if indexed_properties is not None:
+            self._indexed_properties = indexed_properties
+        else:
+            self._indexed_properties = ["oauthId", "email", "externalUserId"]
+            if os.getenv("INDEXED_PROPERTIES"):
+                env_props = os.getenv("INDEXED_PROPERTIES", "").split(",")
+                self._indexed_properties = [p.strip() for p in env_props if p.strip()]
+
         if not Property.exists():
             try:
                 Property.create_table(wait=True)
@@ -391,15 +413,11 @@ class DbPropertyList:
         # Collect indexed properties before deletion
         indexed_props: list[tuple[str, str]] = []
 
-        from actingweb.config import Config
-
-        config = Config()
-
-        if config.use_lookup_table:
+        if self._use_lookup_table:
             # Scan properties to find indexed ones
             self.handle = Property.scan(Property.id == self.actor_id)
             for p in self.handle:
-                if str(p.name) in config.indexed_properties:
+                if str(p.name) in self._indexed_properties:
                     indexed_props.append((str(p.name), str(p.value)))
 
         # Delete all properties

--- a/actingweb/db/dynamodb/property.py
+++ b/actingweb/db/dynamodb/property.py
@@ -441,7 +441,12 @@ class DbPropertyList:
             for name, value in indexed_props:
                 try:
                     lookup = PropertyLookup.get(name, value)
-                    lookup.delete()
+                    # Verify it belongs to this actor before deleting. In
+                    # DynamoDB a shared indexed value is overwritten by the
+                    # latest writer, so deleting an older actor must not remove
+                    # a newer actor's reverse-lookup row.
+                    if str(lookup.actor_id) == self.actor_id:
+                        lookup.delete()
                 except Exception as e:
                     logger.warning(
                         f"Failed to delete lookup entry for property {name}: {e}"

--- a/actingweb/db/postgresql/property.py
+++ b/actingweb/db/postgresql/property.py
@@ -118,11 +118,7 @@ class DbProperty:
         if not name or not value:
             return None
 
-        from actingweb.config import Config
-
-        config = Config()
-
-        if config.use_lookup_table and name in config.indexed_properties:
+        if self._use_lookup_table and name in self._indexed_properties:
             # Use new lookup table approach
             from actingweb.db.postgresql.property_lookup import DbPropertyLookup
 
@@ -407,11 +403,35 @@ class DbPropertyList:
     actor_id: str | None
     props: dict[str, str] | None
 
-    def __init__(self) -> None:
-        """Initialize DbPropertyList."""
+    def __init__(
+        self,
+        use_lookup_table: bool | None = None,
+        indexed_properties: list[str] | None = None,
+    ) -> None:
+        """Initialize DbPropertyList.
+
+        Args:
+            use_lookup_table: Whether to use property lookup table. If None, reads from env.
+            indexed_properties: List of property names to index. If None, uses defaults.
+        """
         self.handle = None
         self.actor_id = None
         self.props = None
+
+        if use_lookup_table is not None:
+            self._use_lookup_table = use_lookup_table
+        else:
+            self._use_lookup_table = (
+                os.getenv("USE_PROPERTY_LOOKUP_TABLE", "").lower() == "true"
+            )
+
+        if indexed_properties is not None:
+            self._indexed_properties = indexed_properties
+        else:
+            self._indexed_properties = ["oauthId", "email", "externalUserId"]
+            if os.getenv("INDEXED_PROPERTIES"):
+                env_props = os.getenv("INDEXED_PROPERTIES", "").split(",")
+                self._indexed_properties = [p.strip() for p in env_props if p.strip()]
 
     def fetch(self, actor_id: str | None = None) -> dict[str, str] | None:
         """
@@ -513,15 +533,11 @@ class DbPropertyList:
             return False
 
         try:
-            from actingweb.config import Config
-
-            config = Config()
-
             with get_connection() as conn:
                 with conn.cursor() as cur:
                     # If using lookup table, collect indexed properties before deletion
                     indexed_props: list[tuple[str, str]] = []
-                    if config.use_lookup_table:
+                    if self._use_lookup_table:
                         cur.execute(
                             """
                             SELECT name, value
@@ -533,7 +549,7 @@ class DbPropertyList:
                         rows = cur.fetchall()
                         for row in rows:
                             name, value = row
-                            if name in config.indexed_properties:
+                            if name in self._indexed_properties:
                                 indexed_props.append((name, value))
 
                     # Delete all properties

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.11.0"
+version = "3.12.0"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@actingweb.io>"]
 maintainers = ["Greger Wedel <support@actingweb.io>"]

--- a/tests/test_property_lookup.py
+++ b/tests/test_property_lookup.py
@@ -477,15 +477,19 @@ class TestPropertyListCleanup:
         self, backend: str, test_actor_id: str, config_with_lookup_table
     ):
         """Regression: bulk delete must not remove a lookup row owned by a
-        different actor that shares the same indexed value.
+        *different* actor that happens to share the same indexed value.
 
-        In DynamoDB the lookup table is keyed on ``(property_name, value)`` and
-        a duplicate indexed value is overwritten by the latest writer. So when
-        two actors have the same indexed value, the row points at whichever
-        wrote last. ``DbPropertyList.delete()`` collects the older actor's
-        indexed values and previously deleted the lookup row unconditionally,
-        wiping out the newer actor's reverse-lookup entry. The bulk cleanup now
+        The lookup table is keyed on ``(property_name, value)``, so when two
+        actors share an indexed value only one of them owns the reverse-lookup
+        row. The owner differs by backend: DynamoDB is last-writer-wins, while
+        PostgreSQL is first-writer-wins (``ON CONFLICT DO NOTHING``).
+        ``DbPropertyList.delete()`` collected the deleted actor's indexed values
+        and previously removed the lookup row unconditionally, so deleting the
+        *non-owning* actor could wipe out the owner's entry. The cleanup now
         verifies ownership before deleting, matching the single-property path.
+
+        This test deletes whichever actor does not own the row and asserts the
+        owner's row survives, which is meaningful for both backends.
         """
         property_mod = get_db_module(backend, "property")
         lookup_mod = get_db_module(backend, "property_lookup")
@@ -501,34 +505,38 @@ class TestPropertyListCleanup:
 
         shared_value = "shared@example.com"
         try:
-            # Older actor writes first, newer actor overwrites the shared value.
+            # Both actors write the same indexed value.
             prop1 = property_mod.DbProperty()
             prop1.set(actor_id=test_actor_id, name="email", value=shared_value)
             prop2 = property_mod.DbProperty()
             prop2.set(actor_id=actor2_id, name="email", value=shared_value)
 
-            # In DynamoDB the lookup row now points at the newer actor.
+            # Whichever actor currently owns the (name, value) lookup row.
             owner = lookup_mod.DbPropertyLookup().get(
                 property_name="email", value=shared_value
             )
+            assert owner in (test_actor_id, actor2_id)
+            non_owner = actor2_id if owner == test_actor_id else test_actor_id
 
-            # Bulk-delete the older actor's properties.
+            # Bulk-delete the actor that does NOT own the lookup row. Its cleanup
+            # must not touch the owner's row.
             prop_list = property_mod.DbPropertyList()
-            prop_list.fetch(actor_id=test_actor_id)
+            prop_list.fetch(actor_id=non_owner)
             prop_list.delete()
 
-            # The lookup row for the newer actor must survive.
+            # The owner's lookup row must survive.
             still = lookup_mod.DbPropertyLookup().get(
                 property_name="email", value=shared_value
             )
             assert still == owner, (
-                "Bulk delete of the older actor removed the newer actor's "
+                "Bulk delete of the non-owning actor removed the owner's "
                 "shared lookup row"
             )
         finally:
-            prop_list2 = property_mod.DbPropertyList()
-            prop_list2.fetch(actor_id=actor2_id)
-            prop_list2.delete()
+            for aid in (test_actor_id, actor2_id):
+                prop_cleanup = property_mod.DbPropertyList()
+                prop_cleanup.fetch(actor_id=aid)
+                prop_cleanup.delete()
             if backend == "postgresql":
                 try:
                     get_db_module("postgresql", "actor").DbActor().delete(

--- a/tests/test_property_lookup.py
+++ b/tests/test_property_lookup.py
@@ -473,6 +473,70 @@ class TestPropertyListCleanup:
             is None
         )
 
+    def test_bulk_delete_preserves_other_actors_lookup_row(
+        self, backend: str, test_actor_id: str, config_with_lookup_table
+    ):
+        """Regression: bulk delete must not remove a lookup row owned by a
+        different actor that shares the same indexed value.
+
+        In DynamoDB the lookup table is keyed on ``(property_name, value)`` and
+        a duplicate indexed value is overwritten by the latest writer. So when
+        two actors have the same indexed value, the row points at whichever
+        wrote last. ``DbPropertyList.delete()`` collects the older actor's
+        indexed values and previously deleted the lookup row unconditionally,
+        wiping out the newer actor's reverse-lookup entry. The bulk cleanup now
+        verifies ownership before deleting, matching the single-property path.
+        """
+        property_mod = get_db_module(backend, "property")
+        lookup_mod = get_db_module(backend, "property_lookup")
+
+        # Second actor sharing the same indexed value. Create the actor row in
+        # PostgreSQL so the property_lookup foreign key constraint is satisfied.
+        actor2_id = str(uuid.uuid4())
+        if backend == "postgresql":
+            actor_mod = get_db_module("postgresql", "actor")
+            actor_mod.DbActor().create(
+                actor_id=actor2_id, creator="test@example.com", passphrase=""
+            )
+
+        shared_value = "shared@example.com"
+        try:
+            # Older actor writes first, newer actor overwrites the shared value.
+            prop1 = property_mod.DbProperty()
+            prop1.set(actor_id=test_actor_id, name="email", value=shared_value)
+            prop2 = property_mod.DbProperty()
+            prop2.set(actor_id=actor2_id, name="email", value=shared_value)
+
+            # In DynamoDB the lookup row now points at the newer actor.
+            owner = lookup_mod.DbPropertyLookup().get(
+                property_name="email", value=shared_value
+            )
+
+            # Bulk-delete the older actor's properties.
+            prop_list = property_mod.DbPropertyList()
+            prop_list.fetch(actor_id=test_actor_id)
+            prop_list.delete()
+
+            # The lookup row for the newer actor must survive.
+            still = lookup_mod.DbPropertyLookup().get(
+                property_name="email", value=shared_value
+            )
+            assert still == owner, (
+                "Bulk delete of the older actor removed the newer actor's "
+                "shared lookup row"
+            )
+        finally:
+            prop_list2 = property_mod.DbPropertyList()
+            prop_list2.fetch(actor_id=actor2_id)
+            prop_list2.delete()
+            if backend == "postgresql":
+                try:
+                    get_db_module("postgresql", "actor").DbActor().delete(
+                        actor_id=actor2_id
+                    )
+                except Exception:
+                    pass
+
 
 @pytest.mark.parametrize("backend", ["postgresql"])
 class TestLargeValueSupport:

--- a/tests/test_property_lookup.py
+++ b/tests/test_property_lookup.py
@@ -401,6 +401,78 @@ class TestPropertyListCleanup:
         lookup6 = lookup_mod.DbPropertyLookup()
         assert lookup6.get(property_name="externalUserId", value="ext999") is None
 
+    def test_bulk_delete_honors_programmatic_config_without_env(
+        self, backend: str, test_actor_id: str, monkeypatch
+    ):
+        """Regression: bulk delete must clean lookup entries when the lookup
+        table is enabled via ``Config`` (programmatically, as ``ActingWebApp``
+        does) rather than via environment variables.
+
+        Previously ``DbPropertyList.delete()`` (and
+        ``DbProperty.get_actor_id_from_property()``) constructed a fresh
+        ``Config()`` internally, which only saw env vars/defaults. A lookup
+        table enabled through the builder therefore read back as disabled inside
+        those methods, so bulk delete skipped cleanup and left stale lookup rows
+        pointing at a deleted actor. The accessors now inject the caller's
+        config, so this path must clean up.
+        """
+        from actingweb.config import Config
+        from actingweb.db import get_property, get_property_list
+
+        # The lookup table must NOT be enabled via the environment - only via
+        # the Config object we pass in. This is what makes the old code fail.
+        monkeypatch.delenv("USE_PROPERTY_LOOKUP_TABLE", raising=False)
+        monkeypatch.delenv("INDEXED_PROPERTIES", raising=False)
+
+        lookup_mod = get_db_module(backend, "property_lookup")
+
+        # Build a Config for the running backend and enable the lookup table the
+        # same way ActingWebApp.get_config() does: by setting attributes, not env.
+        config = Config()
+        config.use_lookup_table = True
+        config.indexed_properties = ["oauthId", "email", "externalUserId"]
+
+        # Set indexed properties through the config-injected accessor.
+        get_property(config).set(
+            actor_id=test_actor_id, name="oauthId", value="github:prog1"
+        )
+        get_property(config).set(
+            actor_id=test_actor_id, name="email", value="prog@example.com"
+        )
+
+        # Sanity: lookup entries were created for the indexed properties.
+        assert (
+            lookup_mod.DbPropertyLookup().get(
+                property_name="oauthId", value="github:prog1"
+            )
+            == test_actor_id
+        )
+        assert (
+            lookup_mod.DbPropertyLookup().get(
+                property_name="email", value="prog@example.com"
+            )
+            == test_actor_id
+        )
+
+        # Bulk delete via the config-injected accessor.
+        prop_list = get_property_list(config)
+        prop_list.fetch(actor_id=test_actor_id)
+        prop_list.delete()
+
+        # Lookup entries must be gone (this leaked stale rows before the fix).
+        assert (
+            lookup_mod.DbPropertyLookup().get(
+                property_name="oauthId", value="github:prog1"
+            )
+            is None
+        )
+        assert (
+            lookup_mod.DbPropertyLookup().get(
+                property_name="email", value="prog@example.com"
+            )
+            is None
+        )
+
 
 @pytest.mark.parametrize("backend", ["postgresql"])
 class TestLargeValueSupport:


### PR DESCRIPTION
Release **v3.12.0**, rolling up everything on master since v3.11.0.

## Highlights

- **Fix (this release's trigger):** property reverse-lookup rows leaked on bulk delete when the lookup table was enabled **programmatically** via the `ActingWebApp` builder (rather than env vars). `DbPropertyList.delete()` and `DbProperty.get_actor_id_from_property()` built a throwaway `Config()` internally, which only saw env vars/defaults — so a builder-enabled lookup table read back as disabled and cleanup was skipped, leaving stale rows pointing at deleted actors. `get_property_list()` now injects `use_lookup_table` / `indexed_properties` (matching `get_property()`), and both methods use the injected settings. DynamoDB + PostgreSQL. Includes a regression test that fails against the old behavior.
- Also bundled (already merged in #113): built-in out-of-the-box web-UI templates, two MCP correctness fixes, and a docs overhaul.

## Version

- `pyproject.toml`, `actingweb/__init__.py` → `3.12.0`
- `CHANGELOG.rst`: `Unreleased` rolled into `v3.12.0: July 9, 2026`
- Minor bump (not patch) because the unreleased set includes a new feature (web-UI templates).

## Release flow

Merge this to master, then cut the `v3.12.0` tag from master to trigger the PyPI publish (tags must be released from master).

🤖 Generated with [Claude Code](https://claude.com/claude-code)