### PR TITLE
DynamoDB backend scalability (v3.13.0)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,9 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write # Required so Claude can post its review via `gh pr comment`
+      issues: write # PR comments post to the issues comments endpoint
       id-token: write
+      actions: read # Required for Claude to read CI results on PRs
 
     steps:
       - name: Checkout repository
@@ -36,6 +37,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Allow Claude to read CI results (test/coverage checks) when reviewing
+          additional_permissions: |
+            actions: read
+
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -53,4 +59,4 @@ jobs:
 
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr checks:*),Bash(gh run view:*)"'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,20 @@ ADDED
 CHANGED
 ~~~~~~~
 
+- **Auto-created DynamoDB tables now use on-demand billing.** Tables the
+  library creates were provisioned with tiny fixed capacities inherited
+  from old Meta defaults (the property lookup table — the login path —
+  got 2 read units / 1 write unit per second, a hard throughput wall).
+  Newly created tables are now ``PAY_PER_REQUEST``. **Existing tables are
+  not changed** — convert them once, in place (never recreate; the lookup
+  table holds live login data)::
+
+      aws dynamodb update-table --table-name <prefix>_property_lookup \
+          --billing-mode PAY_PER_REQUEST
+
+  (AWS allows one billing-mode switch per table per 24 hours. Check
+  ``<prefix>_peertrustees`` too.)
+
 - **Per-actor DynamoDB reads no longer scan the whole table.** Nine call
   sites (property fetch/delete, trust list fetch/delete, peer-trustee
   fetch/lookup/delete) issued a full-table ``Scan`` with a partition-key

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,24 @@ ADDED
 CHANGED
 ~~~~~~~
 
+- **Property reverse-lookup table redesigned (v2, digest keys).** On
+  DynamoDB, lookup rows now live in a new ``<prefix>_property_lookup_v2``
+  table keyed by a SHA-256 digest of (property name, value); the plaintext
+  value is no longer stored. This removes the old design's hot-partition
+  key (all emails shared one partition), its undocumented 1024-byte value
+  cap, and plaintext PII in key material. Writes are conditional: a value
+  already mapped to a **different** actor is now a loudly-logged collision
+  instead of a silent last-writer-wins overwrite (PostgreSQL gained the
+  same idempotent-create/collision semantics). Existing v1 lookup tables
+  are read as a deprecated fallback; rebuild the v2 table from the
+  properties table with the backfill script, verify, then drop the v1
+  table. Reverse lookups for property names not configured as indexed now
+  return ``None`` with a warning instead of silently using the legacy
+  path, and the legacy GSI path raises an actionable error when the index
+  is missing from the live table instead of an opaque backend exception.
+  Lookup write failures are logged at ERROR (previously swallowed —
+  a failed lookup write silently broke login-by-email for that user).
+
 - **Hot-path read amplification removed across the property and actor
   paths.** ``GET /<actor>/properties`` now serves the entire response
   (simple properties, list discovery, list metadata and list items) from a

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,18 @@ ADDED
 CHANGED
 ~~~~~~~
 
+- **Lookup-table mode is now the default reverse-lookup mechanism**
+  (``use_lookup_table`` defaults to ``True``; the deprecated legacy
+  GSI/index mode can be pinned with ``with_legacy_property_index(True)``
+  or ``USE_PROPERTY_LOOKUP_TABLE=false``). Upgrading deployments keep
+  resolving reverse lookups through deprecated fallbacks (v1 lookup
+  table, then the legacy GSI where present) with per-hit warnings and a
+  loud startup ERROR until the new
+  ``scripts/backfill_property_lookup.py`` is run — see
+  ``docs/migration/v3.13.rst`` for the per-deployment decision tree.
+  Note the semantic change: lookup-table matching is per (property name,
+  value); the legacy GSI matched on value alone.
+
 - **Freshly created properties tables match the configured reverse-lookup
   mode.** In lookup-table mode, auto-created ``<prefix>_properties``
   tables no longer carry the legacy value-keyed ``property-index`` GSI —

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,15 @@ ADDED
 CHANGED
 ~~~~~~~
 
+- **Per-actor DynamoDB reads no longer scan the whole table.** Nine call
+  sites (property fetch/delete, trust list fetch/delete, peer-trustee
+  fetch/lookup/delete) issued a full-table ``Scan`` with a partition-key
+  filter — read cost grew with total table size, not the actor's data
+  (measured ~2,000 RCU per property fetch on a 16 MB table). All are now
+  partition ``Query`` calls; the trust reads keep their strong consistency.
+  Trust and peer-trustee list results are now range-key sorted
+  (deterministic order) instead of arbitrary scan order.
+
 - **DynamoDB table-existence checks are now memoised per process.** Every
   accessor construction used to issue a live ``DescribeTable`` call
   (measured at >1,000/minute in a near-idle deployment); the check now runs

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,20 @@ ADDED
 CHANGED
 ~~~~~~~
 
+- **Hot-path read amplification removed across the property and actor
+  paths.** ``GET /<actor>/properties`` now serves the entire response
+  (simple properties, list discovery, list metadata and list items) from a
+  single partition read — it previously re-read every property
+  individually after the bulk read, read the partition a second time for
+  lists, and re-read each list's metadata row. Single-property reads no
+  longer pay an extra list-existence check on every hit, repeat property
+  writes skip the list-collision read, the actor's internal attribute
+  bucket is loaded lazily (once, instead of eagerly twice per actor
+  construction), attribute buckets in general no longer load fully on
+  construction, bulk property deletion reads its partition once instead of
+  twice, and permission evaluation caches confirmed-absent trust
+  overrides instead of re-reading per request.
+
 - **Auto-created DynamoDB tables now use on-demand billing.** Tables the
   library creates were provisioned with tiny fixed capacities inherited
   from old Meta defaults (the property lookup table — the login path —

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ CHANGELOG
 Unreleased
 ----------
 
+FIXED
+~~~~~
+
+- **Property lookup env overrides were silently ignored by the fluent builder.**
+  ``ActingWebApp`` stamped its own hardcoded lookup-table defaults onto the
+  config on every ``with_*()`` call (a guard intended to detect "explicitly
+  set" was always true), so the documented ``USE_PROPERTY_LOOKUP_TABLE`` and
+  ``INDEXED_PROPERTIES`` environment variables were clobbered for any app that
+  called a builder method after construction — including the documented
+  rollback path for lookup-table migration. The builder now tracks whether
+  these settings were explicitly configured; precedence is consistently
+  explicit builder call > environment variable > library default.
+
 v3.12.0: July 9, 2026
 ---------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ CHANGELOG
 Unreleased
 ----------
 
+v3.13.0rc1: July 24, 2026
+-------------------------
+
 ADDED
 ~~~~~
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,15 @@ ADDED
 CHANGED
 ~~~~~~~
 
+- **Freshly created properties tables match the configured reverse-lookup
+  mode.** In lookup-table mode, auto-created ``<prefix>_properties``
+  tables no longer carry the legacy value-keyed ``property-index`` GSI —
+  previously every fresh deployment inherited it even when nothing read
+  it, paying double write/storage cost and rejecting any property value
+  over DynamoDB's 2048-byte GSI-key limit (values over 2 KB now verified
+  to store correctly). Legacy mode still creates the GSI so the legacy
+  reverse-lookup path works. Existing tables are never altered.
+
 - **Property reverse-lookup table redesigned (v2, digest keys).** On
   DynamoDB, lookup rows now live in a new ``<prefix>_property_lookup_v2``
   table keyed by a SHA-256 digest of (property name, value); the plaintext

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -104,6 +104,20 @@ CHANGED
 FIXED
 ~~~~~
 
+- **Changing an indexed property left its old reverse-lookup row behind on
+  DynamoDB.** When an indexed value (e.g. ``email``) was updated through the
+  normal properties API, the old lookup row was never deleted, so reverse
+  lookup by the previous value kept resolving to the actor and blocked any
+  other actor from claiming that value. The DynamoDB backend now reads the
+  current value before writing, matching the PostgreSQL backend. (Only
+  affected lookup-table mode, which is unreleased.)
+
+- **Reverse-lookup migration fallbacks matched on value alone, ignoring the
+  property name.** During a not-yet-backfilled migration, the legacy-GSI
+  (DynamoDB) and sequential-scan (PostgreSQL) fallbacks could return an actor
+  whose *different* property happened to share the requested value; both now
+  filter by property name. (Migration-only path, unreleased.)
+
 - **Two DynamoDB accessors never auto-created their tables.** First use of
   subscription suspension (``DbSubscriptionSuspension``) or the peer-trustee
   list on a fresh deployment crashed with a table-not-found error; both now

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,33 @@ CHANGELOG
 Unreleased
 ----------
 
+ADDED
+~~~~~
+
+- **DynamoDB table auto-creation can now be disabled** for deployments that
+  manage tables via infrastructure-as-code: set
+  ``AWS_DB_AUTO_CREATE_TABLES=false`` or call
+  ``with_dynamodb(auto_create_tables=False)``. With auto-creation off, the
+  library never calls ``DescribeTable``/``CreateTable``, so both permissions
+  can be dropped from the runtime IAM role.
+
+CHANGED
+~~~~~~~
+
+- **DynamoDB table-existence checks are now memoised per process.** Every
+  accessor construction used to issue a live ``DescribeTable`` call
+  (measured at >1,000/minute in a near-idle deployment); the check now runs
+  at most once per table per process, and all tables are pre-warmed
+  concurrently at Flask/FastAPI integration time instead of serially on the
+  first request.
+
 FIXED
 ~~~~~
+
+- **Two DynamoDB accessors never auto-created their tables.** First use of
+  subscription suspension (``DbSubscriptionSuspension``) or the peer-trustee
+  list on a fresh deployment crashed with a table-not-found error; both now
+  go through the same table-existence guard as every other accessor.
 
 - **Property lookup env overrides were silently ignored by the fluent builder.**
   ``ActingWebApp`` stamped its own hardcoded lookup-table defaults onto the

--- a/README.rst
+++ b/README.rst
@@ -205,8 +205,9 @@ Two production-ready backends behind a common protocol:
   Install with the ``postgresql`` extra.
 
 Select with ``database="postgresql"`` or the ``DATABASE_BACKEND`` environment
-variable. Optional **property reverse-lookup tables** (``with_indexed_properties``)
-enable find-actor-by-property-value without GSI size limits. See
+variable. **Property reverse-lookup tables** (on by default; configure names
+with ``with_indexed_properties``) enable find-actor-by-property-value with no
+value-size limits and no plaintext values in the lookup table. See
 ``docs/reference/database-backends.rst``.
 
 The ActingWeb model

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.12.0"
+__version__ = "3.13.0rc1"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/attribute.py
+++ b/actingweb/attribute.py
@@ -15,11 +15,27 @@ class InternalStore:
         if not bucket:
             bucket = "_internal"
         self._db = Attributes(actor_id=actor_id, bucket=bucket, config=config)
-        d = self._db.get_bucket()
+        # The bucket is loaded lazily on first access: constructing the
+        # store (which happens on every Actor construction) must not cost a
+        # database query when the attributes are never touched.
+        self._loaded = False
+        self.__initialised = True
+
+    def _ensure_loaded(self) -> None:
+        """Load the whole bucket into the instance on first access.
+
+        Must run before the first write as well as the first read: a write
+        populates the underlying Attributes cache with a single key, after
+        which get_bucket() would return a partial bucket.
+        """
+        if self.__dict__.get("_loaded"):
+            return
+        self.__dict__["_loaded"] = True
+        d = self.__dict__["_db"].get_bucket()
         if d:
             for k, v in d.items():
-                self.__setattr__(k, v.get("data"))
-        self.__initialised = True
+                # Populate directly — no write-through back to the database
+                self.__dict__[k] = (v or {}).get("data")
 
     def __getitem__(self, k: str) -> Any:
         return self.__getattr__(k)
@@ -32,6 +48,7 @@ class InternalStore:
             return object.__setattr__(self, k, v)
         if k is None:
             raise ValueError
+        self._ensure_loaded()
         if v is None:
             self.__dict__["_db"].delete_attr(name=k)
             if k in self.__dict__:
@@ -41,10 +58,12 @@ class InternalStore:
             self.__dict__["_db"].set_attr(name=k, data=v)
 
     def __getattr__(self, k: str) -> Any:
-        try:
-            return self.__dict__[k]
-        except KeyError:
+        # Only reached when k is not in __dict__. Avoid triggering a load
+        # for private/dunder lookups (pickling, introspection).
+        if k.startswith("_"):
             return None
+        self._ensure_loaded()
+        return self.__dict__.get(k)
 
 
 class Attributes:
@@ -56,8 +75,14 @@ class Attributes:
     """
 
     def get_bucket(self) -> dict[str, Any] | None:
-        """Retrieves the attribute bucket from the database"""
-        if not self.data or len(self.data) == 0:
+        """Retrieves the attribute bucket from the database.
+
+        Tracks full-bucket loads with a flag rather than data emptiness:
+        a set_attr()/get_attr() may have cached individual entries, and
+        treating a partially-cached dict as "loaded" would silently return
+        an incomplete bucket.
+        """
+        if not self._bucket_loaded:
             if self.dbprop:
                 fetched_data = self.dbprop.get_bucket(
                     actor_id=self.actor_id, bucket=self.bucket
@@ -70,6 +95,7 @@ class Attributes:
                     self.data = cast(dict[str, dict[str, Any] | None], fetched_data)
             else:
                 self.data = {}
+            self._bucket_loaded = True
         return self.data
 
     def get_attr(self, name: str | None = None) -> dict[str, Any] | None:
@@ -216,6 +242,7 @@ class Attributes:
             else:
                 self.dbprop = None
             self.data = {}
+            self._bucket_loaded = False
             return True
         else:
             return False
@@ -235,8 +262,11 @@ class Attributes:
         self.bucket = bucket
         self.actor_id = actor_id
         self.data: dict[str, dict[str, Any] | None] = {}
-        if actor_id and bucket and len(bucket) > 0 and config:
-            self.get_bucket()
+        # The bucket is loaded lazily by get_bucket(): most consumers only
+        # ever read/write single attributes (get_attr/set_attr), and eagerly
+        # loading the whole bucket here cost a database query per
+        # construction — including twice per Actor construction.
+        self._bucket_loaded = False
 
 
 class Buckets:

--- a/actingweb/config.py
+++ b/actingweb/config.py
@@ -61,9 +61,12 @@ class Config:
         # Property lookup configuration (backward compatible defaults)
         #########
         self.indexed_properties: list[str] = ["oauthId", "email", "externalUserId"]
-        self.use_lookup_table: bool = (
-            False  # False = use old GSI/index (backward compatible)
-        )
+        # True = lookup-table reverse lookup (the mechanism of record since
+        # v3.13; no value-size limit, no legacy GSI). Legacy GSI/index mode
+        # is deprecated — pin it with use_lookup_table=False /
+        # USE_PROPERTY_LOOKUP_TABLE=false / with_legacy_property_index(True)
+        # only while migrating; see docs/migration/v3.13.rst.
+        self.use_lookup_table: bool = True
         #########
         # Peer profile caching configuration
         #########

--- a/actingweb/db/dynamodb/__init__.py
+++ b/actingweb/db/dynamodb/__init__.py
@@ -9,7 +9,7 @@ from .actor import Actor, CreatorIndex, DbActor, DbActorList
 from .attribute import Attribute, DbAttribute, DbAttributeBucketList
 from .peertrustee import DbPeerTrustee, DbPeerTrusteeList, PeerTrustee
 from .property import DbProperty, DbPropertyList, Property
-from .property_lookup import DbPropertyLookup, PropertyLookup
+from .property_lookup import DbPropertyLookup, PropertyLookup, PropertyLookupV2
 from .subscription import DbSubscription, DbSubscriptionList, Subscription
 from .subscription_diff import (
     DbSubscriptionDiff,
@@ -38,6 +38,7 @@ __all__ = [
     "DbPropertyList",
     # PropertyLookup
     "PropertyLookup",
+    "PropertyLookupV2",
     "DbPropertyLookup",
     # Subscription
     "Subscription",

--- a/actingweb/db/dynamodb/__init__.py
+++ b/actingweb/db/dynamodb/__init__.py
@@ -8,7 +8,7 @@ properties, trust relationships, and subscriptions.
 from .actor import Actor, CreatorIndex, DbActor, DbActorList
 from .attribute import Attribute, DbAttribute, DbAttributeBucketList
 from .peertrustee import DbPeerTrustee, DbPeerTrusteeList, PeerTrustee
-from .property import DbProperty, DbPropertyList, Property
+from .property import DbProperty, DbPropertyList, Property, PropertyLegacy
 from .property_lookup import DbPropertyLookup, PropertyLookup, PropertyLookupV2
 from .subscription import DbSubscription, DbSubscriptionList, Subscription
 from .subscription_diff import (
@@ -34,6 +34,7 @@ __all__ = [
     "DbPeerTrusteeList",
     # Property
     "Property",
+    "PropertyLegacy",
     "DbProperty",
     "DbPropertyList",
     # PropertyLookup

--- a/actingweb/db/dynamodb/_ensure.py
+++ b/actingweb/db/dynamodb/_ensure.py
@@ -1,0 +1,118 @@
+"""
+Process-wide DynamoDB table-existence guard.
+
+Historically every ``Db*`` accessor ``__init__`` ran
+``if not Model.exists(): Model.create_table(wait=True)``. pynamodb's
+``exists()`` always issues a live ``DescribeTable`` control-plane call (it
+populates its metadata cache but never reads from it), so every accessor
+construction paid a network round trip — measured at >1,000 calls/minute in
+a near-idle production deployment. ``ensure_table()`` collapses that to at
+most one check per model class per process.
+
+Auto-creation can be disabled entirely for deployments that manage tables
+via infrastructure-as-code (CloudFormation/Terraform):
+
+- environment: ``AWS_DB_AUTO_CREATE_TABLES=false`` (default: enabled), or
+- fluent API: ``ActingWebApp(...).with_dynamodb(auto_create_tables=False)``.
+
+With auto-creation disabled, neither ``DescribeTable`` nor ``CreateTable``
+is ever called, so both permissions can be dropped from the runtime IAM
+role.
+"""
+
+import logging
+import os
+import threading
+
+from pynamodb.models import Model
+
+logger = logging.getLogger(__name__)
+
+# Model classes whose table is known to exist. Keyed by class (not
+# Meta.table_name) so distinct model classes sharing a table name — e.g. a
+# legacy and a current schema variant — are tracked independently.
+_ensured: set[type[Model]] = set()
+_lock = threading.Lock()
+
+# Tri-state override set via set_auto_create(); None means "consult the
+# AWS_DB_AUTO_CREATE_TABLES environment variable".
+_auto_create_override: bool | None = None
+_flag_logged = False
+
+
+def auto_create_enabled() -> bool:
+    """Whether table auto-creation is currently enabled (override, else env)."""
+    if _auto_create_override is not None:
+        return _auto_create_override
+    return os.getenv("AWS_DB_AUTO_CREATE_TABLES", "true").strip().lower() not in (
+        "false",
+        "0",
+        "no",
+    )
+
+
+def set_auto_create(enabled: bool) -> None:
+    """Programmatically enable/disable table auto-creation.
+
+    Takes precedence over the ``AWS_DB_AUTO_CREATE_TABLES`` environment
+    variable. Must be called before the first database access to be fully
+    effective; a warning is logged if tables have already been ensured.
+    """
+    global _auto_create_override
+    with _lock:
+        if _ensured and not enabled:
+            logger.warning(
+                "set_auto_create(False) called after %d table(s) were already "
+                "ensured; the setting only affects tables not yet accessed. "
+                "Configure it before the first database access.",
+                len(_ensured),
+            )
+        _auto_create_override = enabled
+
+
+def ensure_table(model: type[Model]) -> None:
+    """Create the model's table if absent — at most once per process per model.
+
+    No-op when auto-creation is disabled (the caller's subsequent data-plane
+    operation will fail loudly if the table genuinely does not exist).
+    """
+    global _flag_logged
+    if model in _ensured:
+        return
+    if not auto_create_enabled():
+        # Skip exists() too: production roles without dynamodb:DescribeTable
+        # must not pay (or leak) an AccessDenied on every construction.
+        if not _flag_logged:
+            _flag_logged = True
+            logger.info(
+                "DynamoDB table auto-creation is disabled; tables are assumed "
+                "to be managed externally."
+            )
+        return
+    with _lock:
+        if model in _ensured:
+            return
+        if not model.exists():
+            try:
+                model.create_table(wait=True)
+                logger.info("Created DynamoDB table %s", model.Meta.table_name)
+            except Exception as e:
+                # Another process may have created the table between the
+                # exists() check and create_table(). Anything else (including
+                # AccessDenied) must propagate: swallowing it would turn a
+                # configuration error into silent data loss.
+                if "ResourceInUseException" not in str(e):
+                    raise
+        # Only reached on success — never cache a negative.
+        _ensured.add(model)
+
+
+def reset_ensure_cache() -> None:
+    """Forget which tables were ensured (test hook).
+
+    Must be called by any code that deletes tables in-process (e.g. the
+    integration-test cleanup), otherwise ensure_table() keeps asserting a
+    deleted table exists. Does not reset the auto-create override.
+    """
+    with _lock:
+        _ensured.clear()

--- a/actingweb/db/dynamodb/actor.py
+++ b/actingweb/db/dynamodb/actor.py
@@ -6,6 +6,8 @@ from pynamodb.attributes import UnicodeAttribute
 from pynamodb.indexes import AllProjection, GlobalSecondaryIndex
 from pynamodb.models import Model
 
+from actingweb.db.dynamodb._ensure import ensure_table
+
 """
     DbActor handles all db operations for an actor
     Google datastore for google is used as a backend.
@@ -140,16 +142,7 @@ class DbActor:
 
     def __init__(self):
         self.handle = None
-        if not Actor.exists():
-            try:
-                Actor.create_table(wait=True)
-            except Exception as e:
-                # Handle race condition where another process created the table
-                # between our exists() check and create_table() call
-                if "ResourceInUseException" in str(e):
-                    pass  # Table was created by another process, continue
-                else:
-                    raise
+        ensure_table(Actor)
 
 
 class DbActorList:

--- a/actingweb/db/dynamodb/actor.py
+++ b/actingweb/db/dynamodb/actor.py
@@ -3,6 +3,7 @@ import os
 from typing import Any
 
 from pynamodb.attributes import UnicodeAttribute
+from pynamodb.constants import PAY_PER_REQUEST_BILLING_MODE
 from pynamodb.indexes import AllProjection, GlobalSecondaryIndex
 from pynamodb.models import Model
 
@@ -23,8 +24,6 @@ class CreatorIndex(GlobalSecondaryIndex[Any]):
 
     class Meta:
         index_name = "creator-index"
-        read_capacity_units = 2
-        write_capacity_units = 1
         projection = AllProjection()
 
     creator = UnicodeAttribute(hash_key=True)
@@ -37,8 +36,7 @@ class Actor(Model):
 
     class Meta:  # type: ignore[misc]
         table_name = os.getenv("AWS_DB_PREFIX", "demo_actingweb") + "_actors"
-        read_capacity_units = 6
-        write_capacity_units = 2
+        billing_mode = PAY_PER_REQUEST_BILLING_MODE
         region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
         host = os.getenv("AWS_DB_HOST", None)
 

--- a/actingweb/db/dynamodb/actor.py
+++ b/actingweb/db/dynamodb/actor.py
@@ -151,7 +151,11 @@ class DbActorList:
     """
 
     def fetch(self):
-        """Retrieves the actors in the database"""
+        """Retrieves ALL actors in the database.
+
+        Admin/maintenance use only: this is a deliberate full-table Scan,
+        O(table size) and unpaginated — do not call it on a serving path.
+        """
         self.handle = Actor.scan()
         if self.handle:
             ret = []

--- a/actingweb/db/dynamodb/attribute.py
+++ b/actingweb/db/dynamodb/attribute.py
@@ -10,6 +10,8 @@ from pynamodb.attributes import (
 )
 from pynamodb.models import Model
 
+from actingweb.db.dynamodb._ensure import ensure_table
+
 """
     DbAttribute handles all db operations for an attribute (internal)
     AWS DynamoDB is used as a backend.
@@ -331,16 +333,7 @@ class DbAttribute:
         return deleted
 
     def __init__(self):
-        if not Attribute.exists():
-            try:
-                Attribute.create_table(wait=True)
-            except Exception as e:
-                # Handle race condition where another process created the table
-                # between our exists() check and create_table() call
-                if "ResourceInUseException" in str(e):
-                    pass  # Table was created by another process, continue
-                else:
-                    raise
+        ensure_table(Attribute)
 
 
 class DbAttributeBucketList:
@@ -398,13 +391,4 @@ class DbAttributeBucketList:
         return True
 
     def __init__(self):
-        if not Attribute.exists():
-            try:
-                Attribute.create_table(wait=True)
-            except Exception as e:
-                # Handle race condition where another process created the table
-                # between our exists() check and create_table() call
-                if "ResourceInUseException" in str(e):
-                    pass  # Table was created by another process, continue
-                else:
-                    raise
+        ensure_table(Attribute)

--- a/actingweb/db/dynamodb/attribute.py
+++ b/actingweb/db/dynamodb/attribute.py
@@ -8,6 +8,7 @@ from pynamodb.attributes import (
     UnicodeAttribute,
     UTCDateTimeAttribute,
 )
+from pynamodb.constants import PAY_PER_REQUEST_BILLING_MODE
 from pynamodb.models import Model
 
 from actingweb.db.dynamodb._ensure import ensure_table
@@ -25,8 +26,7 @@ class Attribute(Model):
 
     class Meta:  # type: ignore[misc]
         table_name = os.getenv("AWS_DB_PREFIX", "demo_actingweb") + "_attributes"
-        read_capacity_units = 26
-        write_capacity_units = 2
+        billing_mode = PAY_PER_REQUEST_BILLING_MODE
         region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
         host = os.getenv("AWS_DB_HOST", None)
 

--- a/actingweb/db/dynamodb/peertrustee.py
+++ b/actingweb/db/dynamodb/peertrustee.py
@@ -48,8 +48,8 @@ class DbPeerTrustee:
                 self.handle = PeerTrustee.get(actor_id, peerid, consistent_read=True)
             elif not self.handle and peer_type:
                 count = 0
-                peer_trustees = PeerTrustee.scan(
-                    (PeerTrustee.id == actor_id) & (PeerTrustee.type == peer_type)
+                peer_trustees = PeerTrustee.query(
+                    actor_id, filter_condition=PeerTrustee.type == peer_type
                 )
                 for h in peer_trustees:
                     self.handle = h
@@ -143,7 +143,7 @@ class DbPeerTrusteeList:
             return None
         self.actor_id = actor_id
         self.peertrustees = []
-        self.handle = PeerTrustee.scan(PeerTrustee.id == self.actor_id)
+        self.handle = PeerTrustee.query(self.actor_id)
         if self.handle:
             for t in self.handle:
                 self.peertrustees.append(
@@ -161,7 +161,9 @@ class DbPeerTrusteeList:
 
     def delete(self):
         """Deletes all the peertrustees in the database"""
-        self.handle = PeerTrustee.scan(PeerTrustee.id == self.actor_id)
+        if not self.actor_id:
+            return False
+        self.handle = PeerTrustee.query(self.actor_id)
         if not self.handle:
             return False
         for p in self.handle:

--- a/actingweb/db/dynamodb/peertrustee.py
+++ b/actingweb/db/dynamodb/peertrustee.py
@@ -4,6 +4,8 @@ import os
 from pynamodb.attributes import UnicodeAttribute
 from pynamodb.models import Model
 
+from actingweb.db.dynamodb._ensure import ensure_table
+
 """
     DbPeerTrustee handles all db operations for a peer we are a trustee for.
     Google datastore for google is used as a backend.
@@ -125,16 +127,7 @@ class DbPeerTrustee:
 
     def __init__(self):
         self.handle = None
-        if not PeerTrustee.exists():
-            try:
-                PeerTrustee.create_table(wait=True)
-            except Exception as e:
-                # Handle race condition where another process created the table
-                # between our exists() check and create_table() call
-                if "ResourceInUseException" in str(e):
-                    pass  # Table was created by another process, continue
-                else:
-                    raise
+        ensure_table(PeerTrustee)
 
 
 class DbPeerTrusteeList:
@@ -180,3 +173,4 @@ class DbPeerTrusteeList:
         self.handle = None
         self.actor_id = None
         self.peertrustees = None
+        ensure_table(PeerTrustee)

--- a/actingweb/db/dynamodb/peertrustee.py
+++ b/actingweb/db/dynamodb/peertrustee.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from pynamodb.attributes import UnicodeAttribute
+from pynamodb.constants import PAY_PER_REQUEST_BILLING_MODE
 from pynamodb.models import Model
 
 from actingweb.db.dynamodb._ensure import ensure_table
@@ -17,8 +18,7 @@ logger = logging.getLogger(__name__)
 class PeerTrustee(Model):
     class Meta:  # type: ignore[misc]
         table_name = os.getenv("AWS_DB_PREFIX", "demo_actingweb") + "_peertrustees"
-        read_capacity_units = 1
-        write_capacity_units = 1
+        billing_mode = PAY_PER_REQUEST_BILLING_MODE
         region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
         host = os.getenv("AWS_DB_HOST", None)
 

--- a/actingweb/db/dynamodb/property.py
+++ b/actingweb/db/dynamodb/property.py
@@ -362,7 +362,7 @@ class DbPropertyList:
         if not actor_id:
             return None
         self.actor_id = actor_id
-        self.handle = Property.scan(Property.id == actor_id)
+        self.handle = Property.query(actor_id)
         if self.handle:
             self.props = {}
             for d in self.handle:
@@ -380,7 +380,7 @@ class DbPropertyList:
         if not actor_id:
             return None
         self.actor_id = actor_id
-        self.handle = Property.scan(Property.id == actor_id)
+        self.handle = Property.query(actor_id)
         if self.handle:
             props = {}
             for d in self.handle:
@@ -399,13 +399,13 @@ class DbPropertyList:
 
         if self._use_lookup_table:
             # Scan properties to find indexed ones
-            self.handle = Property.scan(Property.id == self.actor_id)
+            self.handle = Property.query(self.actor_id)
             for p in self.handle:
                 if str(p.name) in self._indexed_properties:
                     indexed_props.append((str(p.name), str(p.value)))
 
         # Delete all properties
-        self.handle = Property.scan(Property.id == self.actor_id)
+        self.handle = Property.query(self.actor_id)
         if not self.handle:
             return False
 

--- a/actingweb/db/dynamodb/property.py
+++ b/actingweb/db/dynamodb/property.py
@@ -7,6 +7,8 @@ from pynamodb.attributes import UnicodeAttribute
 from pynamodb.indexes import AllProjection, GlobalSecondaryIndex
 from pynamodb.models import Model
 
+from actingweb.db.dynamodb._ensure import ensure_table
+
 logger = logging.getLogger(__name__)
 
 """
@@ -78,16 +80,7 @@ class DbProperty:
             indexed_properties: List of property names to index. If None, uses defaults.
         """
         self.handle: Property | None = None
-        if not Property.exists():
-            try:
-                Property.create_table(wait=True)
-            except Exception as e:
-                # Handle race condition where another process created the table
-                # between our exists() check and create_table() call
-                if "ResourceInUseException" in str(e):
-                    pass  # Table was created by another process, continue
-                else:
-                    raise
+        ensure_table(Property)
 
         # Store configuration for lookup table
         if use_lookup_table is not None:
@@ -362,16 +355,7 @@ class DbPropertyList:
                 env_props = os.getenv("INDEXED_PROPERTIES", "").split(",")
                 self._indexed_properties = [p.strip() for p in env_props if p.strip()]
 
-        if not Property.exists():
-            try:
-                Property.create_table(wait=True)
-            except Exception as e:
-                # Handle race condition where another process created the table
-                # between our exists() check and create_table() call
-                if "ResourceInUseException" in str(e):
-                    pass  # Table was created by another process, continue
-                else:
-                    raise
+        ensure_table(Property)
 
     def fetch(self, actor_id: str | None = None) -> dict[str, str] | None:
         """Retrieves the properties of an actor_id from the database"""

--- a/actingweb/db/dynamodb/property.py
+++ b/actingweb/db/dynamodb/property.py
@@ -392,22 +392,13 @@ class DbPropertyList:
         if not self.actor_id:
             return False
 
-        # Collect indexed properties before deletion
+        # Single partition read: collect indexed properties (for lookup-row
+        # cleanup) and delete in the same pass.
         indexed_props: list[tuple[str, str]] = []
-
-        if self._use_lookup_table:
-            # Scan properties to find indexed ones
-            self.handle = Property.query(self.actor_id)
-            for p in self.handle:
-                if str(p.name) in self._indexed_properties:
-                    indexed_props.append((str(p.name), str(p.value)))
-
-        # Delete all properties
         self.handle = Property.query(self.actor_id)
-        if not self.handle:
-            return False
-
         for p in self.handle:
+            if self._use_lookup_table and str(p.name) in self._indexed_properties:
+                indexed_props.append((str(p.name), str(p.value)))
             p.delete()
 
         # Delete lookup entries

--- a/actingweb/db/dynamodb/property.py
+++ b/actingweb/db/dynamodb/property.py
@@ -116,7 +116,7 @@ class DbProperty:
             self._use_lookup_table = use_lookup_table
         else:
             self._use_lookup_table = (
-                os.getenv("USE_PROPERTY_LOOKUP_TABLE", "").lower() == "true"
+                os.getenv("USE_PROPERTY_LOOKUP_TABLE", "true").lower() == "true"
             )
 
         if indexed_properties is not None:
@@ -194,6 +194,39 @@ class DbProperty:
 
             lookup = DbPropertyLookup()
             actor_id = lookup.get(property_name=name, value=value)
+
+            if actor_id is None:
+                # Migration fallback tier 1: the deprecated v1 lookup table
+                # (deployments that adopted lookup mode before the v2 digest
+                # format). A hit means the v2 backfill has not run yet.
+                actor_id = lookup.get_v1(property_name=name, value=value)
+                if actor_id:
+                    logger.warning(
+                        f"DEPRECATED: reverse lookup for '{name}' served from "
+                        f"the v1 lookup table — run "
+                        f"scripts/backfill_property_lookup.py to migrate to "
+                        f"the v2 format, then drop the v1 table. This "
+                        f"fallback is removed in the next major release."
+                    )
+
+            if actor_id is None:
+                # Migration fallback tier 2: the legacy value-keyed GSI
+                # (deployments upgrading from legacy mode with an un-backfilled
+                # lookup table). Missing index/table is a normal state.
+                try:
+                    for res in PropertyLegacy.property_index.query(value):
+                        actor_id = str(res.id) if res.id else None
+                        break
+                except Exception:
+                    actor_id = None
+                if actor_id:
+                    logger.warning(
+                        f"DEPRECATED: reverse lookup for '{name}' served from "
+                        f"the legacy property-index GSI — run "
+                        f"scripts/backfill_property_lookup.py to populate the "
+                        f"lookup table. This fallback is removed in the next "
+                        f"major release."
+                    )
 
             if actor_id:
                 # Load the property into self.handle for subsequent operations
@@ -399,7 +432,7 @@ class DbPropertyList:
             self._use_lookup_table = use_lookup_table
         else:
             self._use_lookup_table = (
-                os.getenv("USE_PROPERTY_LOOKUP_TABLE", "").lower() == "true"
+                os.getenv("USE_PROPERTY_LOOKUP_TABLE", "true").lower() == "true"
             )
 
         if indexed_properties is not None:

--- a/actingweb/db/dynamodb/property.py
+++ b/actingweb/db/dynamodb/property.py
@@ -4,6 +4,7 @@ import os
 from typing import Any
 
 from pynamodb.attributes import UnicodeAttribute
+from pynamodb.constants import PAY_PER_REQUEST_BILLING_MODE
 from pynamodb.indexes import AllProjection, GlobalSecondaryIndex
 from pynamodb.models import Model
 
@@ -24,8 +25,6 @@ class PropertyIndex(GlobalSecondaryIndex[Any]):
 
     class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         index_name = "property-index"
-        read_capacity_units = 2
-        write_capacity_units = 1
         projection = AllProjection()
 
     value = UnicodeAttribute(default="0", hash_key=True)
@@ -38,8 +37,7 @@ class Property(Model):
 
     class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         table_name = os.getenv("AWS_DB_PREFIX", "demo_actingweb") + "_properties"
-        read_capacity_units = 26
-        write_capacity_units = 2
+        billing_mode = PAY_PER_REQUEST_BILLING_MODE
         region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
         host = os.getenv("AWS_DB_HOST", None)
         # Optional PynamoDB configuration attributes

--- a/actingweb/db/dynamodb/property.py
+++ b/actingweb/db/dynamodb/property.py
@@ -140,8 +140,21 @@ class DbProperty:
         if not name or not value:
             return None
 
-        if self._use_lookup_table and name in self._indexed_properties:
-            # Use new lookup table approach
+        if self._use_lookup_table:
+            if name not in self._indexed_properties:
+                # Enforce the documented contract: only properties configured
+                # via with_indexed_properties() support reverse lookup. The
+                # old behaviour silently fell through to the legacy GSI,
+                # which crashes on tables created without that index.
+                logger.warning(
+                    f"Reverse lookup requested for non-indexed property "
+                    f"'{name}' — add it to with_indexed_properties() (or "
+                    f"INDEXED_PROPERTIES) to enable reverse lookup; "
+                    f"returning None"
+                )
+                return None
+
+            # Use lookup table approach
             from actingweb.db.dynamodb.property_lookup import DbPropertyLookup
 
             lookup = DbPropertyLookup()
@@ -159,12 +172,34 @@ class DbProperty:
 
             return actor_id
         else:
-            # Fall back to legacy GSI approach
-            results = Property.property_index.query(value)
-            self.handle = None
-            for res in results:
-                self.handle = res
-                break
+            # Legacy GSI approach (deprecated)
+            try:
+                results = Property.property_index.query(value)
+                self.handle = None
+                for res in results:
+                    self.handle = res
+                    break
+            except Exception as e:
+                if "index" in str(e).lower() or "ValidationException" in str(e):
+                    raise RuntimeError(
+                        f"Legacy property-index GSI is missing from table "
+                        f"'{Property.Meta.table_name}'. Reverse lookup is "
+                        f"configured to use the legacy DynamoDB GSI "
+                        f"(use_lookup_table=False), but this table has no "
+                        f"'property-index' GSI — it was created without one, "
+                        f"and the library cannot add a GSI to a live table. "
+                        f"Three ways to resolve: "
+                        f"(1) RECOMMENDED: switch to lookup-table mode with "
+                        f"with_legacy_property_index(enable=False) and run "
+                        f"scripts/backfill_property_lookup.py; "
+                        f"(2) keep legacy mode and add the GSI to the live "
+                        f"table via 'aws dynamodb update-table' — note this "
+                        f"imposes a 2048-byte limit on ALL property values; "
+                        f"(3) disable reverse lookup entirely with "
+                        f"with_indexed_properties([]). "
+                        f"See docs/migration/v3.13 for details."
+                    ) from e
+                raise
 
             if not self.handle:
                 return None
@@ -234,32 +269,25 @@ class DbProperty:
 
         Best-effort update - logs errors but doesn't fail property write.
         """
+        # Unchanged value: nothing to sync — avoids a delete+put per
+        # repeated write of the same indexed value.
+        if old_value is not None and old_value == new_value:
+            return
         try:
-            from actingweb.db.dynamodb.property_lookup import (
-                DbPropertyLookup,
-                PropertyLookup,
-            )
+            from actingweb.db.dynamodb.property_lookup import DbPropertyLookup
 
-            # Ensure table exists
-            DbPropertyLookup()
+            db = DbPropertyLookup()
 
-            # Delete old lookup entry if exists
-            # Note: Theoretical race condition if another actor creates same value
-            # between get() and delete(), but best-effort design accepts this edge case
-            if old_value and old_value != new_value:
-                try:
-                    lookup = PropertyLookup.get(name, old_value)
-                    if str(lookup.actor_id) == actor_id:  # Verify it's ours
-                        lookup.delete()
-                except Exception:
-                    pass  # Entry doesn't exist or already deleted
+            # Delete the old entry if it exists and belongs to this actor.
+            # Note: theoretical race if another actor creates the same value
+            # between get() and delete(); best-effort design accepts this.
+            if old_value:
+                if db.get(property_name=name, value=old_value) == actor_id:
+                    db.delete()
 
-            # Create new lookup entry (skip if value unchanged)
-            if not old_value or old_value != new_value:
-                lookup = PropertyLookup(
-                    property_name=name, value=new_value, actor_id=actor_id
-                )
-                lookup.save()
+            # Conditional create: a row owned by another actor is a logged
+            # collision, not a silent overwrite (see DbPropertyLookup.create).
+            db.create(property_name=name, value=new_value, actor_id=actor_id)
 
         except Exception as e:
             logger.error(
@@ -276,18 +304,12 @@ class DbProperty:
         Best-effort deletion - logs errors but doesn't fail property delete.
         """
         try:
-            from actingweb.db.dynamodb.property_lookup import (
-                DbPropertyLookup,
-                PropertyLookup,
-            )
+            from actingweb.db.dynamodb.property_lookup import DbPropertyLookup
 
-            # Ensure table exists
-            DbPropertyLookup()
-
-            lookup = PropertyLookup.get(name, value)
+            db = DbPropertyLookup()
             # Verify it belongs to the same actor before deleting
-            if str(lookup.actor_id) == actor_id:
-                lookup.delete()
+            if db.get(property_name=name, value=value) == actor_id:
+                db.delete()
         except Exception as e:
             logger.warning(
                 f"LOOKUP_DELETE_FAILED: actor={actor_id} property={name} "
@@ -403,23 +425,16 @@ class DbPropertyList:
 
         # Delete lookup entries
         if indexed_props:
-            from actingweb.db.dynamodb.property_lookup import (
-                DbPropertyLookup,
-                PropertyLookup,
-            )
+            from actingweb.db.dynamodb.property_lookup import DbPropertyLookup
 
-            # Ensure table exists
-            DbPropertyLookup()
-
+            db = DbPropertyLookup()
             for name, value in indexed_props:
                 try:
-                    lookup = PropertyLookup.get(name, value)
-                    # Verify it belongs to this actor before deleting. In
-                    # DynamoDB a shared indexed value is overwritten by the
-                    # latest writer, so deleting an older actor must not remove
-                    # a newer actor's reverse-lookup row.
-                    if str(lookup.actor_id) == self.actor_id:
-                        lookup.delete()
+                    # Verify ownership before deleting: a shared indexed value
+                    # may map to another actor's row, which must survive this
+                    # actor's deletion.
+                    if db.get(property_name=name, value=value) == self.actor_id:
+                        db.delete()
                 except Exception as e:
                     logger.warning(
                         f"Failed to delete lookup entry for property {name}: {e}"

--- a/actingweb/db/dynamodb/property.py
+++ b/actingweb/db/dynamodb/property.py
@@ -32,7 +32,15 @@ class PropertyIndex(GlobalSecondaryIndex[Any]):
 
 class Property(Model):
     """
-    DynamoDB data model for a property
+    DynamoDB data model for a property.
+
+    Deliberately declares NO global secondary index: in lookup-table mode
+    (the reverse-lookup mechanism of record) the legacy value-keyed GSI
+    would only add write/storage amplification and DynamoDB's 2048-byte
+    GSI-key limit on every property value. Tables created through this
+    class therefore have no GSI. Legacy-mode deployments create the table
+    through :class:`PropertyLegacy` instead — the schema a deployment
+    creates matches the code path its configuration selects.
     """
 
     class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
@@ -49,6 +57,29 @@ class Property(Model):
         aws_access_key_id: str | None = None
         aws_secret_access_key: str | None = None
         aws_session_token: str | None = None
+
+    id = UnicodeAttribute(hash_key=True)
+    name = UnicodeAttribute(range_key=True)
+    value = UnicodeAttribute()
+
+
+class PropertyLegacy(Model):
+    """Legacy schema variant of the SAME properties table (deprecated).
+
+    Identical item shape to :class:`Property` plus the value-keyed
+    ``property-index`` GSI. Used only (a) to create the table when the
+    deployment runs in legacy reverse-lookup mode, and (b) to query the
+    GSI on the legacy reverse-lookup path. All regular data-plane
+    operations go through :class:`Property` — the two classes are
+    item-compatible. Removed in the next major release together with the
+    legacy path.
+    """
+
+    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+        table_name = os.getenv("AWS_DB_PREFIX", "demo_actingweb") + "_properties"
+        billing_mode = PAY_PER_REQUEST_BILLING_MODE
+        region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
+        host = os.getenv("AWS_DB_HOST", None)
 
     id = UnicodeAttribute(hash_key=True)
     name = UnicodeAttribute(range_key=True)
@@ -77,10 +108,10 @@ class DbProperty:
             use_lookup_table: Whether to use property lookup table. If None, reads from env.
             indexed_properties: List of property names to index. If None, uses defaults.
         """
-        self.handle: Property | None = None
-        ensure_table(Property)
+        self.handle: Property | PropertyLegacy | None = None
 
-        # Store configuration for lookup table
+        # Store configuration for lookup table (resolved before table
+        # creation — the mode decides which schema a fresh table gets)
         if use_lookup_table is not None:
             self._use_lookup_table = use_lookup_table
         else:
@@ -95,6 +126,10 @@ class DbProperty:
             if os.getenv("INDEXED_PROPERTIES"):
                 env_props = os.getenv("INDEXED_PROPERTIES", "").split(",")
                 self._indexed_properties = [p.strip() for p in env_props if p.strip()]
+
+        # Lookup mode creates the table WITHOUT the legacy GSI; legacy mode
+        # keeps it. Existing tables are never altered — first creator wins.
+        ensure_table(Property if self._use_lookup_table else PropertyLegacy)
 
     def _should_index_property(self, name: str) -> bool:
         """
@@ -174,7 +209,7 @@ class DbProperty:
         else:
             # Legacy GSI approach (deprecated)
             try:
-                results = Property.property_index.query(value)
+                results = PropertyLegacy.property_index.query(value)
                 self.handle = None
                 for res in results:
                     self.handle = res
@@ -375,7 +410,9 @@ class DbPropertyList:
                 env_props = os.getenv("INDEXED_PROPERTIES", "").split(",")
                 self._indexed_properties = [p.strip() for p in env_props if p.strip()]
 
-        ensure_table(Property)
+        # Lookup mode creates the table WITHOUT the legacy GSI; legacy mode
+        # keeps it. Existing tables are never altered — first creator wins.
+        ensure_table(Property if self._use_lookup_table else PropertyLegacy)
 
     def fetch(self, actor_id: str | None = None) -> dict[str, str] | None:
         """Retrieves the properties of an actor_id from the database"""

--- a/actingweb/db/dynamodb/property.py
+++ b/actingweb/db/dynamodb/property.py
@@ -214,7 +214,12 @@ class DbProperty:
                 # (deployments upgrading from legacy mode with an un-backfilled
                 # lookup table). Missing index/table is a normal state.
                 try:
-                    for res in PropertyLegacy.property_index.query(value):
+                    # The GSI is keyed on value alone; filter by name so a
+                    # same-value/different-property row on another actor
+                    # can't hijack the lookup.
+                    for res in PropertyLegacy.property_index.query(
+                        value, filter_condition=PropertyLegacy.name == name
+                    ):
                         actor_id = str(res.id) if res.id else None
                         break
                 except Exception:
@@ -309,6 +314,13 @@ class DbProperty:
         if self._should_index_property(name):
             if self.handle and self.handle.value:
                 old_value = str(self.handle.value)
+            elif actor_id:
+                # PropertyStore.__setattr__ builds a fresh DbProperty for
+                # every write, so self.handle is unset on the primary public
+                # path. Read the current stored value (like the PostgreSQL
+                # backend) so changing an indexed value deletes its stale
+                # lookup row instead of leaving it to resolve forever.
+                old_value = self.get(actor_id=actor_id, name=name)
 
         # Save property
         if not self.handle:

--- a/actingweb/db/dynamodb/property_lookup.py
+++ b/actingweb/db/dynamodb/property_lookup.py
@@ -5,6 +5,8 @@ import os
 from pynamodb.attributes import UnicodeAttribute
 from pynamodb.models import Model
 
+from actingweb.db.dynamodb._ensure import ensure_table
+
 logger = logging.getLogger(__name__)
 
 """
@@ -54,16 +56,7 @@ class DbPropertyLookup:
 
     def __init__(self) -> None:
         self.handle: PropertyLookup | None = None
-        if not PropertyLookup.exists():
-            try:
-                PropertyLookup.create_table(wait=True)
-            except Exception as e:
-                # Handle race condition where another process created the table
-                # between our exists() check and create_table() call
-                if "ResourceInUseException" in str(e):
-                    pass  # Table was created by another process, continue
-                else:
-                    raise
+        ensure_table(PropertyLookup)
 
     def get(
         self, property_name: str | None = None, value: str | None = None

--- a/actingweb/db/dynamodb/property_lookup.py
+++ b/actingweb/db/dynamodb/property_lookup.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from pynamodb.attributes import UnicodeAttribute
+from pynamodb.constants import PAY_PER_REQUEST_BILLING_MODE
 from pynamodb.models import Model
 
 from actingweb.db.dynamodb._ensure import ensure_table
@@ -26,8 +27,7 @@ class PropertyLookup(Model):
 
     class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
         table_name = os.getenv("AWS_DB_PREFIX", "demo_actingweb") + "_property_lookup"
-        read_capacity_units = 2
-        write_capacity_units = 1
+        billing_mode = PAY_PER_REQUEST_BILLING_MODE
         region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
         host = os.getenv("AWS_DB_HOST", None)
         # Optional PynamoDB configuration attributes

--- a/actingweb/db/dynamodb/property_lookup.py
+++ b/actingweb/db/dynamodb/property_lookup.py
@@ -1,28 +1,80 @@
 # mypy: disable-error-code="override"
+"""
+Reverse-lookup table for indexed properties (value -> actor_id).
+
+v2 key design (current): a single hash key ``lookup_key`` holding the hex
+SHA-256 digest of the canonical (property_name, value) encoding — see
+:func:`compute_lookup_key`. This is a **permanent data format**:
+
+    lookup_key = sha256(property_name + "\\x00" + value).hexdigest()
+
+The NUL separator makes the encoding unambiguous for any property name.
+The value is hashed verbatim as stored (no normalisation, no lowercasing)
+and is **never stored** in the table — only ``actor_id`` and
+``property_name`` are kept as attributes (needed for stale-row
+verification tooling; not PII).
+
+Why digests instead of the v1 ``(property_name, value)`` composite key:
+
+- uniform partition distribution — v1 put every email under the single
+  partition key ``"email"`` (per-partition throughput ceiling on login
+  bursts);
+- no value-size limit — v1's range key capped values at 1024 bytes while
+  claiming to remove the GSI's 2048-byte limit;
+- no plaintext PII in key material (note: this is pseudonymisation, not
+  anonymisation — and the properties table itself still stores values);
+- conditional puts turn silent cross-actor overwrites into detectable,
+  logged collisions.
+
+The v1 model below is retained read-only for the migration fallback and
+is never auto-created. Migration: run scripts/backfill_property_lookup.py
+(rebuilds v2 from the properties table — the source of truth), verify,
+then drop the v1 table.
+"""
+
+import hashlib
 import logging
 import os
 
 from pynamodb.attributes import UnicodeAttribute
 from pynamodb.constants import PAY_PER_REQUEST_BILLING_MODE
+from pynamodb.exceptions import DoesNotExist, PutError
 from pynamodb.models import Model
 
 from actingweb.db.dynamodb._ensure import ensure_table
 
 logger = logging.getLogger(__name__)
 
-"""
-    DbPropertyLookup handles all db operations for property lookup table
-    AWS DynamoDB is used as a backend.
-"""
+
+def compute_lookup_key(property_name: str, value: str) -> str:
+    """Compute the v2 lookup key: hex SHA-256 of ``name + NUL + value``.
+
+    Permanent data format — changing this orphans every stored lookup row.
+    """
+    return hashlib.sha256(f"{property_name}\x00{value}".encode()).hexdigest()
+
+
+class PropertyLookupV2(Model):
+    """v2 lookup row: digest hash key, actor/property attributes only."""
+
+    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+        table_name = (
+            os.getenv("AWS_DB_PREFIX", "demo_actingweb") + "_property_lookup_v2"
+        )
+        billing_mode = PAY_PER_REQUEST_BILLING_MODE
+        region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
+        host = os.getenv("AWS_DB_HOST", None)
+
+    lookup_key = UnicodeAttribute(hash_key=True)
+    actor_id = UnicodeAttribute()
+    property_name = UnicodeAttribute()
 
 
 class PropertyLookup(Model):
-    """
-    DynamoDB data model for property lookup table.
+    """DEPRECATED v1 lookup row — read-only migration fallback.
 
-    Replaces GSI on Property.value to avoid 2048-byte limit.
-    Key design: (property_name, value) enables efficient lookups and
-    distributes load across property name partitions.
+    Never auto-created; a missing table is a normal state handled by the
+    fallback read path. Removed (with the table) in the next major release.
     """
 
     class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
@@ -30,33 +82,29 @@ class PropertyLookup(Model):
         billing_mode = PAY_PER_REQUEST_BILLING_MODE
         region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
         host = os.getenv("AWS_DB_HOST", None)
-        # Optional PynamoDB configuration attributes
-        connect_timeout_seconds: int | None = None
-        read_timeout_seconds: int | None = None
-        max_retry_attempts: int | None = None
-        max_pool_connections: int | None = None
-        extra_headers: dict[str, str] | None = None
-        aws_access_key_id: str | None = None
-        aws_secret_access_key: str | None = None
-        aws_session_token: str | None = None
 
-    # Composite primary key: property_name (hash) + value (range)
     property_name = UnicodeAttribute(hash_key=True)
     value = UnicodeAttribute(range_key=True)
     actor_id = UnicodeAttribute()
 
 
+def _digest_prefix(property_name: str, value: str) -> str:
+    """Short digest prefix for log correlation — never log the value."""
+    return compute_lookup_key(property_name, value)[:12]
+
+
 class DbPropertyLookup:
     """
-    DbPropertyLookup handles all db operations for property lookup table.
+    DbPropertyLookup handles all db operations for the property lookup table.
 
-    This table enables reverse lookups (property value → actor_id) without
-    DynamoDB's 2048-byte GSI key size limit.
+    Enables reverse lookups (property value -> actor_id) without any
+    value-size limit. All operations recompute the digest from the caller's
+    (property_name, value), so the plaintext value never touches the table.
     """
 
     def __init__(self) -> None:
-        self.handle: PropertyLookup | None = None
-        ensure_table(PropertyLookup)
+        self.handle: PropertyLookupV2 | None = None
+        ensure_table(PropertyLookupV2)
 
     def get(
         self, property_name: str | None = None, value: str | None = None
@@ -66,7 +114,7 @@ class DbPropertyLookup:
 
         Args:
             property_name: Property name (e.g., "oauthId")
-            value: Property value to lookup
+            value: Property value to lookup (exact match, verbatim)
 
         Returns:
             Actor ID if found, None otherwise
@@ -75,9 +123,35 @@ class DbPropertyLookup:
             return None
 
         try:
-            self.handle = PropertyLookup.get(property_name, value, consistent_read=True)
+            self.handle = PropertyLookupV2.get(
+                compute_lookup_key(property_name, value), consistent_read=True
+            )
             return str(self.handle.actor_id) if self.handle.actor_id else None
-        except Exception:  # PynamoDB DoesNotExist exception
+        except DoesNotExist:
+            return None
+        except Exception as e:
+            logger.error(
+                f"LOOKUP_GET_FAILED: property={property_name} "
+                f"digest={_digest_prefix(property_name, value)} error={e}"
+            )
+            return None
+
+    def get_v1(
+        self, property_name: str | None = None, value: str | None = None
+    ) -> str | None:
+        """Read-only fallback against the deprecated v1 table.
+
+        Returns None when the v1 table does not exist (normal for fresh
+        deployments) or holds no row. A hit means the deployment has not
+        run the v2 backfill yet.
+        """
+        if not property_name or not value:
+            return None
+        try:
+            row = PropertyLookup.get(property_name, value, consistent_read=True)
+            return str(row.actor_id) if row.actor_id else None
+        except Exception:
+            # DoesNotExist and missing-table errors alike mean "no v1 answer"
             return None
 
     def create(
@@ -85,41 +159,97 @@ class DbPropertyLookup:
         property_name: str | None = None,
         value: str | None = None,
         actor_id: str | None = None,
+        overwrite: bool = False,
     ) -> bool:
         """
-        Create lookup entry.
+        Create a lookup entry.
 
-        Args:
-            property_name: Property name
-            value: Property value
-            actor_id: Actor ID
+        Uses a conditional put: an existing row for the same (name, value)
+        owned by a DIFFERENT actor is a collision — logged loudly, not
+        silently overwritten (pass overwrite=True for legitimate value
+        moves). Re-creating an identical row is idempotent.
 
         Returns:
-            True on success, False on failure
+            True on success (including idempotent re-create), False on
+            collision or write failure.
         """
         if not property_name or not value or not actor_id:
             return False
 
+        key = compute_lookup_key(property_name, value)
+        row = PropertyLookupV2(
+            lookup_key=key,
+            actor_id=actor_id,
+            property_name=property_name,
+        )
         try:
-            self.handle = PropertyLookup(
-                property_name=property_name,
-                value=value,
-                actor_id=actor_id,
-            )
-            self.handle.save()
+            if overwrite:
+                row.save()
+            else:
+                row.save(condition=PropertyLookupV2.lookup_key.does_not_exist())
+            self.handle = row
             return True
+        except PutError as e:
+            if "ConditionalCheckFailed" in str(e):
+                try:
+                    existing = PropertyLookupV2.get(key, consistent_read=True)
+                except Exception:
+                    existing = None
+                if existing is not None and str(existing.actor_id) == actor_id:
+                    # Idempotent re-create of the same mapping
+                    self.handle = existing
+                    return True
+                logger.error(
+                    f"LOOKUP_COLLISION: property={property_name} "
+                    f"digest={key[:12]} actor={actor_id} "
+                    f"existing_actor={existing.actor_id if existing else 'unknown'} — "
+                    "two actors share an indexed value; not overwriting"
+                )
+                return False
+            logger.error(
+                f"LOOKUP_CREATE_FAILED: property={property_name} "
+                f"digest={key[:12]} actor={actor_id} error={e}"
+            )
+            return False
         except Exception as e:
             logger.error(
-                f"LOOKUP_CREATE_FAILED: property={property_name} value_len={len(value)} "
-                f"actor={actor_id} error={e}"
+                f"LOOKUP_CREATE_FAILED: property={property_name} "
+                f"digest={key[:12]} actor={actor_id} error={e}"
             )
             return False
 
-    def delete(self) -> bool:
-        """Delete lookup entry after get()."""
+    def delete(
+        self, property_name: str | None = None, value: str | None = None
+    ) -> bool:
+        """Delete the lookup entry for (property_name, value).
+
+        Can be called directly with the pair, or with no arguments after a
+        get() (which leaves self.handle set).
+        """
+        if property_name and value:
+            key = compute_lookup_key(property_name, value)
+            try:
+                row = PropertyLookupV2.get(key, consistent_read=True)
+            except DoesNotExist:
+                return False
+            except Exception as e:
+                logger.error(
+                    f"LOOKUP_DELETE_FAILED: property={property_name} "
+                    f"digest={key[:12]} error={e}"
+                )
+                return False
+            try:
+                row.delete()
+                return True
+            except Exception as e:
+                logger.error(
+                    f"LOOKUP_DELETE_FAILED: property={property_name} "
+                    f"digest={key[:12]} error={e}"
+                )
+                return False
+
         if not self.handle:
             return False
-
         try:
             self.handle.delete()
             self.handle = None

--- a/actingweb/db/dynamodb/subscription.py
+++ b/actingweb/db/dynamodb/subscription.py
@@ -2,6 +2,7 @@ import logging
 import os
 
 from pynamodb.attributes import BooleanAttribute, NumberAttribute, UnicodeAttribute
+from pynamodb.constants import PAY_PER_REQUEST_BILLING_MODE
 from pynamodb.models import Model
 
 from actingweb.db.dynamodb._ensure import ensure_table
@@ -19,8 +20,7 @@ logger = logging.getLogger(__name__)
 class Subscription(Model):
     class Meta:  # type: ignore[misc]
         table_name = os.getenv("AWS_DB_PREFIX", "demo_actingweb") + "_subscriptions"
-        read_capacity_units = 2
-        write_capacity_units = 1
+        billing_mode = PAY_PER_REQUEST_BILLING_MODE
         region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
         host = os.getenv("AWS_DB_HOST", None)
 

--- a/actingweb/db/dynamodb/subscription.py
+++ b/actingweb/db/dynamodb/subscription.py
@@ -4,6 +4,8 @@ import os
 from pynamodb.attributes import BooleanAttribute, NumberAttribute, UnicodeAttribute
 from pynamodb.models import Model
 
+from actingweb.db.dynamodb._ensure import ensure_table
+
 """
     DbSubscription handles all db operations for a subscription
 
@@ -154,16 +156,7 @@ class DbSubscription:
 
     def __init__(self):
         self.handle = None
-        if not Subscription.exists():
-            try:
-                Subscription.create_table(wait=True)
-            except Exception as e:
-                # Handle race condition where another process created the table
-                # between our exists() check and create_table() call
-                if "ResourceInUseException" in str(e):
-                    pass  # Table was created by another process, continue
-                else:
-                    raise
+        ensure_table(Subscription)
 
 
 class DbSubscriptionList:
@@ -215,13 +208,4 @@ class DbSubscriptionList:
         self.handle = None
         self.actor_id = None
         self.subscriptions = []
-        if not Subscription.exists():
-            try:
-                Subscription.create_table(wait=True)
-            except Exception as e:
-                # Handle race condition where another process created the table
-                # between our exists() check and create_table() call
-                if "ResourceInUseException" in str(e):
-                    pass  # Table was created by another process, continue
-                else:
-                    raise
+        ensure_table(Subscription)

--- a/actingweb/db/dynamodb/subscription_diff.py
+++ b/actingweb/db/dynamodb/subscription_diff.py
@@ -3,6 +3,7 @@ import logging
 import os
 
 from pynamodb.attributes import NumberAttribute, UnicodeAttribute, UTCDateTimeAttribute
+from pynamodb.constants import PAY_PER_REQUEST_BILLING_MODE
 from pynamodb.models import Model
 
 from actingweb.db.dynamodb._ensure import ensure_table
@@ -20,8 +21,7 @@ logger = logging.getLogger(__name__)
 class SubscriptionDiff(Model):
     class Meta:  # type: ignore[misc]
         table_name = os.getenv("AWS_DB_PREFIX", "demo_actingweb") + "_subscriptiondiffs"
-        read_capacity_units = 2
-        write_capacity_units = 3
+        billing_mode = PAY_PER_REQUEST_BILLING_MODE
         region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
         host = os.getenv("AWS_DB_HOST", None)
 

--- a/actingweb/db/dynamodb/subscription_diff.py
+++ b/actingweb/db/dynamodb/subscription_diff.py
@@ -5,6 +5,8 @@ import os
 from pynamodb.attributes import NumberAttribute, UnicodeAttribute, UTCDateTimeAttribute
 from pynamodb.models import Model
 
+from actingweb.db.dynamodb._ensure import ensure_table
+
 """
     DbSubscriptionDiff handles all db operations for a subscription diff
 
@@ -100,16 +102,7 @@ class DbSubscriptionDiff:
 
     def __init__(self):
         self.handle = None
-        if not SubscriptionDiff.exists():
-            try:
-                SubscriptionDiff.create_table(wait=True)
-            except Exception as e:
-                # Handle race condition where another process created the table
-                # between our exists() check and create_table() call
-                if "ResourceInUseException" in str(e):
-                    pass  # Table was created by another process, continue
-                else:
-                    raise
+        ensure_table(SubscriptionDiff)
 
 
 class DbSubscriptionDiffList:
@@ -168,13 +161,4 @@ class DbSubscriptionDiffList:
         self.diffs = []
         self.actor_id = None
         self.subid = None
-        if not SubscriptionDiff.exists():
-            try:
-                SubscriptionDiff.create_table(wait=True)
-            except Exception as e:
-                # Handle race condition where another process created the table
-                # between our exists() check and create_table() call
-                if "ResourceInUseException" in str(e):
-                    pass  # Table was created by another process, continue
-                else:
-                    raise
+        ensure_table(SubscriptionDiff)

--- a/actingweb/db/dynamodb/subscription_suspension.py
+++ b/actingweb/db/dynamodb/subscription_suspension.py
@@ -10,6 +10,7 @@ import os
 from datetime import UTC, datetime
 
 from pynamodb.attributes import UnicodeAttribute, UTCDateTimeAttribute
+from pynamodb.constants import PAY_PER_REQUEST_BILLING_MODE
 from pynamodb.exceptions import DoesNotExist
 from pynamodb.models import Model
 
@@ -25,8 +26,7 @@ class SubscriptionSuspension(Model):
         table_name = (
             os.getenv("AWS_DB_PREFIX", "demo_actingweb") + "_subscription_suspensions"
         )
-        read_capacity_units = 2
-        write_capacity_units = 1
+        billing_mode = PAY_PER_REQUEST_BILLING_MODE
         region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
         host = os.getenv("AWS_DB_HOST", None)
 

--- a/actingweb/db/dynamodb/subscription_suspension.py
+++ b/actingweb/db/dynamodb/subscription_suspension.py
@@ -13,6 +13,8 @@ from pynamodb.attributes import UnicodeAttribute, UTCDateTimeAttribute
 from pynamodb.exceptions import DoesNotExist
 from pynamodb.models import Model
 
+from actingweb.db.dynamodb._ensure import ensure_table
+
 logger = logging.getLogger(__name__)
 
 
@@ -47,6 +49,7 @@ class DbSubscriptionSuspension:
 
     def __init__(self, actor_id: str) -> None:
         self._actor_id = actor_id
+        ensure_table(SubscriptionSuspension)
 
     def is_suspended(self, target: str, subtarget: str | None = None) -> bool:
         """Check if a target/subtarget is currently suspended."""

--- a/actingweb/db/dynamodb/trust.py
+++ b/actingweb/db/dynamodb/trust.py
@@ -6,6 +6,7 @@ from pynamodb.attributes import BooleanAttribute, UnicodeAttribute, UTCDateTimeA
 from pynamodb.indexes import AllProjection, GlobalSecondaryIndex
 from pynamodb.models import Model
 
+from actingweb.db.dynamodb._ensure import ensure_table
 from actingweb.db.utils import ensure_timezone_aware_iso
 from actingweb.trust import canonical_connection_method
 
@@ -428,16 +429,7 @@ class DbTrust:
 
     def __init__(self):
         self.handle = None
-        if not Trust.exists():
-            try:
-                Trust.create_table(wait=True)
-            except Exception as e:
-                # Handle race condition where another process created the table
-                # between our exists() check and create_table() call
-                if "ResourceInUseException" in str(e):
-                    pass  # Table was created by another process, continue
-                else:
-                    raise
+        ensure_table(Trust)
 
 
 class DbTrustList:
@@ -530,13 +522,4 @@ class DbTrustList:
         self.handle = None
         self.actor_id = None
         self.trusts = []
-        if not Trust.exists():
-            try:
-                Trust.create_table(wait=True)
-            except Exception as e:
-                # Handle race condition where another process created the table
-                # between our exists() check and create_table() call
-                if "ResourceInUseException" in str(e):
-                    pass  # Table was created by another process, continue
-                else:
-                    raise
+        ensure_table(Trust)

--- a/actingweb/db/dynamodb/trust.py
+++ b/actingweb/db/dynamodb/trust.py
@@ -444,7 +444,7 @@ class DbTrustList:
         if not actor_id:
             return None
         self.actor_id = actor_id
-        self.handle = Trust.scan(Trust.id == self.actor_id, consistent_read=True)
+        self.handle = Trust.query(self.actor_id, consistent_read=True)
         self.trusts = []
         if self.handle:
             for t in self.handle:
@@ -509,8 +509,10 @@ class DbTrustList:
             return []
 
     def delete(self):
-        """Deletes all the properties in the database"""
-        self.handle = Trust.scan(Trust.id == self.actor_id, consistent_read=True)
+        """Deletes all the trusts in the database"""
+        if not self.actor_id:
+            return False
+        self.handle = Trust.query(self.actor_id, consistent_read=True)
         if not self.handle:
             return False
         for p in self.handle:

--- a/actingweb/db/dynamodb/trust.py
+++ b/actingweb/db/dynamodb/trust.py
@@ -3,6 +3,7 @@ import os
 from datetime import datetime
 
 from pynamodb.attributes import BooleanAttribute, UnicodeAttribute, UTCDateTimeAttribute
+from pynamodb.constants import PAY_PER_REQUEST_BILLING_MODE
 from pynamodb.indexes import AllProjection, GlobalSecondaryIndex
 from pynamodb.models import Model
 
@@ -54,8 +55,6 @@ class SecretIndex(GlobalSecondaryIndex):
 
     class Meta:
         index_name = "secret-index"
-        read_capacity_units = 2
-        write_capacity_units = 1
         projection = AllProjection()
 
     secret = UnicodeAttribute(hash_key=True)
@@ -66,8 +65,7 @@ class Trust(Model):
 
     class Meta:  # type: ignore[misc]
         table_name = os.getenv("AWS_DB_PREFIX", "demo_actingweb") + "_trusts"
-        read_capacity_units = 5
-        write_capacity_units = 2
+        billing_mode = PAY_PER_REQUEST_BILLING_MODE
         region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
         host = os.getenv("AWS_DB_HOST", None)
 

--- a/actingweb/db/postgresql/property.py
+++ b/actingweb/db/postgresql/property.py
@@ -149,10 +149,10 @@ class DbProperty:
                             cur.execute(
                                 """
                                 SELECT id FROM properties
-                                WHERE value = %s
+                                WHERE name = %s AND value = %s
                                 LIMIT 1
                                 """,
-                                (value,),
+                                (name, value),
                             )
                             row = cur.fetchone()
                             if row:

--- a/actingweb/db/postgresql/property.py
+++ b/actingweb/db/postgresql/property.py
@@ -118,6 +118,19 @@ class DbProperty:
         if not name or not value:
             return None
 
+        if self._use_lookup_table and name not in self._indexed_properties:
+            # Same contract as the DynamoDB backend: only properties
+            # configured via with_indexed_properties() support reverse
+            # lookup in lookup-table mode. The old behaviour silently fell
+            # through to an unindexed full-table sequential scan.
+            logger.warning(
+                f"Reverse lookup requested for non-indexed property "
+                f"'{name}' — add it to with_indexed_properties() (or "
+                f"INDEXED_PROPERTIES) to enable reverse lookup; "
+                f"returning None"
+            )
+            return None
+
         if self._use_lookup_table and name in self._indexed_properties:
             # Use new lookup table approach
             from actingweb.db.postgresql.property_lookup import DbPropertyLookup

--- a/actingweb/db/postgresql/property.py
+++ b/actingweb/db/postgresql/property.py
@@ -39,7 +39,7 @@ class DbProperty:
             self._use_lookup_table = use_lookup_table
         else:
             self._use_lookup_table = (
-                os.getenv("USE_PROPERTY_LOOKUP_TABLE", "").lower() == "true"
+                os.getenv("USE_PROPERTY_LOOKUP_TABLE", "true").lower() == "true"
             )
 
         if indexed_properties is not None:
@@ -137,6 +137,36 @@ class DbProperty:
 
             lookup = DbPropertyLookup()
             actor_id = lookup.get(property_name=name, value=value)
+
+            if actor_id is None:
+                # Migration fallback: an un-backfilled lookup table on an
+                # upgrading deployment. The legacy query is an unindexed
+                # sequential scan (the value index was dropped by migration
+                # c3d4e5f6a7b8) — populate the lookup table to escape it.
+                try:
+                    with get_connection() as conn:
+                        with conn.cursor() as cur:
+                            cur.execute(
+                                """
+                                SELECT id FROM properties
+                                WHERE value = %s
+                                LIMIT 1
+                                """,
+                                (value,),
+                            )
+                            row = cur.fetchone()
+                            if row:
+                                actor_id = row[0]
+                except Exception:
+                    actor_id = None
+                if actor_id:
+                    logger.warning(
+                        f"DEPRECATED: reverse lookup for '{name}' served by a "
+                        f"full-table scan of the properties table — run "
+                        f"scripts/backfill_property_lookup.py to populate the "
+                        f"lookup table. This fallback is removed in the next "
+                        f"major release."
+                    )
 
             if actor_id:
                 # Load the property into self.handle for subsequent operations
@@ -435,7 +465,7 @@ class DbPropertyList:
             self._use_lookup_table = use_lookup_table
         else:
             self._use_lookup_table = (
-                os.getenv("USE_PROPERTY_LOOKUP_TABLE", "").lower() == "true"
+                os.getenv("USE_PROPERTY_LOOKUP_TABLE", "true").lower() == "true"
             )
 
         if indexed_properties is not None:

--- a/actingweb/db/postgresql/property_lookup.py
+++ b/actingweb/db/postgresql/property_lookup.py
@@ -63,17 +63,19 @@ class DbPropertyLookup:
         property_name: str | None = None,
         value: str | None = None,
         actor_id: str | None = None,
+        overwrite: bool = False,
     ) -> bool:
         """
         Create lookup entry.
 
-        Args:
-            property_name: Property name
-            value: Property value
-            actor_id: Actor ID
+        Same contract as the DynamoDB backend: an existing row for the same
+        (name, value) owned by a DIFFERENT actor is a collision — logged
+        loudly and rejected (pass overwrite=True for legitimate moves).
+        Re-creating the identical mapping is idempotent.
 
         Returns:
-            True on success, False on duplicate or error
+            True on success (including idempotent re-create), False on
+            collision or error
         """
         if not property_name or not value or not actor_id:
             return False
@@ -81,13 +83,45 @@ class DbPropertyLookup:
         try:
             with get_connection() as conn:
                 with conn.cursor() as cur:
-                    cur.execute(
-                        """
-                        INSERT INTO property_lookup (property_name, value, actor_id)
-                        VALUES (%s, %s, %s)
-                        """,
-                        (property_name, value, actor_id),
-                    )
+                    if overwrite:
+                        cur.execute(
+                            """
+                            INSERT INTO property_lookup (property_name, value, actor_id)
+                            VALUES (%s, %s, %s)
+                            ON CONFLICT (property_name, value)
+                            DO UPDATE SET actor_id = EXCLUDED.actor_id
+                            """,
+                            (property_name, value, actor_id),
+                        )
+                        inserted = True
+                    else:
+                        cur.execute(
+                            """
+                            INSERT INTO property_lookup (property_name, value, actor_id)
+                            VALUES (%s, %s, %s)
+                            ON CONFLICT (property_name, value) DO NOTHING
+                            """,
+                            (property_name, value, actor_id),
+                        )
+                        inserted = cur.rowcount > 0
+                    if not inserted:
+                        cur.execute(
+                            """
+                            SELECT actor_id FROM property_lookup
+                            WHERE property_name = %s AND value = %s
+                            """,
+                            (property_name, value),
+                        )
+                        row = cur.fetchone()
+                        existing_actor = row[0] if row else None
+                        if existing_actor != actor_id:
+                            logger.error(
+                                f"LOOKUP_COLLISION: property={property_name} "
+                                f"actor={actor_id} existing_actor={existing_actor} — "
+                                "two actors share an indexed value; not overwriting"
+                            )
+                            conn.commit()
+                            return False
                 conn.commit()
                 self.handle = {
                     "property_name": property_name,

--- a/actingweb/handlers/properties.py
+++ b/actingweb/handlers/properties.py
@@ -3,6 +3,7 @@ import json
 import logging
 from typing import Any
 
+from actingweb.db import get_property_list
 from actingweb.handlers import base_handler
 
 from ..permission_evaluator import PermissionResult, get_permission_evaluator
@@ -156,9 +157,16 @@ class PropertiesHandler(base_handler.BaseHandler):
                 self.response.set_status(404, "Not found")
             return
 
-        # Check if this is a list property first
+        # Try the simple property first (one read). Only on a miss consult
+        # the list metadata — the collision checks guarantee a name cannot be
+        # both a simple property and a list, so a simple-property hit never
+        # needs the extra list-existence read.
+        lookup = myself.property[name] if myself and myself.property else None
+
+        # Check if this is a list property
         if (
-            myself
+            lookup is None
+            and myself
             and hasattr(myself, "property_lists")
             and myself.property_lists is not None
             and myself.property_lists.exists(name)
@@ -284,8 +292,7 @@ class PropertiesHandler(base_handler.BaseHandler):
                     self.response.set_status(500, "Error accessing list property")
                 return
 
-        # Regular property handling
-        lookup = myself.property[name] if myself and myself.property else None
+        # Regular property handling (lookup was fetched above)
         if not lookup:
             if self.response:
                 self.response.set_status(404, "Property not found")
@@ -342,7 +349,22 @@ class PropertiesHandler(base_handler.BaseHandler):
                 self.response.set_status(500, "Internal error")
             return
 
-        properties = actor_interface.properties.to_dict()
+        # One partition read serves the whole response: simple properties,
+        # list discovery, list metadata and (for format=full/metadata) list
+        # items all come from this mapping instead of separate re-reads.
+        all_rows: dict[str, Any] = {}
+        if myself and myself.id and self.config:
+            try:
+                db_list = get_property_list(self.config)
+                all_rows = db_list.fetch_all_including_lists(actor_id=myself.id) or {}
+            except Exception as e:
+                logger.error(f"Error bulk-reading properties: {e}")
+                all_rows = {}
+        properties = {
+            name: value
+            for name, value in all_rows.items()
+            if not name.startswith("list:")
+        }
         # Check query parameters
         include_metadata = self.request.get("metadata") == "true"
         format_param = self.request.get("format") or None
@@ -413,7 +435,12 @@ class PropertiesHandler(base_handler.BaseHandler):
             and hasattr(actor_interface, "property_lists")
             and actor_interface.property_lists is not None
         ):
-            all_list_names = set(actor_interface.property_lists.list_all() or [])
+            # Derived from the bulk read above (same parse as list_all())
+            all_list_names = {
+                name[5:-5]
+                for name in all_rows
+                if name.startswith("list:") and name.endswith("-meta")
+            }
 
             # Filter list properties based on peer permissions (bulk evaluation)
             if peer_id and actor_interface and actor_interface.id:
@@ -446,7 +473,8 @@ class PropertiesHandler(base_handler.BaseHandler):
             lists_info: dict[str, Any] = {}
             for list_name in list_names:
                 list_prop = getattr(actor_interface.property_lists, list_name)
-                items = list(list_prop)
+                list_prop.prime_from_rows(all_rows)
+                items = list_prop.to_list_from_rows(all_rows)
                 total_bytes = sum(len(json.dumps(item)) for item in items)
                 lists_info[list_name] = {
                     "count": len(items),
@@ -465,7 +493,8 @@ class PropertiesHandler(base_handler.BaseHandler):
             # Full format: simple props as-is + list props with items, description, explanation
             for list_name in list_names:
                 list_prop = getattr(actor_interface.property_lists, list_name)
-                items = list(list_prop)
+                list_prop.prime_from_rows(all_rows)
+                items = list_prop.to_list_from_rows(all_rows)
                 # Execute property hooks on list items if available
                 if self.hooks and actor_interface:
                     auth_context = self._create_auth_context(check, "read")
@@ -490,6 +519,7 @@ class PropertiesHandler(base_handler.BaseHandler):
             # Default / format=short: simple props as-is + minimal list markers
             for list_name in list_names:
                 list_prop = getattr(actor_interface.property_lists, list_name)
+                list_prop.prime_from_rows(all_rows)
                 pair[list_name] = {
                     "_list": True,
                     "count": len(list_prop),

--- a/actingweb/interface/app.py
+++ b/actingweb/interface/app.py
@@ -74,11 +74,13 @@ class ActingWebApp:
             10  # Default thread pool size for FastAPI integration
         )
 
-        # Property lookup configuration
-        self._indexed_properties: list[str] = ["oauthId", "email", "externalUserId"]
-        self._use_lookup_table: bool = (
-            False  # False by default for backward compatibility
-        )
+        # Property lookup configuration. None means "not set via the builder":
+        # Config's own default and the INDEXED_PROPERTIES /
+        # USE_PROPERTY_LOOKUP_TABLE env overrides stay authoritative. An
+        # explicit with_indexed_properties()/with_legacy_property_index() call
+        # takes precedence over both (builder > env > default).
+        self._indexed_properties: list[str] | None = None
+        self._use_lookup_table: bool | None = None
 
         # Peer profile caching configuration
         # None = disabled, list of attributes = enabled
@@ -186,10 +188,14 @@ class ActingWebApp:
             self._config.actors = dict(self._actors_config)
         if self._enable_bot:
             self._config.bot = dict(self._bot_config or {})
-        # Property lookup configuration
-        if hasattr(self, "_indexed_properties"):
+        # Property lookup configuration. Only stamp values the builder was
+        # explicitly given; None must leave Config's default and the
+        # INDEXED_PROPERTIES / USE_PROPERTY_LOOKUP_TABLE env overrides intact.
+        # (An unconditional hasattr() guard here used to clobber the env vars
+        # on every with_*() call.)
+        if self._indexed_properties is not None:
             self._config.indexed_properties = self._indexed_properties
-        if hasattr(self, "_use_lookup_table"):
+        if self._use_lookup_table is not None:
             self._config.use_lookup_table = self._use_lookup_table
         # Subscription callback mode
         if hasattr(self, "_sync_subscription_callbacks"):
@@ -405,7 +411,9 @@ class ActingWebApp:
         Note:
             Only properties listed here can be used with Actor.get_from_property().
             Changes require application restart to take effect.
-            Use environment variable INDEXED_PROPERTIES for runtime override.
+            An explicit call to this method takes precedence over the
+            INDEXED_PROPERTIES environment variable; if this method is never
+            called, the env variable (when set) overrides the library default.
         """
         if properties is not None:
             self._indexed_properties = properties
@@ -416,9 +424,9 @@ class ActingWebApp:
         """
         Enable legacy GSI/index-based property reverse lookup (for migration).
 
-        When False (default), uses new lookup table approach which supports
-        property values larger than 2048 bytes. When True, uses legacy DynamoDB
-        GSI or PostgreSQL index on value field (limited to 2048 bytes).
+        When False, uses the new lookup table approach which supports property
+        values larger than 2048 bytes. When True, uses the legacy DynamoDB GSI
+        or PostgreSQL index on the value field (limited to 2048 bytes).
 
         Args:
             enable: True to use legacy GSI/index, False for new lookup table
@@ -427,8 +435,10 @@ class ActingWebApp:
             Self for method chaining
 
         Note:
-            Set this to True during migration from legacy systems. Once all
-            properties are migrated to lookup table, set back to False (default).
+            An explicit call to this method takes precedence over the
+            USE_PROPERTY_LOOKUP_TABLE environment variable. If this method is
+            never called, the env variable (when set) overrides the library
+            default, which is currently the legacy GSI/index path.
         """
         self._use_lookup_table = not enable
         self._apply_runtime_changes_to_config()
@@ -1237,13 +1247,19 @@ class ActingWebApp:
                 mcp=self._enable_mcp,
                 mcp_server_name=self._mcp_server_name,
                 mcp_instructions=self._mcp_instructions,
-                indexed_properties=self._indexed_properties,
                 sync_subscription_callbacks=self._sync_subscription_callbacks,
-                use_lookup_table=self._use_lookup_table,
                 peer_profile_attributes=self._peer_profile_attributes,
                 peer_capabilities_caching=self._peer_capabilities_caching,
                 peer_permissions_caching=self._peer_permissions_caching,
             )
+            # Property lookup settings are deliberately NOT passed as kwargs:
+            # Config applies its INDEXED_PROPERTIES / USE_PROPERTY_LOOKUP_TABLE
+            # env overrides after kwargs, so kwargs could never win. Stamping
+            # explicit builder values here gives builder > env > default.
+            if self._indexed_properties is not None:
+                self._config.indexed_properties = self._indexed_properties
+            if self._use_lookup_table is not None:
+                self._config.use_lookup_table = self._use_lookup_table
             # Populate multi-provider OAuth config on initial creation
             named = {k: dict(v) for k, v in self._oauth_configs.items() if k}
             if named:

--- a/actingweb/interface/app.py
+++ b/actingweb/interface/app.py
@@ -1380,6 +1380,62 @@ class ActingWebApp:
         except Exception as e:
             logger.info(f"Table pre-warm skipped: {e}")
 
+    def _check_lookup_backfill_needed(self) -> None:
+        """Warn loudly when reverse lookups would silently miss.
+
+        Fires when lookup-table mode is active, the properties table has
+        data, but the v2 lookup table is empty — the state every upgrading
+        deployment is in until it runs the backfill. Without the backfill,
+        indexed lookups are served by deprecated fallbacks (or return None
+        once those are removed). One cheap single-item probe per table,
+        once per process. Modeled on _warn_lambda_async_callbacks.
+        """
+        if self.database != "dynamodb" or getattr(self, "_backfill_checked", False):
+            return
+        self._backfill_checked = True
+        import logging
+
+        logger = logging.getLogger(__name__)
+        try:
+            if not self.get_config().use_lookup_table:
+                return
+            from ..db.dynamodb.property import Property
+            from ..db.dynamodb.property_lookup import (
+                PropertyLookup,
+                PropertyLookupV2,
+            )
+
+            if any(True for _ in PropertyLookupV2.scan(limit=1)):
+                return  # v2 populated — nothing to do
+            if not any(True for _ in Property.scan(limit=1)):
+                return  # fresh deployment, nothing to backfill
+            v1_has_rows = False
+            try:
+                v1_has_rows = any(True for _ in PropertyLookup.scan(limit=1))
+            except Exception:
+                pass
+            if v1_has_rows:
+                logger.error(
+                    "Property lookup table needs migration: the v1 lookup "
+                    "table has data but the v2 table "
+                    f"('{PropertyLookupV2.Meta.table_name}') is empty. "
+                    "Reverse lookups are being served by a deprecated "
+                    "fallback. Run scripts/backfill_property_lookup.py to "
+                    "rebuild the v2 table from the properties table, verify, "
+                    "then drop the v1 table. See docs/migration/v3.13."
+                )
+            else:
+                logger.error(
+                    "Property lookup table is empty but the properties table "
+                    "has data: reverse lookups (e.g. find-actor-by-email) "
+                    "depend on a deprecated fallback or will return None. "
+                    "Run scripts/backfill_property_lookup.py to populate "
+                    f"'{PropertyLookupV2.Meta.table_name}'. "
+                    "See docs/migration/v3.13."
+                )
+        except Exception as e:
+            logger.debug(f"Lookup backfill check skipped: {e}")
+
     def integrate_flask(self, flask_app: Any) -> "FlaskIntegration":
         """Integrate with Flask application."""
         try:
@@ -1390,6 +1446,7 @@ class ActingWebApp:
                 "Install with: pip install 'actingweb[flask]'"
             ) from e
         self._prewarm_dynamodb_tables()
+        self._check_lookup_backfill_needed()
         integration = FlaskIntegration(self, flask_app)
         integration.setup_routes()
         return integration
@@ -1420,6 +1477,7 @@ class ActingWebApp:
             ) from e
 
         self._prewarm_dynamodb_tables()
+        self._check_lookup_backfill_needed()
         integration = FastAPIIntegration(
             self,
             fastapi_app,

--- a/actingweb/interface/app.py
+++ b/actingweb/interface/app.py
@@ -1356,10 +1356,12 @@ class ActingWebApp:
             ]
             # The lookup table is only used (and thus only created) in
             # lookup-table mode; don't create it for legacy deployments.
+            # (The deprecated v1 lookup model is read-only and never
+            # auto-created.)
             if self.get_config().use_lookup_table:
-                from ..db.dynamodb.property_lookup import PropertyLookup
+                from ..db.dynamodb.property_lookup import PropertyLookupV2
 
-                models.append(PropertyLookup)
+                models.append(PropertyLookupV2)
 
             with ThreadPoolExecutor(max_workers=len(models)) as pool:
                 futures = {m: pool.submit(ensure_table, m) for m in models}

--- a/actingweb/interface/app.py
+++ b/actingweb/interface/app.py
@@ -444,6 +444,32 @@ class ActingWebApp:
         self._apply_runtime_changes_to_config()
         return self
 
+    def with_dynamodb(self, auto_create_tables: bool = True) -> "ActingWebApp":
+        """Configure DynamoDB backend options.
+
+        Args:
+            auto_create_tables: When True (default), tables are created
+                automatically on first access — convenient for development.
+                Set False for production deployments that manage tables via
+                infrastructure-as-code; the runtime IAM role can then drop
+                the ``dynamodb:CreateTable`` and ``dynamodb:DescribeTable``
+                permissions.
+
+        Returns:
+            Self for method chaining
+
+        Note:
+            An explicit call takes precedence over the
+            ``AWS_DB_AUTO_CREATE_TABLES`` environment variable. Call it
+            before integrating with the web framework — the setting only
+            affects tables not yet accessed. Has no effect on the
+            PostgreSQL backend (tables there are managed by Alembic).
+        """
+        from ..db.dynamodb._ensure import set_auto_create
+
+        set_auto_create(auto_create_tables)
+        return self
+
     def with_bot(
         self, token: str = "", email: str = "", secret: str = "", admin_room: str = ""
     ) -> "ActingWebApp":
@@ -1287,6 +1313,68 @@ class ActingWebApp:
         """Check if MCP functionality is enabled."""
         return self._enable_mcp
 
+    def _prewarm_dynamodb_tables(self) -> None:
+        """Ensure all DynamoDB tables exist before serving traffic.
+
+        Runs the per-table existence checks concurrently at integration time
+        so the first request per process does not pay a serial DescribeTable
+        sweep (worst on serverless cold starts, which land during scale-up
+        bursts). No-op for other backends or when auto-creation is disabled.
+        Failures degrade to the lazy per-accessor path.
+        """
+        if self.database != "dynamodb":
+            return
+        import logging
+
+        logger = logging.getLogger(__name__)
+        try:
+            from concurrent.futures import ThreadPoolExecutor
+
+            from ..db.dynamodb._ensure import auto_create_enabled, ensure_table
+
+            if not auto_create_enabled():
+                return
+
+            from ..db.dynamodb.actor import Actor
+            from ..db.dynamodb.attribute import Attribute
+            from ..db.dynamodb.peertrustee import PeerTrustee
+            from ..db.dynamodb.property import Property
+            from ..db.dynamodb.subscription import Subscription
+            from ..db.dynamodb.subscription_diff import SubscriptionDiff
+            from ..db.dynamodb.subscription_suspension import SubscriptionSuspension
+            from ..db.dynamodb.trust import Trust
+
+            models = [
+                Actor,
+                Attribute,
+                PeerTrustee,
+                Property,
+                Subscription,
+                SubscriptionDiff,
+                SubscriptionSuspension,
+                Trust,
+            ]
+            # The lookup table is only used (and thus only created) in
+            # lookup-table mode; don't create it for legacy deployments.
+            if self.get_config().use_lookup_table:
+                from ..db.dynamodb.property_lookup import PropertyLookup
+
+                models.append(PropertyLookup)
+
+            with ThreadPoolExecutor(max_workers=len(models)) as pool:
+                futures = {m: pool.submit(ensure_table, m) for m in models}
+            for model, future in futures.items():
+                exc = future.exception()
+                if exc is not None:
+                    logger.info(
+                        "Table pre-warm failed for %s (will fall back to "
+                        "lazy creation): %s",
+                        model.Meta.table_name,
+                        exc,
+                    )
+        except Exception as e:
+            logger.info(f"Table pre-warm skipped: {e}")
+
     def integrate_flask(self, flask_app: Any) -> "FlaskIntegration":
         """Integrate with Flask application."""
         try:
@@ -1296,6 +1384,7 @@ class ActingWebApp:
                 "Flask integration requires Flask to be installed. "
                 "Install with: pip install 'actingweb[flask]'"
             ) from e
+        self._prewarm_dynamodb_tables()
         integration = FlaskIntegration(self, flask_app)
         integration.setup_routes()
         return integration
@@ -1325,6 +1414,7 @@ class ActingWebApp:
                 "Install with: pip install 'actingweb[fastapi]'"
             ) from e
 
+        self._prewarm_dynamodb_tables()
         integration = FastAPIIntegration(
             self,
             fastapi_app,

--- a/actingweb/interface/app.py
+++ b/actingweb/interface/app.py
@@ -1338,17 +1338,20 @@ class ActingWebApp:
             from ..db.dynamodb.actor import Actor
             from ..db.dynamodb.attribute import Attribute
             from ..db.dynamodb.peertrustee import PeerTrustee
-            from ..db.dynamodb.property import Property
+            from ..db.dynamodb.property import Property, PropertyLegacy
             from ..db.dynamodb.subscription import Subscription
             from ..db.dynamodb.subscription_diff import SubscriptionDiff
             from ..db.dynamodb.subscription_suspension import SubscriptionSuspension
             from ..db.dynamodb.trust import Trust
 
+            use_lookup = bool(self.get_config().use_lookup_table)
             models = [
                 Actor,
                 Attribute,
                 PeerTrustee,
-                Property,
+                # Lookup mode creates the properties table WITHOUT the
+                # legacy value-keyed GSI; legacy mode keeps it.
+                Property if use_lookup else PropertyLegacy,
                 Subscription,
                 SubscriptionDiff,
                 SubscriptionSuspension,
@@ -1358,7 +1361,7 @@ class ActingWebApp:
             # lookup-table mode; don't create it for legacy deployments.
             # (The deprecated v1 lookup model is read-only and never
             # auto-created.)
-            if self.get_config().use_lookup_table:
+            if use_lookup:
                 from ..db.dynamodb.property_lookup import PropertyLookupV2
 
                 models.append(PropertyLookupV2)

--- a/actingweb/interface/property_store.py
+++ b/actingweb/interface/property_store.py
@@ -172,14 +172,12 @@ class PropertyStore:
         return iter(self)
 
     def values(self) -> Iterator[Any]:
-        """Get all property values."""
-        for key in self:
-            yield self[key]
+        """Get all property values (single bulk read)."""
+        yield from self.to_dict().values()
 
     def items(self) -> Iterator[tuple[str, Any]]:
-        """Get all property key-value pairs."""
-        for key in self:
-            yield (key, self[key])
+        """Get all property key-value pairs (single bulk read)."""
+        yield from self.to_dict().items()
 
     def update(self, other: dict[str, Any]) -> None:
         """Update properties from dictionary with hooks and diff registration."""
@@ -197,8 +195,20 @@ class PropertyStore:
             self._actor.register_diffs(target="properties", subtarget=None, blob="")
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert to dictionary."""
-        return dict(self.items())
+        """Convert to dictionary with one backend read.
+
+        Reads everything via get_all() instead of re-fetching each key
+        individually (the old path issued one GetItem per property right
+        after having bulk-read them all).
+        """
+        try:
+            if hasattr(self._core_store, "get_all"):
+                all_props = self._core_store.get_all()
+                if isinstance(all_props, dict):
+                    return dict(all_props)
+        except (AttributeError, TypeError):
+            pass
+        return {}
 
     @property
     def core_store(self) -> CorePropertyStore:
@@ -294,6 +304,12 @@ class NotifyingListProperty:
 
     def to_list(self) -> list[Any]:
         return self._list_prop.to_list()
+
+    def prime_from_rows(self, rows: dict[str, Any]) -> None:
+        self._list_prop.prime_from_rows(rows)
+
+    def to_list_from_rows(self, rows: dict[str, Any]) -> list[Any]:
+        return self._list_prop.to_list_from_rows(rows)
 
     def slice(self, start: int, end: int) -> list[Any]:
         return self._list_prop.slice(start, end)

--- a/actingweb/property.py
+++ b/actingweb/property.py
@@ -97,8 +97,13 @@ class PropertyStore:
             if k in self.__dict__:
                 self.__delattr__(k)
         else:
-            # Check for list collision - error if list exists
-            if self.__dict__.get("_config"):
+            # Check for list collision - error if list exists. Only needed
+            # when the property is not already known as an existing simple
+            # property in this store (collision checks in both directions
+            # guarantee a name cannot be both) — skipping it saves one
+            # metadata read on every repeat write. A cached None (missed
+            # read) must NOT skip the check.
+            if self.__dict__.get(k) is None and self.__dict__.get("_config"):
                 list_store = PropertyListStore(
                     actor_id=self.__dict__.get("_actor_id"),
                     config=self.__dict__["_config"],

--- a/actingweb/property_list.py
+++ b/actingweb/property_list.py
@@ -144,6 +144,47 @@ class ListProperty:
         """Invalidate the metadata cache."""
         self._meta_cache = None
 
+    def prime_from_rows(self, rows: dict[str, Any]) -> None:
+        """Hydrate the metadata cache from a pre-fetched name->value mapping.
+
+        `rows` is the result of a bulk fetch_all_including_lists() read.
+        Priming avoids re-reading the `list:<name>-meta` row that the bulk
+        read already returned. Ignores missing or unparsable metadata (the
+        normal lazy path then applies).
+        """
+        meta_str = rows.get(self._get_meta_property_name())
+        if meta_str is None:
+            return
+        try:
+            parsed = json.loads(meta_str)
+        except (json.JSONDecodeError, TypeError):
+            return
+        if isinstance(parsed, dict):
+            self._meta_cache = parsed
+
+    def to_list_from_rows(self, rows: dict[str, Any]) -> list[Any]:
+        """Like to_list(), but served from a pre-fetched name->value mapping.
+
+        Falls back to a per-item database read for any row missing from the
+        mapping. Item decoding matches __getitem__: JSON with a raw-string
+        fallback.
+        """
+        length = len(self)
+        result: list[Any] = []
+        for i in range(length):
+            item_str = rows.get(self._get_item_property_name(i))
+            if item_str is None:
+                try:
+                    result.append(self[i])
+                except (IndexError, json.JSONDecodeError) as e:
+                    logger.error(f"Error loading list item {i}: {e}")
+                continue
+            try:
+                result.append(json.loads(item_str))
+            except (json.JSONDecodeError, TypeError):
+                result.append(item_str)
+        return result
+
     def get_description(self) -> str:
         """Get the description field for UI info about the list."""
         meta = self._load_metadata()

--- a/actingweb/trust_permissions.py
+++ b/actingweb/trust_permissions.py
@@ -91,7 +91,10 @@ class TrustPermissionStore:
 
     def __init__(self, config: config_class.Config):
         self.config = config
-        self._cache: dict[str, TrustPermissions] = {}
+        # Values may be None: a confirmed "no override stored" is cached too,
+        # otherwise every permission evaluation for a peer without an
+        # override re-reads the attribute bucket.
+        self._cache: dict[str, TrustPermissions | None] = {}
 
     def _get_permissions_bucket(self, actor_id: str) -> attribute.Attributes | None:
         """Get the trust permissions attribute bucket for an actor."""
@@ -483,6 +486,9 @@ class TrustPermissionStore:
             attr_data = bucket.get_attr(name=permission_key)
 
             if not attr_data or "data" not in attr_data:
+                # Cache the negative: store/delete paths update the cache, so
+                # this stays correct within the process.
+                self._cache[cache_key] = None
                 return None
 
             # Parse JSON and create TrustPermissions

--- a/docs/contributing/architecture.rst
+++ b/docs/contributing/architecture.rst
@@ -490,6 +490,9 @@ Config-Aware DB Accessors
 **Why This Matters**:
 
 - Property lookup table settings (``use_lookup_table``, ``indexed_properties``) must be properly configured
+- Directly-constructed accessors fall back to environment variables, which can
+  silently disagree with app-level configuration (e.g. reverse-lookup mode) —
+  the factory injects the resolved config
 - Accessor functions provide type-safe, testable interfaces
 - Clearer dependency on configuration
 

--- a/docs/guides/database-maintenance.rst
+++ b/docs/guides/database-maintenance.rst
@@ -43,6 +43,40 @@ Choose the appropriate section based on your database backend:
   use pg_cron or scheduled cleanup scripts for the remaining temporary data
   (OAuth sessions, MCP tokens, orphaned index entries)
 
+DynamoDB Billing Mode for Auto-Created Tables
+---------------------------------------------
+
+Tables auto-created by ActingWeb **before v3.13** were PROVISIONED with
+tiny fixed capacities inherited from old defaults — typically
+``<prefix>_property_lookup`` (2 read units / 1 write unit per second — a
+hard throughput wall on the login path) and ``<prefix>_peertrustees``.
+Since v3.13 auto-created tables are on-demand, but **existing tables are
+never changed automatically**. Convert them in place:
+
+.. code-block:: bash
+
+    # Find provisioned stragglers
+    for t in $(aws dynamodb list-tables --query 'TableNames[]' --output text); do
+      aws dynamodb describe-table --table-name "$t" \
+        --query 'Table.[TableName,BillingModeSummary.BillingMode]' --output text
+    done
+
+    # Convert (allowed once per table per 24 hours)
+    aws dynamodb update-table --table-name <prefix>_peertrustees \
+      --billing-mode PAY_PER_REQUEST
+
+.. warning::
+
+   Never delete and recreate a table to change its billing mode — every
+   ActingWeb table holds live data (the lookup table backs the login
+   path). ``update-table`` converts in place with no downtime.
+
+For fully infrastructure-as-code-managed deployments, disable
+auto-creation (``AWS_DB_AUTO_CREATE_TABLES=false`` or
+``with_dynamodb(auto_create_tables=False)``) and drop
+``dynamodb:CreateTable`` / ``dynamodb:DescribeTable`` from the runtime
+role.
+
 DynamoDB TTL Configuration
 --------------------------
 

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -12,6 +12,7 @@ Contents
 .. toctree::
    :maxdepth: 2
 
+   v3.13
    v3.11
    v3.10
    v3.7

--- a/docs/migration/v3.13.rst
+++ b/docs/migration/v3.13.rst
@@ -144,9 +144,11 @@ Behaviour changes to be aware of
 
 - **Reverse-lookup matching is now (name, value)**, not value-only: the
   legacy GSI matched on value alone, so a value shared across *different*
-  property names could resolve "cross-name". The lookup table cannot.
-  The fallback tiers preserve the old behaviour until removed in the next
-  major release.
+  property names could resolve "cross-name". The lookup table cannot, and
+  the migration fallback tiers (v1 table, legacy GSI, PostgreSQL scan) now
+  also filter by property name — so the value-only cross-name match is gone
+  on every path, not just the primary one. The fallbacks remain only to
+  serve un-backfilled deployments and are removed in the next major release.
 - **Non-indexed property names return None** from
   ``Actor.get_from_property()`` / ``ActorInterface.get_by_property()``
   (with a warning) instead of silently querying the legacy path. Add

--- a/docs/migration/v3.13.rst
+++ b/docs/migration/v3.13.rst
@@ -1,0 +1,168 @@
+===========================
+Migrating to ActingWeb 3.13
+===========================
+
+Overview
+========
+
+ActingWeb 3.13 is a **DynamoDB scalability release**. It fixes two measured
+superlinear cost defects (full-table scans on per-actor reads; a
+``DescribeTable`` control-plane call on every accessor construction),
+removes hot-path read amplification, defaults auto-created tables to
+on-demand billing, and — the one change that affects behaviour for
+deployments that change nothing — **flips the default property
+reverse-lookup mechanism to lookup-table mode**, backed by a redesigned
+(v2, digest-keyed) lookup table.
+
+Nothing in this release requires code changes. What it may require is
+**one operational step**: running the lookup-table backfill script so
+reverse lookups (find-actor-by-email/oauthId — typically your login path)
+are served from the new table instead of deprecated fallbacks.
+
+Which deployment am I?
+======================
+
+Find your row; do what its column says. "Implicit legacy" means you never
+called ``with_legacy_property_index()`` and never set
+``USE_PROPERTY_LOOKUP_TABLE``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 34 33 33
+
+   * - State before 3.13
+     - After upgrading (no config change)
+     - Action needed
+   * - Implicit legacy; properties table **has** the ``property-index``
+       GSI (created by an older ActingWeb)
+     - Reverse lookups keep working via the **deprecated GSI fallback**
+       (a warning is logged per hit; an ERROR is logged at startup)
+     - Run the backfill (below). Optionally delete the now-unused GSI to
+       halve property write cost — only after verifying.
+   * - Implicit legacy; properties table has **no** GSI (created before
+       the GSI existed). Reverse lookups were **crashing** before 3.13.
+     - Reverse lookups now work IF the lookup table is populated;
+       until then they return ``None`` (startup ERROR tells you)
+     - Run the backfill (below).
+   * - Lookup mode already enabled (``with_legacy_property_index(False)``)
+       on the **v1** lookup table
+     - Reverse lookups keep working via the **deprecated v1 fallback**
+       (warning per hit; startup ERROR)
+     - Run the backfill, verify, then **drop the v1
+       ``<prefix>_property_lookup`` table**.
+   * - Explicit legacy (``with_legacy_property_index(True)`` or
+       ``USE_PROPERTY_LOOKUP_TABLE=false``)
+     - Unchanged: legacy GSI path stays active. If the table lacks the
+       GSI you now get an actionable error instead of an opaque crash.
+     - None immediately. Legacy mode is deprecated — plan the migration.
+   * - Fresh deployment
+     - Lookup-table mode, on-demand billing, no legacy GSI — the
+       intended end state
+     - None.
+
+Required: run the backfill (all upgrading deployments using reverse lookup)
+===========================================================================
+
+The lookup table is **derived data**; the properties table is the source
+of truth. The script rebuilds the v2 table from it — streaming,
+rate-limited, resumable and idempotent::
+
+    # With the SAME environment as the app (AWS_DB_PREFIX, region,
+    # credentials, INDEXED_PROPERTIES if customised):
+    poetry run python scripts/backfill_property_lookup.py --dry-run
+    poetry run python scripts/backfill_property_lookup.py --rps 50
+
+Notes:
+
+- ``--rps`` caps items/second — a full-table scan against production
+  should not brown-out serving traffic. ``--segments N`` parallelises.
+- Interrupted runs resume from ``--checkpoint-file``.
+- Values are copied **verbatim** (no normalisation) — runtime lookups are
+  exact-match.
+- A value shared by two actors is reported as a **collision** and not
+  overwritten (exit code 1). Resolve manually and re-run — re-runs are
+  idempotent.
+
+Verify, then clean up:
+
+1. Watch logs: reverse lookups should stop logging
+   ``DEPRECATED: reverse lookup ... served from ...`` warnings, and the
+   startup ERROR should disappear on the next restart.
+2. **v1 cohort**: drop the old table —
+   ``aws dynamodb delete-table --table-name <prefix>_property_lookup``.
+   (Never touch ``<prefix>_properties`` — that is the source of truth.)
+3. **GSI cohort (optional, saves ~half of property write cost)**: delete
+   the legacy index::
+
+       aws dynamodb update-table --table-name <prefix>_properties \
+         --global-secondary-index-updates '[{"Delete":{"IndexName":"property-index"}}]'
+
+   Only after the backfill is verified: deleting the GSI removes the
+   fallback the un-backfilled state depends on. Note that deleting the
+   GSI makes a later return to legacy mode impossible without recreating
+   the index.
+
+Rollback: setting ``USE_PROPERTY_LOOKUP_TABLE=false`` (or
+``with_legacy_property_index(enable=True)``) restores the legacy path.
+(3.13 also fixed a bug where the env variable was silently ignored by
+apps using the fluent builder — the rollback now actually works.)
+
+Recommended: convert old auto-created tables to on-demand billing
+=================================================================
+
+Tables the library auto-created before 3.13 are PROVISIONED with tiny
+capacities — typically ``<prefix>_property_lookup`` (2 RCU / 1 WCU: a
+hard wall on the login path) and ``<prefix>_peertrustees``. New tables
+are on-demand; **existing tables are not changed automatically**.
+Convert them in place::
+
+    aws dynamodb update-table --table-name <prefix>_peertrustees \
+      --billing-mode PAY_PER_REQUEST
+
+- AWS allows one billing-mode switch per table per 24 hours.
+- **Never delete and recreate a table to change billing** — the v1 lookup
+  table (pre-backfill) and every other table hold live data.
+- Check for other PROVISIONED stragglers:
+  ``aws dynamodb list-tables`` + ``describe-table``.
+
+Recommended: disable auto-creation in production
+================================================
+
+If your tables are managed by CloudFormation/Terraform, turn off the
+library's table auto-creation and slim the runtime role::
+
+    AWS_DB_AUTO_CREATE_TABLES=false        # env, or:
+    app.with_dynamodb(auto_create_tables=False)
+
+With auto-creation off the library never calls ``DescribeTable`` or
+``CreateTable``, so both can be dropped from the runtime IAM policy. If
+your IAM policy lists tables by name, add the new
+``<prefix>_property_lookup_v2`` table.
+
+Behaviour changes to be aware of
+================================
+
+- **Reverse-lookup matching is now (name, value)**, not value-only: the
+  legacy GSI matched on value alone, so a value shared across *different*
+  property names could resolve "cross-name". The lookup table cannot.
+  The fallback tiers preserve the old behaviour until removed in the next
+  major release.
+- **Non-indexed property names return None** from
+  ``Actor.get_from_property()`` / ``ActorInterface.get_by_property()``
+  (with a warning) instead of silently querying the legacy path. Add
+  names to ``with_indexed_properties()`` to make them resolvable.
+- **Cross-actor lookup collisions are refused and logged** instead of
+  silently overwritten (DynamoDB previously last-writer-wins; PostgreSQL
+  already refused — the backends now agree, including idempotent
+  re-creates).
+- **Trust/peer-trustee list ordering is deterministic** (range-key
+  sorted) instead of arbitrary scan order.
+- **Subscription-suspension and peer-trustee-list accessors now
+  auto-create their tables** like every other accessor (previously a
+  fresh deployment crashed on first use of suspension).
+- The lookup table stores **SHA-256 digests, not plaintext values** —
+  update your data map (see ``docs/reference/security.rst``).
+
+No changes needed for PostgreSQL schemas (the lookup table and its
+Alembic migration already exist); the default flip applies to both
+backends.

--- a/docs/quickstart/configuration.rst
+++ b/docs/quickstart/configuration.rst
@@ -537,10 +537,18 @@ Size Limits
      - 2048 bytes
      - 8191 bytes (btree index)
    * - Lookup Table
-     - No limit (400KB item)
+     - No limit (fixed-size digest key)
      - No limit (TEXT column)
 
 **Recommendation:** Use lookup tables if you need to store OAuth tokens, long external IDs, or any property values exceeding 2KB.
+
+.. note::
+   On DynamoDB, lookup rows are keyed by a SHA-256 digest of
+   ``(property name, value)`` and the plaintext value is **not stored** in
+   the lookup table — this removes any value-size limit and keeps
+   personally identifiable values (emails, OAuth IDs) out of the lookup
+   table entirely. Note this is pseudonymisation, not anonymisation: the
+   properties table itself still stores values in plaintext.
 
 **Practical Size Limits:**
 

--- a/docs/quickstart/configuration.rst
+++ b/docs/quickstart/configuration.rst
@@ -147,7 +147,7 @@ Backend selection is controlled by the ``database`` parameter in ``ActingWebApp(
      - DynamoDB
      - PostgreSQL
    * - Setup Complexity
-     - Low (auto-creates tables)
+     - Low (auto-creates tables; disable in production)
      - Medium (requires migrations)
    * - Local Development
      - DynamoDB Local (Docker)
@@ -197,10 +197,25 @@ Local Development (DynamoDB Local)
 
 Point your app to DynamoDB Local via these environment variables (no code changes needed). The library uses its bundled PynamoDB models to create/access required tables at runtime.
 
+Other DynamoDB environment variables:
+
+- ``AWS_DB_PREFIX`` — table-name prefix (default ``demo_actingweb``); every
+  table is named ``<prefix>_<kind>``. Must be set **before** the first
+  import of any ``actingweb.db.dynamodb`` module — table names are bound
+  at import time.
+- ``AWS_DB_AUTO_CREATE_TABLES`` — set ``false`` to disable table
+  auto-creation entirely (recommended in production with
+  infrastructure-as-code-managed tables). Equivalent fluent API:
+  ``with_dynamodb(auto_create_tables=False)``. Auto-created tables use
+  on-demand (``PAY_PER_REQUEST``) billing.
+
 Production (AWS DynamoDB)
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Configure IAM with least-privilege on the app's tables: ``dynamodb:GetItem``, ``PutItem``, ``UpdateItem``, ``DeleteItem``, ``Query``, ``Scan``.
+  With auto-creation enabled (the default) the role also needs
+  ``dynamodb:CreateTable`` and ``dynamodb:DescribeTable``; with
+  ``AWS_DB_AUTO_CREATE_TABLES=false`` both can be dropped.
 - Ensure tables exist (actor, properties, attributes, subscriptions, trust, and related indexes) before first traffic; the library's DB modules are under ``actingweb.db.dynamodb``.
 - Set region/credentials via standard AWS mechanisms (env vars, instance roles, profiles).
 
@@ -407,14 +422,20 @@ Property Reverse Lookup
 
 ActingWeb supports efficient reverse lookups (find actor by property value) using a dedicated lookup table. This is particularly useful for OAuth authentication where you need to find an actor by their OAuth provider ID.
 
-**Why Use Lookup Tables?**
+**How it works**
 
-By default, ActingWeb uses database indexes for reverse lookups:
+Lookup-table mode is the **default** (since v3.13) and the mechanism of
+record. On DynamoDB, lookup rows are keyed by a SHA-256 digest of the
+(property name, value) pair — no value-size limit, uniform partition
+distribution, and no plaintext values in the lookup table.
 
-- **DynamoDB**: Global Secondary Index (GSI) on the ``value`` field - limited to 2048 bytes
-- **PostgreSQL**: Index on the ``value`` column - works but less efficient for large values
+The deprecated legacy mode used database indexes instead:
 
-The lookup table approach removes size limits and improves query performance for configured properties.
+- **DynamoDB**: Global Secondary Index (GSI) on the ``value`` field — limited to 2048 bytes
+- **PostgreSQL**: unindexed query on the ``value`` column — a full-table scan
+
+Legacy mode remains available for migration (``with_legacy_property_index(enable=True)``)
+and is removed in the next major release.
 
 Configuration
 ~~~~~~~~~~~~~
@@ -430,20 +451,24 @@ Enable lookup tables via API or environment variables:
         fqdn="myapp.example.com"
     ).with_indexed_properties(["oauthId", "email", "externalUserId"])
 
-    # Enable lookup table mode (disable legacy indexes)
-    app.with_legacy_property_index(enable=False)  # Recommended for new deployments
+    # Lookup-table mode is the default; pin legacy mode only for migration:
+    # app.with_legacy_property_index(enable=True)
 
 **Environment Variables:**
 
 .. code-block:: bash
 
-    export USE_PROPERTY_LOOKUP_TABLE=true                           # Enable lookup table
+    export USE_PROPERTY_LOOKUP_TABLE=false                         # Pin deprecated legacy mode
     export INDEXED_PROPERTIES=oauthId,email,externalUserId         # Which properties to index
 
 **Default Configuration:**
 
-- ``USE_PROPERTY_LOOKUP_TABLE``: ``false`` (uses legacy GSI/index for backward compatibility)
+- ``USE_PROPERTY_LOOKUP_TABLE``: ``true`` (lookup-table mode; set ``false`` to pin the deprecated legacy GSI/index)
 - ``INDEXED_PROPERTIES``: ``["oauthId", "email", "externalUserId"]``
+
+Precedence: an explicit ``with_indexed_properties()`` /
+``with_legacy_property_index()`` call beats the environment variable,
+which beats the library default.
 
 Usage Example
 ~~~~~~~~~~~~~
@@ -488,40 +513,26 @@ The lookup happens automatically when you set indexed properties:
 Migration Guide
 ~~~~~~~~~~~~~~~
 
-**New Deployments:** Enable lookup tables from the start:
+**New deployments** need nothing — lookup-table mode is the default.
 
-.. code-block:: python
+**Deployments upgrading from pre-3.13** (or from the v1 lookup-table
+format): reverse lookups keep working through deprecated fallbacks, but
+you must populate the v2 lookup table:
 
-    app.with_legacy_property_index(enable=False)
+.. code-block:: bash
 
-**Existing Deployments:** Use dual-mode for gradual migration:
+    # With the same environment as the app:
+    poetry run python scripts/backfill_property_lookup.py --dry-run
+    poetry run python scripts/backfill_property_lookup.py --rps 50
 
-1. **Phase 1 - Deploy with Lookup Table Support:**
+The script is streaming, rate-limited, resumable and idempotent, and
+reports (without overwriting) any value shared by two actors. See
+:doc:`../migration/v3.13` for the full decision tree, verification steps,
+and the optional legacy-GSI / v1-table cleanup.
 
-   .. code-block:: python
-
-       # Keep legacy mode enabled (default)
-       app = ActingWebApp(...)  # use_lookup_table defaults to False
-
-   Deploy this version. Both legacy and lookup table code paths are available.
-
-2. **Phase 2 - Enable Lookup Tables:**
-
-   .. code-block:: bash
-
-       export USE_PROPERTY_LOOKUP_TABLE=true
-
-   Restart the application. New writes will populate lookup tables. Legacy GSI/index still used for reads.
-
-3. **Phase 3 - Backfill Existing Data (Optional):**
-
-   Run a backfill script to populate lookup tables for existing actors (implementation depends on your deployment).
-
-4. **Phase 4 - Disable Legacy Index:**
-
-   Once backfill is complete and you've verified lookup tables work correctly, you can disable the legacy GSI/index at the database level.
-
-**Rollback:** Set ``USE_PROPERTY_LOOKUP_TABLE=false`` to revert to legacy GSI/index mode.
+**Rollback:** Set ``USE_PROPERTY_LOOKUP_TABLE=false`` (or call
+``with_legacy_property_index(enable=True)``) to pin the deprecated
+legacy GSI/index mode.
 
 Size Limits
 ~~~~~~~~~~~

--- a/docs/quickstart/local-dev-setup.rst
+++ b/docs/quickstart/local-dev-setup.rst
@@ -52,12 +52,13 @@ Launch DynamoDB Local and configure environment:
 
 Notes:
 
-- The library auto-creates tables on first access through its PynamoDB models.
-  Table names are prefixed (default ``demo_actingweb``, e.g.
-  ``demo_actingweb_actors``; override with the ``AWS_DB_PREFIX`` environment
-  variable). During startup you may see benign ``DEBUG`` log lines about a
-  not-yet-existent table (e.g. ``demo_actingweb_subscription_suspensions``) as
-  each table is created lazily on first use — these are harmless.
+- The library auto-creates tables (a development convenience — disable in
+  production with ``AWS_DB_AUTO_CREATE_TABLES=false`` when tables are managed
+  by infrastructure-as-code). Table names are prefixed (default
+  ``demo_actingweb``, e.g. ``demo_actingweb_actors``; override with the
+  ``AWS_DB_PREFIX`` environment variable **before** the app imports any
+  database module). Tables are pre-created at framework-integration time and
+  use on-demand billing.
 - For production, configure IAM and real AWS hosts (do not set ``AWS_DB_HOST``).
 
 Option 2: PostgreSQL (Recommended for New Projects)
@@ -133,7 +134,7 @@ If you prefer to run alembic directly without the helper script:
 
 **Notes:**
 
-- PostgreSQL requires running Alembic migrations before first use (unlike DynamoDB which auto-creates tables)
+- PostgreSQL requires running Alembic migrations before first use (unlike DynamoDB, which auto-creates tables by default)
 - For native PostgreSQL: ``brew install postgresql`` (macOS) or ``apt install postgresql`` (Ubuntu)
 - Connection pooling is automatic (psycopg3 with configurable min/max connections)
 - Use Docker Compose for multi-service setups (see :doc:`../guides/postgresql-migration`)

--- a/docs/reference/database-backends.rst
+++ b/docs/reference/database-backends.rst
@@ -16,7 +16,7 @@ Quick Comparison
      - DynamoDB
      - PostgreSQL
    * - **Setup Complexity**
-     - Low (auto-creates tables)
+     - Low (auto-creates tables; disable via ``AWS_DB_AUTO_CREATE_TABLES=false`` in production)
      - Medium (requires Alembic migrations)
    * - **Local Development**
      - DynamoDB Local (Docker)
@@ -367,9 +367,11 @@ Index Strategy
 **DynamoDB:**
 
 - Global Secondary Indexes (GSI) for non-key lookups:
-  - ``actors``: GSI on ``creator`` field
-  - ``properties``: GSI on ``value`` field (reverse lookups)
-  - ``trusts``: GSI on ``secret`` field (token lookups)
+  ``actors`` has a GSI on the ``creator`` field, ``trusts`` on the
+  ``secret`` field (token lookups).
+- ``properties`` reverse lookups use the dedicated digest-keyed
+  ``property_lookup_v2`` table (default). Only tables created in the
+  deprecated legacy mode carry a GSI on ``value`` (2048-byte limit).
 
 **PostgreSQL:**
 

--- a/docs/reference/security.rst
+++ b/docs/reference/security.rst
@@ -60,4 +60,15 @@ Data Backend
 
 - Local dev: use DynamoDB Local with `AWS_DB_HOST` set.
 - Production: use IAM with least privilege and do not set `AWS_DB_HOST`.
+- Production with IaC-managed tables: set ``AWS_DB_AUTO_CREATE_TABLES=false``
+  (or ``with_dynamodb(auto_create_tables=False)``) and drop
+  ``dynamodb:CreateTable`` and ``dynamodb:DescribeTable`` from the runtime
+  role.
+- **Data mapping / GDPR**: indexed property values (emails, OAuth IDs)
+  used for reverse lookup are stored in the DynamoDB lookup table only as
+  SHA-256 digests — no plaintext copy. This is pseudonymisation, not
+  anonymisation: low-entropy values remain dictionary-attackable, and the
+  properties table itself stores values in plaintext, so include *both*
+  tables in your data map. On PostgreSQL the lookup table stores plaintext
+  values (same database and access surface as the properties table).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.12.0"
+version = "3.13.0rc1"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@actingweb.io>"]
 maintainers = ["Greger Wedel <support@actingweb.io>"]

--- a/scripts/backfill_property_lookup.py
+++ b/scripts/backfill_property_lookup.py
@@ -42,6 +42,7 @@ import sys
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any
 
 logging.basicConfig(
     level=os.getenv("LOG_LEVEL", "INFO"),
@@ -76,7 +77,9 @@ class Checkpoint:
     def __init__(self, path: str | None, total_segments: int) -> None:
         self._path = path
         self._lock = threading.Lock()
-        self._state: dict[str, object] = {}
+        # Per-segment value is the DynamoDB last_evaluated_key (a key dict)
+        # or the "done" sentinel once the segment is exhausted.
+        self._state: dict[str, dict[str, Any] | str] = {}
         if path and os.path.exists(path):
             try:
                 with open(path) as f:
@@ -90,10 +93,10 @@ class Checkpoint:
                 logger.warning(f"Could not read checkpoint {path}: {e}")
         self._total_segments = total_segments
 
-    def get(self, segment: int):
+    def get(self, segment: int) -> dict[str, Any] | str | None:
         return self._state.get(str(segment))
 
-    def set(self, segment: int, last_evaluated_key) -> None:
+    def set(self, segment: int, last_evaluated_key: dict[str, Any] | None) -> None:
         with self._lock:
             self._state[str(segment)] = (
                 last_evaluated_key if last_evaluated_key is not None else "done"

--- a/scripts/backfill_property_lookup.py
+++ b/scripts/backfill_property_lookup.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""
+Backfill the v2 property lookup table from the properties table.
+
+The properties table is the source of truth: this script scans it for
+indexed properties and writes v2 digest-keyed lookup rows
+(sha256(name + NUL + value)). v1 lookup rows are never read as input.
+Values are copied VERBATIM — no re-encoding, no normalisation, no
+lowercasing — because runtime lookups are exact-match against the stored
+string.
+
+Run it with the SAME environment as the application (AWS_DB_PREFIX,
+AWS_DEFAULT_REGION, AWS_DB_HOST, INDEXED_PROPERTIES, credentials), e.g.::
+
+    poetry run python scripts/backfill_property_lookup.py --dry-run
+    poetry run python scripts/backfill_property_lookup.py --rps 50
+
+Features:
+- streaming (never accumulates the table in memory)
+- --rps rate limit (items/second across all segments; a full-table scan
+  against production must not brown-out serving traffic or run up an
+  unbounded on-demand bill)
+- --segments N parallel scan segments
+- checkpointed resume: per-segment last_evaluated_key persisted to
+  --checkpoint-file after every page; re-running continues where it left
+  off
+- idempotent: conditional puts — an identical existing mapping counts as
+  ok; a row owned by a DIFFERENT actor is reported as a collision and NOT
+  overwritten (resolve manually, then re-run)
+- --dry-run reports what would be written without writing
+
+Exit code 0 on success with no collisions/errors, 1 otherwise.
+After a clean run, verify reverse lookups resolve without deprecation
+warnings, then drop the v1 ``<prefix>_property_lookup`` table.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+logging.basicConfig(
+    level=os.getenv("LOG_LEVEL", "INFO"),
+    format="%(asctime)s %(levelname)s %(message)s",
+)
+logger = logging.getLogger("backfill_property_lookup")
+
+
+class RateLimiter:
+    """Simple thread-safe items/second limiter shared across segments."""
+
+    def __init__(self, rps: float | None) -> None:
+        self._interval = 1.0 / rps if rps and rps > 0 else 0.0
+        self._lock = threading.Lock()
+        self._next_at = 0.0
+
+    def wait(self) -> None:
+        if not self._interval:
+            return
+        with self._lock:
+            now = time.monotonic()
+            wake_at = max(self._next_at, now)
+            self._next_at = wake_at + self._interval
+        delay = wake_at - time.monotonic()
+        if delay > 0:
+            time.sleep(delay)
+
+
+class Checkpoint:
+    """Per-segment last_evaluated_key persistence for resume."""
+
+    def __init__(self, path: str | None, total_segments: int) -> None:
+        self._path = path
+        self._lock = threading.Lock()
+        self._state: dict[str, object] = {}
+        if path and os.path.exists(path):
+            try:
+                with open(path) as f:
+                    saved = json.load(f)
+                if saved.get("total_segments") == total_segments:
+                    self._state = saved.get("segments", {})
+                    logger.info(f"Resuming from checkpoint {path}")
+                else:
+                    logger.warning("Checkpoint segment count mismatch — starting over")
+            except Exception as e:
+                logger.warning(f"Could not read checkpoint {path}: {e}")
+        self._total_segments = total_segments
+
+    def get(self, segment: int):
+        return self._state.get(str(segment))
+
+    def set(self, segment: int, last_evaluated_key) -> None:
+        with self._lock:
+            self._state[str(segment)] = (
+                last_evaluated_key if last_evaluated_key is not None else "done"
+            )
+            if self._path:
+                tmp = f"{self._path}.tmp"
+                with open(tmp, "w") as f:
+                    json.dump(
+                        {
+                            "total_segments": self._total_segments,
+                            "segments": self._state,
+                        },
+                        f,
+                    )
+                os.replace(tmp, self._path)
+
+
+class Stats:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self.scanned = 0
+        self.matched = 0
+        self.written = 0
+        self.collisions: list[str] = []
+        self.errors = 0
+
+    def bump(self, field: str, amount: int = 1) -> None:
+        with self._lock:
+            setattr(self, field, getattr(self, field) + amount)
+
+    def collision(self, detail: str) -> None:
+        with self._lock:
+            self.collisions.append(detail)
+
+
+def run_segment(
+    segment: int,
+    total_segments: int,
+    indexed: set[str],
+    limiter: RateLimiter,
+    checkpoint: Checkpoint,
+    stats: Stats,
+    dry_run: bool,
+) -> None:
+    # Imported here so env validation in main() runs first
+    from actingweb.db.dynamodb.property import Property
+    from actingweb.db.dynamodb.property_lookup import (
+        DbPropertyLookup,
+        compute_lookup_key,
+    )
+
+    start_key = checkpoint.get(segment)
+    if start_key == "done":
+        logger.info(f"segment {segment}: already complete (checkpoint)")
+        return
+    if not isinstance(start_key, dict):
+        start_key = None
+
+    lookup = DbPropertyLookup() if not dry_run else None
+    results = Property.scan(
+        segment=segment,
+        total_segments=total_segments,
+        last_evaluated_key=start_key,
+    )
+    pages_since_checkpoint = 0
+    for item in results:
+        stats.bump("scanned")
+        name = str(item.name) if item.name else ""
+        if name in indexed and item.value:
+            stats.bump("matched")
+            value = str(item.value)  # verbatim — exactly as stored
+            actor_id = str(item.id)
+            limiter.wait()
+            if dry_run:
+                stats.bump("written")
+            else:
+                assert lookup is not None
+                if lookup.create(property_name=name, value=value, actor_id=actor_id):
+                    stats.bump("written")
+                else:
+                    # create() logs LOOKUP_COLLISION or LOOKUP_CREATE_FAILED
+                    stats.collision(
+                        f"property={name} actor={actor_id} "
+                        f"digest={compute_lookup_key(name, value)[:12]}"
+                    )
+        pages_since_checkpoint += 1
+        if pages_since_checkpoint >= 100:
+            pages_since_checkpoint = 0
+            checkpoint.set(segment, results.last_evaluated_key)
+    checkpoint.set(segment, None)  # done
+    logger.info(f"segment {segment}: complete")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill the v2 property lookup table from properties."
+    )
+    parser.add_argument("--dry-run", action="store_true", help="count, do not write")
+    parser.add_argument(
+        "--rps",
+        type=float,
+        default=25.0,
+        help="max indexed items processed per second across all segments "
+        "(default 25; 0 = unlimited)",
+    )
+    parser.add_argument(
+        "--segments",
+        type=int,
+        default=4,
+        help="parallel scan segments (default 4)",
+    )
+    parser.add_argument(
+        "--checkpoint-file",
+        default=".backfill_property_lookup.checkpoint.json",
+        help="resume state file (default .backfill_property_lookup.checkpoint.json)",
+    )
+    parser.add_argument(
+        "--properties",
+        default=None,
+        help="comma-separated indexed property names (default: resolved "
+        "from INDEXED_PROPERTIES env or the library default)",
+    )
+    args = parser.parse_args()
+
+    if args.properties:
+        indexed = {p.strip() for p in args.properties.split(",") if p.strip()}
+    else:
+        from actingweb.config import Config
+
+        indexed = set(Config(database="dynamodb").indexed_properties)
+    if not indexed:
+        logger.error("No indexed properties configured — nothing to backfill")
+        return 1
+
+    prefix = os.getenv("AWS_DB_PREFIX", "demo_actingweb")
+    logger.info(
+        f"Backfilling {prefix}_property_lookup_v2 from {prefix}_properties; "
+        f"indexed properties: {sorted(indexed)}; "
+        f"{'DRY RUN' if args.dry_run else 'writing'}; "
+        f"rps={args.rps} segments={args.segments}"
+    )
+
+    limiter = RateLimiter(args.rps)
+    checkpoint = Checkpoint(
+        args.checkpoint_file if not args.dry_run else None, args.segments
+    )
+    stats = Stats()
+
+    with ThreadPoolExecutor(max_workers=args.segments) as pool:
+        futures = [
+            pool.submit(
+                run_segment,
+                seg,
+                args.segments,
+                indexed,
+                limiter,
+                checkpoint,
+                stats,
+                args.dry_run,
+            )
+            for seg in range(args.segments)
+        ]
+        for future in futures:
+            try:
+                future.result()
+            except Exception as e:
+                logger.error(f"Segment failed: {e}")
+                stats.bump("errors")
+
+    logger.info(
+        f"Summary: scanned={stats.scanned} indexed-matches={stats.matched} "
+        f"{'would-write' if args.dry_run else 'written-or-present'}="
+        f"{stats.written} collisions={len(stats.collisions)} "
+        f"segment-errors={stats.errors}"
+    )
+    for detail in stats.collisions:
+        logger.warning(f"COLLISION (not overwritten): {detail}")
+    if stats.collisions:
+        logger.warning(
+            "Collisions mean two actors share an indexed value; the earlier "
+            "lookup row was kept. Resolve manually, then re-run (idempotent)."
+        )
+    if not args.dry_run and not stats.collisions and not stats.errors:
+        logger.info(
+            "Backfill complete. Verify reverse lookups resolve without "
+            "deprecation warnings, then drop the v1 "
+            f"{prefix}_property_lookup table."
+        )
+        if os.path.exists(args.checkpoint_file):
+            os.unlink(args.checkpoint_file)
+    return 1 if (stats.collisions or stats.errors) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/migrate_db.py
+++ b/scripts/migrate_db.py
@@ -87,7 +87,9 @@ def run_alembic(alembic_ini, args):
 
     print(f"🔧 Running: alembic {' '.join(alembic_args)}")
     print(f"📁 Config: {alembic_ini}")
-    print(f"🗄️  Database: {os.getenv('PG_DB_NAME')} @ {os.getenv('PG_DB_HOST')}:{os.getenv('PG_DB_PORT')}")
+    print(
+        f"🗄️  Database: {os.getenv('PG_DB_NAME')} @ {os.getenv('PG_DB_HOST')}:{os.getenv('PG_DB_PORT')}"
+    )
     print()
 
     try:
@@ -95,10 +97,11 @@ def run_alembic(alembic_ini, args):
         print("\n✅ Migration completed successfully")
     except Exception as e:
         import traceback
+
         print(f"\n❌ Migration failed: {e}")
-        print("\n" + "="*60)
+        print("\n" + "=" * 60)
         print("Full error traceback:")
-        print("="*60)
+        print("=" * 60)
         traceback.print_exc()
         sys.exit(1)
 
@@ -108,6 +111,7 @@ def main():
     # Load .env file if it exists
     try:
         from dotenv import load_dotenv
+
         if Path(".env").exists():
             load_dotenv()
             print("✅ Loaded environment variables from .env")

--- a/scripts/migrate_dynamodb_to_postgresql.py
+++ b/scripts/migrate_dynamodb_to_postgresql.py
@@ -93,7 +93,9 @@ def export_dynamodb(
             TrustModel,  # type: ignore[import-untyped]
         )
     except ImportError as e:
-        logger.error("Failed to import DynamoDB models. Install with: poetry install --extras dynamodb")
+        logger.error(
+            "Failed to import DynamoDB models. Install with: poetry install --extras dynamodb"
+        )
         logger.error("Error: %s", e)
         sys.exit(1)
 
@@ -128,13 +130,17 @@ def export_dynamodb(
 
             count = len(records)
             total_records += count
-            logger.info("Exported %d records from %s to %s", count, table_name, output_file)
+            logger.info(
+                "Exported %d records from %s to %s", count, table_name, output_file
+            )
 
         except Exception as e:
             logger.error("Failed to export %s: %s", table_name, e)
             raise
 
-    logger.info("Export complete: %d total records exported to %s", total_records, output_dir)
+    logger.info(
+        "Export complete: %d total records exported to %s", total_records, output_dir
+    )
 
 
 def import_postgresql(
@@ -172,7 +178,9 @@ def import_postgresql(
     try:
         from actingweb.db.postgresql.connection import get_connection
     except ImportError as e:
-        logger.error("Failed to import PostgreSQL dependencies. Install with: poetry install --extras postgresql")
+        logger.error(
+            "Failed to import PostgreSQL dependencies. Install with: poetry install --extras postgresql"
+        )
         logger.error("Error: %s", e)
         sys.exit(1)
 
@@ -220,13 +228,21 @@ def import_postgresql(
                         if table_name == "actors":
                             cur.execute(
                                 "INSERT INTO actors (id, creator, passphrase) VALUES (%s, %s, %s)",
-                                (record.get("id"), record.get("creator"), record.get("passphrase")),
+                                (
+                                    record.get("id"),
+                                    record.get("creator"),
+                                    record.get("passphrase"),
+                                ),
                             )
 
                         elif table_name == "properties":
                             cur.execute(
                                 "INSERT INTO properties (id, name, value) VALUES (%s, %s, %s)",
-                                (record.get("id"), record.get("name"), record.get("value")),
+                                (
+                                    record.get("id"),
+                                    record.get("name"),
+                                    record.get("value"),
+                                ),
                             )
 
                         elif table_name == "attributes":
@@ -243,7 +259,9 @@ def import_postgresql(
                                     bucket_name,
                                     record.get("bucket"),
                                     record.get("name"),
-                                    json.dumps(record.get("data")) if record.get("data") else None,
+                                    json.dumps(record.get("data"))
+                                    if record.get("data")
+                                    else None,
                                     record.get("timestamp"),
                                     record.get("ttl_timestamp"),
                                 ),
@@ -302,7 +320,9 @@ def import_postgresql(
 
                         elif table_name == "subscriptions":
                             # Convert peer_sub_id composite key
-                            peer_sub_id = f"{record.get('peerid')}:{record.get('subid')}"
+                            peer_sub_id = (
+                                f"{record.get('peerid')}:{record.get('subid')}"
+                            )
                             cur.execute(
                                 """
                                 INSERT INTO subscriptions
@@ -349,18 +369,26 @@ def import_postgresql(
                             skipped += 1
                             logger.debug("Skipped duplicate: %s", record)
                         else:
-                            logger.error("Failed to import record from %s: %s", table_name, e)
+                            logger.error(
+                                "Failed to import record from %s: %s", table_name, e
+                            )
                             logger.error("Record: %s", record)
                             raise
 
                 # Commit after each table
                 conn.commit()
 
-        logger.info("Imported %d records from %s (%d skipped)", imported, table_name, skipped)
+        logger.info(
+            "Imported %d records from %s (%d skipped)", imported, table_name, skipped
+        )
         total_imported += imported
         total_skipped += skipped
 
-    logger.info("Import complete: %d total records imported, %d skipped", total_imported, total_skipped)
+    logger.info(
+        "Import complete: %d total records imported, %d skipped",
+        total_imported,
+        total_skipped,
+    )
 
 
 def validate_migration(
@@ -399,7 +427,9 @@ def validate_migration(
     try:
         from actingweb.db.postgresql.connection import get_connection
     except ImportError as e:
-        logger.error("Failed to import PostgreSQL dependencies. Install with: poetry install --extras postgresql")
+        logger.error(
+            "Failed to import PostgreSQL dependencies. Install with: poetry install --extras postgresql"
+        )
         logger.error("Error: %s", e)
         sys.exit(1)
 
@@ -423,7 +453,9 @@ def validate_migration(
                 json_file = input_path / f"{table_name}.json"
 
                 if not json_file.exists():
-                    logger.warning("File not found: %s (skipping validation)", json_file)
+                    logger.warning(
+                        "File not found: %s (skipping validation)", json_file
+                    )
                     continue
 
                 # Load JSON data
@@ -440,7 +472,12 @@ def validate_migration(
                 if json_count == pg_count:
                     logger.info("✓ %s: %d records (match)", table_name, pg_count)
                 else:
-                    logger.error("✗ %s: JSON=%d, PostgreSQL=%d (MISMATCH)", table_name, json_count, pg_count)
+                    logger.error(
+                        "✗ %s: JSON=%d, PostgreSQL=%d (MISMATCH)",
+                        table_name,
+                        json_count,
+                        pg_count,
+                    )
                     all_valid = False
 
                 # Sample validation (check first record exists)
@@ -448,7 +485,10 @@ def validate_migration(
                     first_record = records[0]
 
                     if table_name == "actors":
-                        cur.execute("SELECT id FROM actors WHERE id = %s", (first_record.get("id"),))
+                        cur.execute(
+                            "SELECT id FROM actors WHERE id = %s",
+                            (first_record.get("id"),),
+                        )
                     elif table_name == "properties":
                         cur.execute(
                             "SELECT id FROM properties WHERE id = %s AND name = %s",

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -133,6 +133,12 @@ def cleanup_dynamodb_tables(worker_info: dict) -> None:
     """
     import boto3
 
+    from actingweb.db.dynamodb._ensure import reset_ensure_cache
+
+    # Tables are deleted in-process below; the process-wide ensure_table()
+    # memo must forget them or later accessors would skip re-creation.
+    reset_ensure_cache()
+
     client = boto3.client(
         "dynamodb",
         region_name="us-west-1",
@@ -312,7 +318,21 @@ def setup_database(docker_services, worker_info):
 
     For PostgreSQL: Runs migrations to create tables with worker-specific schema.
     For DynamoDB: Pre-cleanup stale tables from previous failed runs.
+
+    Sets the backend env vars FIRST: pynamodb model classes freeze
+    AWS_DB_PREFIX / AWS_DB_HOST into Meta at import time, and importing
+    anything under actingweb.db.dynamodb (e.g. the ensure-cache reset in
+    cleanup_dynamodb_tables) imports every model module via the package
+    __init__. If the env is not set before that first import, every model
+    binds to the default prefix and to real AWS for the whole process.
     """
+    os.environ["DATABASE_BACKEND"] = DATABASE_BACKEND
+    if DATABASE_BACKEND == "dynamodb":
+        os.environ["AWS_ACCESS_KEY_ID"] = "test"
+        os.environ["AWS_SECRET_ACCESS_KEY"] = "test"
+        os.environ["AWS_DB_HOST"] = TEST_DYNAMODB_HOST
+        os.environ["AWS_DB_PREFIX"] = worker_info["db_prefix"]
+
     if DATABASE_BACKEND == "postgresql":
         # Pre-cleanup: Drop schema from previous failed run
         schema_name = f"{worker_info['db_prefix']}public"

--- a/tests/test_billing_mode.py
+++ b/tests/test_billing_mode.py
@@ -1,0 +1,86 @@
+"""
+Auto-created DynamoDB tables must use on-demand (PAY_PER_REQUEST) billing.
+
+The old Meta defaults created provisioned tables with tiny fixed
+capacities (e.g. the property lookup table at 2 RCU / 1 WCU — a hard
+throughput wall on the login path). A library cannot know its consumers'
+traffic shape; on-demand is the only safe default. Existing tables are
+unaffected (DynamoDB never alters live tables) — the migration doc covers
+the one-time update-table conversion.
+"""
+
+import os
+
+import pytest
+
+from actingweb.db.dynamodb import _ensure
+
+
+@pytest.fixture(autouse=True)
+def _require_dynamodb():
+    if os.getenv("DATABASE_BACKEND", "dynamodb") != "dynamodb":
+        pytest.skip("DynamoDB-only test")
+
+
+def _boto_client():
+    import boto3
+
+    return boto3.client(
+        "dynamodb",
+        region_name=os.getenv("AWS_DEFAULT_REGION", "us-west-1"),
+        endpoint_url=os.getenv("AWS_DB_HOST", "http://localhost:8001"),
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID", "test"),
+        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY", "test"),
+    )
+
+
+def test_fresh_table_is_on_demand():
+    """Delete + recreate the suspension table and verify billing mode."""
+    from actingweb.db.dynamodb.subscription_suspension import (
+        DbSubscriptionSuspension,
+        SubscriptionSuspension,
+    )
+
+    client = _boto_client()
+    table_name = SubscriptionSuspension.Meta.table_name
+
+    try:
+        client.delete_table(TableName=table_name)
+        client.get_waiter("table_not_exists").wait(
+            TableName=table_name, WaiterConfig={"Delay": 1, "MaxAttempts": 15}
+        )
+    except client.exceptions.ResourceNotFoundException:
+        pass
+    _ensure.reset_ensure_cache()
+
+    # Accessor construction auto-creates the table
+    DbSubscriptionSuspension("billing-test-actor")
+
+    desc = client.describe_table(TableName=table_name)["Table"]
+    assert desc.get("BillingModeSummary", {}).get("BillingMode") == "PAY_PER_REQUEST"
+
+
+def test_fresh_table_with_gsi_is_on_demand():
+    """A model with a GSI must create table AND index without throughput."""
+    from actingweb.db.dynamodb.actor import Actor, DbActor
+
+    client = _boto_client()
+    table_name = Actor.Meta.table_name
+
+    try:
+        client.delete_table(TableName=table_name)
+        client.get_waiter("table_not_exists").wait(
+            TableName=table_name, WaiterConfig={"Delay": 1, "MaxAttempts": 15}
+        )
+    except client.exceptions.ResourceNotFoundException:
+        pass
+    _ensure.reset_ensure_cache()
+
+    DbActor()
+
+    desc = client.describe_table(TableName=table_name)["Table"]
+    assert desc.get("BillingModeSummary", {}).get("BillingMode") == "PAY_PER_REQUEST"
+    for gsi in desc.get("GlobalSecondaryIndexes", []):
+        throughput = gsi.get("ProvisionedThroughput", {})
+        assert throughput.get("ReadCapacityUnits", 0) == 0
+        assert throughput.get("WriteCapacityUnits", 0) == 0

--- a/tests/test_billing_mode.py
+++ b/tests/test_billing_mode.py
@@ -7,11 +7,21 @@ throughput wall on the login path). A library cannot know its consumers'
 traffic shape; on-demand is the only safe default. Existing tables are
 unaffected (DynamoDB never alters live tables) — the migration doc covers
 the one-time update-table conversion.
+
+These tests create throwaway clone tables mirroring the production model
+Metas — shared unit-test tables must never be deleted mid-run (other
+xdist workers use them concurrently).
 """
 
 import os
+import uuid
+from typing import Any
 
 import pytest
+from pynamodb.attributes import UnicodeAttribute
+from pynamodb.constants import PAY_PER_REQUEST_BILLING_MODE
+from pynamodb.indexes import AllProjection, GlobalSecondaryIndex
+from pynamodb.models import Model
 
 from actingweb.db.dynamodb import _ensure
 
@@ -34,53 +44,115 @@ def _boto_client():
     )
 
 
-def test_fresh_table_is_on_demand():
-    """Delete + recreate the suspension table and verify billing mode."""
-    from actingweb.db.dynamodb.subscription_suspension import (
-        DbSubscriptionSuspension,
-        SubscriptionSuspension,
+def test_production_model_metas_declare_on_demand():
+    """Every real model Meta must carry the on-demand billing mode (and no
+    stale provisioned capacity values)."""
+    from actingweb.db.dynamodb import (
+        Actor,
+        Attribute,
+        PeerTrustee,
+        Property,
+        PropertyLegacy,
+        PropertyLookup,
+        PropertyLookupV2,
+        Subscription,
+        SubscriptionDiff,
+        Trust,
     )
+    from actingweb.db.dynamodb.subscription_suspension import SubscriptionSuspension
 
-    client = _boto_client()
-    table_name = SubscriptionSuspension.Meta.table_name
+    for model in (
+        Actor,
+        Attribute,
+        PeerTrustee,
+        Property,
+        PropertyLegacy,
+        PropertyLookup,
+        PropertyLookupV2,
+        Subscription,
+        SubscriptionDiff,
+        SubscriptionSuspension,
+        Trust,
+    ):
+        assert getattr(model.Meta, "billing_mode", None) == "PAY_PER_REQUEST", (
+            model.__name__
+        )
+        assert not hasattr(model.Meta, "read_capacity_units"), model.__name__
+        assert not hasattr(model.Meta, "write_capacity_units"), model.__name__
+
+
+@pytest.fixture
+def clone_table_name():
+    return f"awtest_billing_{uuid.uuid4().hex[:12]}"
+
+
+def test_fresh_table_is_on_demand(clone_table_name):
+    """A table created via ensure_table with the standard Meta shape comes
+    up PAY_PER_REQUEST."""
+    table = clone_table_name
+    aws_region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
+    db_host = os.getenv("AWS_DB_HOST", "http://localhost:8001")
+
+    class CloneSimple(Model):
+        class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+            table_name = table
+            billing_mode = PAY_PER_REQUEST_BILLING_MODE
+            region = aws_region
+            host = db_host
+
+        id = UnicodeAttribute(hash_key=True)
+        name = UnicodeAttribute(range_key=True)
 
     try:
-        client.delete_table(TableName=table_name)
-        client.get_waiter("table_not_exists").wait(
-            TableName=table_name, WaiterConfig={"Delay": 1, "MaxAttempts": 15}
+        _ensure.ensure_table(CloneSimple)
+        desc = _boto_client().describe_table(TableName=table)["Table"]
+        assert (
+            desc.get("BillingModeSummary", {}).get("BillingMode") == "PAY_PER_REQUEST"
         )
-    except client.exceptions.ResourceNotFoundException:
-        pass
-    _ensure.reset_ensure_cache()
-
-    # Accessor construction auto-creates the table
-    DbSubscriptionSuspension("billing-test-actor")
-
-    desc = client.describe_table(TableName=table_name)["Table"]
-    assert desc.get("BillingModeSummary", {}).get("BillingMode") == "PAY_PER_REQUEST"
+    finally:
+        try:
+            CloneSimple.delete_table()
+        except Exception:
+            pass
 
 
-def test_fresh_table_with_gsi_is_on_demand():
-    """A model with a GSI must create table AND index without throughput."""
-    from actingweb.db.dynamodb.actor import Actor, DbActor
+def test_fresh_table_with_gsi_is_on_demand(clone_table_name):
+    """A model with a GSI must create table AND index without provisioned
+    throughput."""
+    table = clone_table_name
+    aws_region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
+    db_host = os.getenv("AWS_DB_HOST", "http://localhost:8001")
 
-    client = _boto_client()
-    table_name = Actor.Meta.table_name
+    class CloneIndex(GlobalSecondaryIndex[Any]):
+        class Meta:
+            index_name = "clone-index"
+            projection = AllProjection()
+
+        creator = UnicodeAttribute(default="0", hash_key=True)
+
+    class CloneWithGsi(Model):
+        class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+            table_name = table
+            billing_mode = PAY_PER_REQUEST_BILLING_MODE
+            region = aws_region
+            host = db_host
+
+        id = UnicodeAttribute(hash_key=True)
+        creator = UnicodeAttribute()
+        clone_index = CloneIndex()
 
     try:
-        client.delete_table(TableName=table_name)
-        client.get_waiter("table_not_exists").wait(
-            TableName=table_name, WaiterConfig={"Delay": 1, "MaxAttempts": 15}
+        _ensure.ensure_table(CloneWithGsi)
+        desc = _boto_client().describe_table(TableName=table)["Table"]
+        assert (
+            desc.get("BillingModeSummary", {}).get("BillingMode") == "PAY_PER_REQUEST"
         )
-    except client.exceptions.ResourceNotFoundException:
-        pass
-    _ensure.reset_ensure_cache()
-
-    DbActor()
-
-    desc = client.describe_table(TableName=table_name)["Table"]
-    assert desc.get("BillingModeSummary", {}).get("BillingMode") == "PAY_PER_REQUEST"
-    for gsi in desc.get("GlobalSecondaryIndexes", []):
-        throughput = gsi.get("ProvisionedThroughput", {})
-        assert throughput.get("ReadCapacityUnits", 0) == 0
-        assert throughput.get("WriteCapacityUnits", 0) == 0
+        for gsi in desc.get("GlobalSecondaryIndexes", []):
+            throughput = gsi.get("ProvisionedThroughput", {})
+            assert throughput.get("ReadCapacityUnits", 0) == 0
+            assert throughput.get("WriteCapacityUnits", 0) == 0
+    finally:
+        try:
+            CloneWithGsi.delete_table()
+        except Exception:
+            pass

--- a/tests/test_conditional_gsi_schema.py
+++ b/tests/test_conditional_gsi_schema.py
@@ -1,0 +1,152 @@
+"""
+Conditional GSI schema: the properties-table shape must match the
+configured reverse-lookup mode.
+
+Lookup-table mode creates the table WITHOUT the legacy value-keyed
+``property-index`` GSI (no write/storage amplification, no 2048-byte
+GSI-key write rejection on real AWS); legacy mode creates it WITH the
+GSI so the legacy reverse-lookup path works. Existing tables are never
+altered.
+
+These tests use throwaway clone models with unique table names — the
+shared unit-test properties table must never be deleted or recreated
+mid-run (other xdist workers use it concurrently), and its shape is
+whatever the first creator chose.
+"""
+
+import os
+import uuid
+from typing import Any
+from unittest import mock
+
+import pytest
+from pynamodb.attributes import UnicodeAttribute
+from pynamodb.constants import PAY_PER_REQUEST_BILLING_MODE
+from pynamodb.indexes import AllProjection, GlobalSecondaryIndex
+from pynamodb.models import Model
+
+from actingweb.db.dynamodb import _ensure
+
+
+@pytest.fixture(autouse=True)
+def _require_dynamodb():
+    if os.getenv("DATABASE_BACKEND", "dynamodb") != "dynamodb":
+        pytest.skip("DynamoDB-only test")
+
+
+def _make_clone_models(table_name: str):
+    """Build GSI-less and GSI'd model clones bound to the same table name,
+    mirroring actingweb.db.dynamodb.property.Property / PropertyLegacy."""
+
+    clone_table = table_name
+    clone_region = os.getenv("AWS_DEFAULT_REGION", "us-west-1")
+    clone_host = os.getenv("AWS_DB_HOST", "http://localhost:8001")
+
+    class CloneIndex(GlobalSecondaryIndex[Any]):
+        class Meta:
+            index_name = "property-index"
+            projection = AllProjection()
+
+        value = UnicodeAttribute(default="0", hash_key=True)
+
+    class CloneNoGsi(Model):
+        class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+            table_name = clone_table
+            billing_mode = PAY_PER_REQUEST_BILLING_MODE
+            region = clone_region
+            host = clone_host
+
+        id = UnicodeAttribute(hash_key=True)
+        name = UnicodeAttribute(range_key=True)
+        value = UnicodeAttribute()
+
+    class CloneWithGsi(Model):
+        class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+            table_name = clone_table
+            billing_mode = PAY_PER_REQUEST_BILLING_MODE
+            region = clone_region
+            host = clone_host
+
+        id = UnicodeAttribute(hash_key=True)
+        name = UnicodeAttribute(range_key=True)
+        value = UnicodeAttribute()
+        property_index = CloneIndex()
+
+    return CloneNoGsi, CloneWithGsi
+
+
+@pytest.fixture
+def clone_models():
+    table_name = f"awtest_gsi_{uuid.uuid4().hex[:12]}"
+    no_gsi, with_gsi = _make_clone_models(table_name)
+    yield no_gsi, with_gsi
+    for model in (no_gsi, with_gsi):
+        try:
+            model.delete_table()
+            break
+        except Exception:
+            continue
+
+
+def _boto_client():
+    import boto3
+
+    return boto3.client(
+        "dynamodb",
+        region_name=os.getenv("AWS_DEFAULT_REGION", "us-west-1"),
+        endpoint_url=os.getenv("AWS_DB_HOST", "http://localhost:8001"),
+        aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID", "test"),
+        aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY", "test"),
+    )
+
+
+def test_lookup_shape_has_no_gsi(clone_models):
+    no_gsi, _ = clone_models
+    _ensure.ensure_table(no_gsi)
+    desc = _boto_client().describe_table(TableName=no_gsi.Meta.table_name)["Table"]
+    assert desc.get("GlobalSecondaryIndexes") is None
+    # No GSI key constraint: large values store fine (note: DynamoDB Local
+    # does not enforce the 2048-byte GSI-key limit either way, so the
+    # meaningful assertion is the table shape above; on real AWS the limit
+    # only exists when the GSI does).
+    big = "x" * 5000
+    no_gsi(id="actor-a", name="bigprop", value=big).save()
+    assert no_gsi.get("actor-a", "bigprop").value == big
+
+
+def test_legacy_shape_has_gsi_and_serves_reverse_lookup(clone_models):
+    _, with_gsi = clone_models
+    _ensure.ensure_table(with_gsi)
+    desc = _boto_client().describe_table(TableName=with_gsi.Meta.table_name)["Table"]
+    gsis = desc.get("GlobalSecondaryIndexes") or []
+    assert [g["IndexName"] for g in gsis] == ["property-index"]
+
+    value = f"legacy-{uuid.uuid4()}"
+    with_gsi(id="actor-b", name="oauthId", value=value).save()
+    hits = [str(r.id) for r in with_gsi.property_index.query(value)]
+    assert hits == ["actor-b"]
+
+
+def test_first_creator_wins_shape(clone_models):
+    """Mixing modes in one process: the first creator fixes the schema;
+    the second mode's ensure must not alter the live table."""
+    no_gsi, with_gsi = clone_models
+    _ensure.ensure_table(no_gsi)
+    _ensure.ensure_table(with_gsi)  # table exists — must be a no-op
+    desc = _boto_client().describe_table(TableName=no_gsi.Meta.table_name)["Table"]
+    assert desc.get("GlobalSecondaryIndexes") is None
+
+
+class TestAccessorWiring:
+    """DbProperty/DbPropertyList must ensure the mode-appropriate class."""
+
+    @pytest.mark.parametrize("accessor_name", ["DbProperty", "DbPropertyList"])
+    @pytest.mark.parametrize("use_lookup", [True, False])
+    def test_mode_selects_schema_class(self, accessor_name, use_lookup):
+        from actingweb.db.dynamodb import property as prop_mod
+
+        with mock.patch.object(prop_mod, "ensure_table") as ensure_spy:
+            accessor_cls = getattr(prop_mod, accessor_name)
+            accessor_cls(use_lookup_table=use_lookup, indexed_properties=["email"])
+        expected = prop_mod.Property if use_lookup else prop_mod.PropertyLegacy
+        ensure_spy.assert_called_once_with(expected)

--- a/tests/test_ensure_table.py
+++ b/tests/test_ensure_table.py
@@ -1,0 +1,193 @@
+"""
+Tests for the process-wide DynamoDB table-existence guard (_ensure.py).
+
+The guard replaces the per-accessor `if not Model.exists(): create_table()`
+pattern (one live DescribeTable per accessor construction) with at most one
+check per model class per process, plus an opt-out for IaC-managed
+deployments (AWS_DB_AUTO_CREATE_TABLES / with_dynamodb()).
+"""
+
+import threading
+from unittest import mock
+
+import pytest
+
+from actingweb.db.dynamodb import _ensure
+
+
+@pytest.fixture(autouse=True)
+def clean_ensure_state(monkeypatch):
+    """Reset module-level guard state around every test."""
+    monkeypatch.delenv("AWS_DB_AUTO_CREATE_TABLES", raising=False)
+    _ensure.reset_ensure_cache()
+    _ensure._auto_create_override = None
+    _ensure._flag_logged = False
+    yield
+    _ensure.reset_ensure_cache()
+    _ensure._auto_create_override = None
+    _ensure._flag_logged = False
+
+
+def make_fake_model(name: str = "faketable", exists: bool = False):
+    """Build a stand-in model class with call-counting exists/create_table."""
+    # Bind under a different name: a class-body assignment named `exists`
+    # cannot read the enclosing function's `exists` parameter.
+    table_exists = exists
+
+    class FakeModel:
+        class Meta:
+            table_name = name
+
+        exists = mock.MagicMock(return_value=table_exists)
+        create_table = mock.MagicMock()
+
+    return FakeModel
+
+
+class TestEnsureTableMemoisation:
+    def test_exists_called_at_most_once(self):
+        model = make_fake_model(exists=True)
+        for _ in range(50):
+            _ensure.ensure_table(model)  # type: ignore[arg-type]
+        assert model.exists.call_count == 1
+        model.create_table.assert_not_called()
+
+    def test_creates_table_when_absent(self):
+        model = make_fake_model(exists=False)
+        _ensure.ensure_table(model)  # type: ignore[arg-type]
+        model.create_table.assert_called_once_with(wait=True)
+        # Second call is fully memoised
+        _ensure.ensure_table(model)  # type: ignore[arg-type]
+        assert model.exists.call_count == 1
+
+    def test_resource_in_use_race_is_benign(self):
+        model = make_fake_model(exists=False)
+        model.create_table.side_effect = Exception("ResourceInUseException: race")
+        _ensure.ensure_table(model)  # type: ignore[arg-type]
+        # Memoised as success despite the benign race
+        _ensure.ensure_table(model)  # type: ignore[arg-type]
+        assert model.exists.call_count == 1
+
+    def test_other_errors_propagate_and_are_not_cached(self):
+        model = make_fake_model(exists=False)
+        model.create_table.side_effect = Exception("AccessDeniedException: nope")
+        with pytest.raises(Exception, match="AccessDenied"):
+            _ensure.ensure_table(model)  # type: ignore[arg-type]
+        # Negative result must not be cached: next call re-checks
+        model.create_table.side_effect = None
+        _ensure.ensure_table(model)  # type: ignore[arg-type]
+        assert model.exists.call_count == 2
+
+    def test_distinct_models_tracked_independently(self):
+        model_a = make_fake_model("shared_table", exists=True)
+        model_b = make_fake_model("shared_table", exists=True)
+        _ensure.ensure_table(model_a)  # type: ignore[arg-type]
+        _ensure.ensure_table(model_b)  # type: ignore[arg-type]
+        # Keyed by class, not table name: both get their own check
+        assert model_a.exists.call_count == 1
+        assert model_b.exists.call_count == 1
+
+    def test_reset_ensure_cache_forces_recheck(self):
+        model = make_fake_model(exists=True)
+        _ensure.ensure_table(model)  # type: ignore[arg-type]
+        _ensure.reset_ensure_cache()
+        _ensure.ensure_table(model)  # type: ignore[arg-type]
+        assert model.exists.call_count == 2
+
+    def test_thread_safety_single_check(self):
+        model = make_fake_model(exists=True)
+        barrier = threading.Barrier(8)
+
+        def worker():
+            barrier.wait()
+            _ensure.ensure_table(model)  # type: ignore[arg-type]
+
+        threads = [threading.Thread(target=worker) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert model.exists.call_count == 1
+
+
+class TestAutoCreateFlag:
+    def test_env_false_skips_exists_and_create(self, monkeypatch):
+        monkeypatch.setenv("AWS_DB_AUTO_CREATE_TABLES", "false")
+        model = make_fake_model(exists=False)
+        _ensure.ensure_table(model)  # type: ignore[arg-type]
+        model.exists.assert_not_called()
+        model.create_table.assert_not_called()
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", " False "])
+    def test_env_disabling_values(self, monkeypatch, value):
+        monkeypatch.setenv("AWS_DB_AUTO_CREATE_TABLES", value)
+        assert _ensure.auto_create_enabled() is False
+
+    @pytest.mark.parametrize("value", ["true", "1", "yes", "anything"])
+    def test_env_enabling_values(self, monkeypatch, value):
+        monkeypatch.setenv("AWS_DB_AUTO_CREATE_TABLES", value)
+        assert _ensure.auto_create_enabled() is True
+
+    def test_default_is_enabled(self):
+        assert _ensure.auto_create_enabled() is True
+
+    def test_set_auto_create_beats_env(self, monkeypatch):
+        monkeypatch.setenv("AWS_DB_AUTO_CREATE_TABLES", "true")
+        _ensure.set_auto_create(False)
+        assert _ensure.auto_create_enabled() is False
+        model = make_fake_model(exists=False)
+        _ensure.ensure_table(model)  # type: ignore[arg-type]
+        model.exists.assert_not_called()
+
+    def test_set_auto_create_warns_when_late(self, caplog):
+        model = make_fake_model(exists=True)
+        _ensure.ensure_table(model)  # type: ignore[arg-type]
+        with caplog.at_level("WARNING"):
+            _ensure.set_auto_create(False)
+        assert any("already" in r.message for r in caplog.records)
+
+
+class TestPreviouslyUnguardedModels:
+    """Regression: these accessors had no auto-create guard at all, so first
+    use on a fresh deployment crashed with table-not-found."""
+
+    @pytest.fixture(autouse=True)
+    def _require_dynamodb(self):
+        import os
+
+        if os.getenv("DATABASE_BACKEND", "dynamodb") != "dynamodb":
+            pytest.skip("DynamoDB-only test")
+
+    def test_subscription_suspension_autocreates_table(self):
+        from actingweb.db.dynamodb.subscription_suspension import (
+            DbSubscriptionSuspension,
+            SubscriptionSuspension,
+        )
+
+        db = DbSubscriptionSuspension("ensure-test-actor")
+        assert db.is_suspended("some-target") is False
+        assert SubscriptionSuspension.exists()
+
+    def test_peertrustee_list_autocreates_table(self):
+        from actingweb.db.dynamodb.peertrustee import (
+            DbPeerTrusteeList,
+            PeerTrustee,
+        )
+
+        DbPeerTrusteeList()
+        assert PeerTrustee.exists()
+
+
+class TestFluentApi:
+    def test_with_dynamodb_disables_auto_create(self):
+        from actingweb.interface import ActingWebApp
+
+        app = ActingWebApp(
+            aw_type="urn:actingweb:test:ensure",
+            database="dynamodb",
+            fqdn="test.example.com",
+        )
+        app.with_dynamodb(auto_create_tables=False)
+        assert _ensure.auto_create_enabled() is False
+        app.with_dynamodb(auto_create_tables=True)
+        assert _ensure.auto_create_enabled() is True

--- a/tests/test_hot_path_n_plus_one.py
+++ b/tests/test_hot_path_n_plus_one.py
@@ -61,13 +61,11 @@ class TestPropertyStoreBulkReads:
     def test_to_dict_is_single_bulk_read(self, config, populated_actor):
         store, core = self._interface_store(config, populated_actor)
         with (
+            mock.patch.object(type(core), "get_all", wraps=core.get_all) as get_all_spy,
             mock.patch.object(
-                type(core), "get_all", wraps=core.get_all
-            ) as get_all_spy,
-            mock.patch.object(
-                type(core), "__getattr__", side_effect=AssertionError(
-                    "per-key read on the bulk path"
-                )
+                type(core),
+                "__getattr__",
+                side_effect=AssertionError("per-key read on the bulk path"),
             ),
         ):
             result = store.to_dict()
@@ -153,9 +151,9 @@ class TestInternalStoreLazy:
         from actingweb import attribute
 
         with mock.patch.object(
-            attribute.Attributes, "get_bucket", side_effect=AssertionError(
-                "bucket loaded during construction"
-            )
+            attribute.Attributes,
+            "get_bucket",
+            side_effect=AssertionError("bucket loaded during construction"),
         ):
             attribute.InternalStore(actor_id=actor_id, config=config)
 

--- a/tests/test_hot_path_n_plus_one.py
+++ b/tests/test_hot_path_n_plus_one.py
@@ -1,0 +1,202 @@
+"""
+Regression tests for the hot-path N+1 fixes.
+
+The property read path used to re-read every property individually right
+after bulk-reading them all, re-read list metadata rows the bulk read
+already returned, pay a list-collision GetItem on every repeat write, and
+load the actor's _internal attribute bucket eagerly (twice) on every Actor
+construction. These tests pin the fixed read counts.
+"""
+
+import uuid
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _require_dynamodb():
+    import os
+
+    if os.getenv("DATABASE_BACKEND", "dynamodb") != "dynamodb":
+        pytest.skip("DynamoDB-only test")
+
+
+@pytest.fixture
+def config():
+    from actingweb.config import Config
+
+    return Config(database="dynamodb")
+
+
+@pytest.fixture
+def actor_id():
+    return f"nplus1-{uuid.uuid4()}"
+
+
+@pytest.fixture
+def populated_actor(config, actor_id):
+    """Actor with 5 simple properties; cleans up after the test."""
+    from actingweb import property as property_module
+
+    store = property_module.PropertyStore(actor_id=actor_id, config=config)
+    for i in range(5):
+        setattr(store, f"prop{i}", f"value{i}")
+    yield actor_id
+    from actingweb.db import get_property_list
+
+    lst = get_property_list(config)
+    lst.fetch(actor_id=actor_id)
+    lst.delete()
+
+
+class TestPropertyStoreBulkReads:
+    def _interface_store(self, config, actor_id):
+        from actingweb import property as property_module
+        from actingweb.interface.property_store import PropertyStore
+
+        core = property_module.PropertyStore(actor_id=actor_id, config=config)
+        return PropertyStore(core), core
+
+    def test_to_dict_is_single_bulk_read(self, config, populated_actor):
+        store, core = self._interface_store(config, populated_actor)
+        with (
+            mock.patch.object(
+                type(core), "get_all", wraps=core.get_all
+            ) as get_all_spy,
+            mock.patch.object(
+                type(core), "__getattr__", side_effect=AssertionError(
+                    "per-key read on the bulk path"
+                )
+            ),
+        ):
+            result = store.to_dict()
+        assert result == {f"prop{i}": f"value{i}" for i in range(5)}
+        assert get_all_spy.call_count == 1
+
+    def test_items_and_values_are_bulk_reads(self, config, populated_actor):
+        store, core = self._interface_store(config, populated_actor)
+        with mock.patch.object(
+            type(core), "get_all", wraps=core.get_all
+        ) as get_all_spy:
+            items = dict(store.items())
+            values = sorted(store.values())
+        assert items == {f"prop{i}": f"value{i}" for i in range(5)}
+        assert values == sorted(f"value{i}" for i in range(5))
+        # one bulk read per bulk operation, none per key
+        assert get_all_spy.call_count == 2
+
+    def test_repeat_write_skips_collision_check(self, config, populated_actor):
+        from actingweb import property as property_module
+
+        core = property_module.PropertyStore(actor_id=populated_actor, config=config)
+        # Load the property into the instance first
+        assert core["prop0"] == "value0"
+        with mock.patch.object(
+            property_module.PropertyListStore, "exists"
+        ) as exists_spy:
+            core["prop0"] = "new-value"
+        exists_spy.assert_not_called()
+
+    def test_first_write_still_collision_checks(self, config, actor_id):
+        from actingweb import property as property_module
+
+        core = property_module.PropertyStore(actor_id=actor_id, config=config)
+        with mock.patch.object(
+            property_module.PropertyListStore, "exists", return_value=True
+        ):
+            with pytest.raises(ValueError, match="list with this name"):
+                core["newprop"] = "value"
+
+
+class TestListPropertyPriming:
+    def test_primed_list_serves_from_rows(self, config, actor_id):
+        from actingweb.db import get_property_list
+        from actingweb.property_list import ListProperty
+
+        lst = ListProperty(actor_id, "mylist", config)
+        lst.append({"a": 1})
+        lst.append("plain string")
+        lst.append([1, 2, 3])
+        try:
+            rows = (
+                get_property_list(config).fetch_all_including_lists(actor_id=actor_id)
+                or {}
+            )
+            fresh = ListProperty(actor_id, "mylist", config)
+            fresh.prime_from_rows(rows)
+            # Metadata primed: len() must not hit the database
+            with mock.patch.object(
+                type(fresh), "_load_metadata", wraps=fresh._load_metadata
+            ):
+                assert len(fresh) == 3
+            # Items served from rows match the per-item read path exactly
+            assert fresh.to_list_from_rows(rows) == lst.to_list()
+        finally:
+            lst.delete()
+
+    def test_unprimed_behaviour_unchanged(self, config, actor_id):
+        from actingweb.property_list import ListProperty
+
+        lst = ListProperty(actor_id, "otherlist", config)
+        lst.append("x")
+        try:
+            fresh = ListProperty(actor_id, "otherlist", config)
+            fresh.prime_from_rows({})  # nothing to prime — lazy path applies
+            assert fresh.to_list() == ["x"]
+        finally:
+            lst.delete()
+
+
+class TestInternalStoreLazy:
+    def test_construction_does_not_query_bucket(self, config, actor_id):
+        from actingweb import attribute
+
+        with mock.patch.object(
+            attribute.Attributes, "get_bucket", side_effect=AssertionError(
+                "bucket loaded during construction"
+            )
+        ):
+            attribute.InternalStore(actor_id=actor_id, config=config)
+
+    def test_first_access_loads_bucket_once(self, config, actor_id):
+        from actingweb import attribute
+
+        store = attribute.InternalStore(actor_id=actor_id, config=config)
+        with mock.patch.object(
+            attribute.Attributes, "get_bucket", return_value={"em": {"data": "x@y.z"}}
+        ) as spy:
+            assert store.em == "x@y.z"
+            assert store.missing is None
+        assert spy.call_count == 1
+
+    def test_write_then_read_sees_full_bucket(self, config, actor_id):
+        from actingweb import attribute
+
+        # Seed the bucket through one store
+        seed = attribute.InternalStore(actor_id=actor_id, config=config)
+        seed.existing = "seeded"
+        # A fresh store that WRITES first must still see other attributes
+        # (the load-before-write rule; a partial-cache bug would lose them)
+        fresh = attribute.InternalStore(actor_id=actor_id, config=config)
+        fresh.other = "written"
+        assert fresh.existing == "seeded"
+        # Cleanup
+        fresh.existing = None
+        fresh.other = None
+
+
+class TestNegativePermissionCache:
+    def test_missing_override_cached(self, config):
+        from actingweb.trust_permissions import TrustPermissionStore
+
+        store = TrustPermissionStore(config)
+        fake_bucket = mock.MagicMock()
+        fake_bucket.get_attr.return_value = None
+        with mock.patch.object(
+            TrustPermissionStore, "_get_permissions_bucket", return_value=fake_bucket
+        ):
+            assert store.get_permissions("actor-x", "peer-y") is None
+            assert store.get_permissions("actor-x", "peer-y") is None
+        # Second call must be served from the cache
+        assert fake_bucket.get_attr.call_count == 1

--- a/tests/test_lookup_migration.py
+++ b/tests/test_lookup_migration.py
@@ -1,0 +1,336 @@
+"""
+Upgrade-path tests for the lookup-table default flip (v3.13).
+
+Two upgrading cohorts must keep resolving reverse lookups between the
+upgrade and the backfill:
+(a) legacy-GSI deployments (populated GSI, no lookup tables) — served by
+    the GSI fallback tier;
+(b) v1-lookup deployments (populated v1 table, typically NO GSI — the
+    measured production shape) — served by the v1 fallback tier.
+Both fallbacks log deprecation warnings; after the backfill, lookups
+resolve from v2 with no fallback. The startup check warns loudly for the
+un-backfilled state.
+"""
+
+import uuid
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _require_dynamodb():
+    import os
+
+    if os.getenv("DATABASE_BACKEND", "dynamodb") != "dynamodb":
+        pytest.skip("DynamoDB-only test")
+
+
+@pytest.fixture
+def actor_id():
+    return f"migration-{uuid.uuid4()}"
+
+
+def _lookup_mode_prop(indexed):
+    from actingweb.db.dynamodb.property import DbProperty
+
+    return DbProperty(use_lookup_table=True, indexed_properties=list(indexed))
+
+
+class TestV1CohortFallback:
+    """Cohort (b): populated v1 table, empty v2, no GSI needed."""
+
+    def test_v1_fallback_serves_and_warns(self, actor_id, caplog):
+        from actingweb.db.dynamodb.property import Property
+        from actingweb.db.dynamodb.property_lookup import (
+            DbPropertyLookup,
+            PropertyLookup,
+        )
+
+        value = f"v1cohort-{uuid.uuid4()}"
+        # Simulate pre-upgrade state: property row + v1 lookup row only
+        # (write via the models directly — the current writers would
+        # populate v2, which this cohort does not have yet).
+        Property(id=actor_id, name="email", value=value).save()
+        if not PropertyLookup.exists():
+            PropertyLookup.create_table(wait=True)
+        PropertyLookup(property_name="email", value=value, actor_id=actor_id).save()
+
+        try:
+            reader = _lookup_mode_prop(["email"])
+            with caplog.at_level("WARNING", logger="actingweb.db.dynamodb.property"):
+                found = reader.get_actor_id_from_property(name="email", value=value)
+            assert found == actor_id
+            assert any(
+                "v1 lookup table" in r.message and "DEPRECATED" in r.message
+                for r in caplog.records
+            )
+            # v2 still empty for this value — fallback did not write through
+            assert DbPropertyLookup().get("email", value) is None
+        finally:
+            Property.get(actor_id, "email").delete()
+            PropertyLookup.get("email", value).delete()
+
+
+class TestGsiCohortFallback:
+    """Cohort (a): legacy GSI populated, no lookup tables."""
+
+    def test_gsi_fallback_serves_and_warns(self, actor_id, caplog):
+        from actingweb.db.dynamodb.property import Property, PropertyLegacy
+
+        # Requires the shared table to carry the GSI (see
+        # test_conditional_gsi_schema for shape coverage)
+        try:
+            desc = PropertyLegacy._get_connection().describe_table()
+        except Exception:
+            desc = None
+        if not (desc and desc.get("GlobalSecondaryIndexes")):
+            pytest.skip("shared properties table has the lookup-mode shape")
+
+        value = f"gsicohort-{uuid.uuid4()}"
+        Property(id=actor_id, name="email", value=value).save()
+        try:
+            reader = _lookup_mode_prop(["email"])
+            with caplog.at_level("WARNING", logger="actingweb.db.dynamodb.property"):
+                found = reader.get_actor_id_from_property(name="email", value=value)
+            assert found == actor_id
+            assert any(
+                "property-index GSI" in r.message and "DEPRECATED" in r.message
+                for r in caplog.records
+            )
+        finally:
+            Property.get(actor_id, "email").delete()
+
+    def test_gsi_fallback_warns_mocked(self, actor_id, caplog):
+        """Shape-independent coverage of the tier-2 hit path."""
+        from actingweb.db.dynamodb import property as prop_mod
+
+        fake_row = mock.MagicMock()
+        fake_row.id = actor_id
+        reader = _lookup_mode_prop(["email"])
+        with (
+            mock.patch.object(
+                prop_mod.PropertyLegacy.property_index,
+                "query",
+                return_value=iter([fake_row]),
+            ),
+            mock.patch.object(prop_mod.Property, "get", return_value=fake_row),
+            caplog.at_level("WARNING", logger="actingweb.db.dynamodb.property"),
+        ):
+            found = reader.get_actor_id_from_property(
+                name="email", value=f"mocked-{uuid.uuid4()}"
+            )
+        assert found == actor_id
+        assert any(
+            "property-index GSI" in r.message and "DEPRECATED" in r.message
+            for r in caplog.records
+        )
+
+    def test_missing_gsi_fallback_is_none_not_crash(self, actor_id):
+        """On a GSI-less table the tier-2 fallback must swallow the missing
+        index and return None — never surface the backend exception."""
+        from actingweb.db.dynamodb import property as prop_mod
+
+        reader = _lookup_mode_prop(["email"])
+        with mock.patch.object(
+            prop_mod.PropertyLegacy.property_index,
+            "query",
+            side_effect=Exception(
+                "ValidationException: The table does not have the specified index"
+            ),
+        ):
+            assert (
+                reader.get_actor_id_from_property(
+                    name="email", value=f"missing-{uuid.uuid4()}"
+                )
+                is None
+            )
+
+
+class TestBackfillScript:
+    def _run_backfill(self, argv):
+        import sys
+
+        sys.path.insert(0, "scripts")
+        try:
+            import backfill_property_lookup  # type: ignore[import-not-found]
+
+            with mock.patch.object(sys, "argv", ["backfill_property_lookup.py", *argv]):
+                return backfill_property_lookup.main()
+        finally:
+            sys.path.remove("scripts")
+
+    @pytest.fixture
+    def prop_name(self):
+        # Unique indexed-property name per test so the backfill scan of the
+        # SHARED table matches only this test's rows.
+        return f"bfprop{uuid.uuid4().hex[:10]}"
+
+    def test_dry_run_counts_without_writing(self, actor_id, prop_name, tmp_path):
+        from actingweb.db.dynamodb.property import Property
+        from actingweb.db.dynamodb.property_lookup import DbPropertyLookup
+
+        value = f"dry-{uuid.uuid4()}"
+        Property(id=actor_id, name=prop_name, value=value).save()
+        try:
+            rc = self._run_backfill(
+                [
+                    "--dry-run",
+                    "--rps",
+                    "0",
+                    "--segments",
+                    "2",
+                    "--properties",
+                    prop_name,
+                ]
+            )
+            assert rc == 0
+            assert DbPropertyLookup().get(prop_name, value) is None
+        finally:
+            Property.get(actor_id, prop_name).delete()
+
+    def test_backfill_then_lookup_without_fallback(
+        self, actor_id, prop_name, tmp_path, caplog
+    ):
+        from actingweb.db.dynamodb.property import Property
+        from actingweb.db.dynamodb.property_lookup import DbPropertyLookup
+
+        value = f"real-{uuid.uuid4()}"
+        Property(id=actor_id, name=prop_name, value=value).save()
+        try:
+            checkpoint = str(tmp_path / "ckpt.json")
+            rc = self._run_backfill(
+                [
+                    "--rps",
+                    "0",
+                    "--segments",
+                    "2",
+                    "--properties",
+                    prop_name,
+                    "--checkpoint-file",
+                    checkpoint,
+                ]
+            )
+            assert rc == 0
+            assert DbPropertyLookup().get(prop_name, value) == actor_id
+
+            # Reverse lookup now resolves from v2 — no deprecation warnings
+            reader = _lookup_mode_prop([prop_name])
+            with caplog.at_level("WARNING", logger="actingweb.db.dynamodb.property"):
+                assert (
+                    reader.get_actor_id_from_property(name=prop_name, value=value)
+                    == actor_id
+                )
+            assert not any("DEPRECATED" in r.message for r in caplog.records)
+
+            # Idempotent re-run
+            rc2 = self._run_backfill(
+                [
+                    "--rps",
+                    "0",
+                    "--segments",
+                    "2",
+                    "--properties",
+                    prop_name,
+                    "--checkpoint-file",
+                    checkpoint,
+                ]
+            )
+            assert rc2 == 0
+        finally:
+            Property.get(actor_id, prop_name).delete()
+            DbPropertyLookup().delete(prop_name, value)
+
+    def test_collision_reported_not_overwritten(self, prop_name, tmp_path):
+        from actingweb.db.dynamodb.property import Property
+        from actingweb.db.dynamodb.property_lookup import DbPropertyLookup
+
+        value = f"shared-{uuid.uuid4()}"
+        actor_a = f"bf-a-{uuid.uuid4()}"
+        actor_b = f"bf-b-{uuid.uuid4()}"
+        Property(id=actor_a, name=prop_name, value=value).save()
+        Property(id=actor_b, name=prop_name, value=value).save()
+        try:
+            rc = self._run_backfill(
+                [
+                    "--rps",
+                    "0",
+                    "--segments",
+                    "1",
+                    "--properties",
+                    prop_name,
+                    "--checkpoint-file",
+                    str(tmp_path / "c.json"),
+                ]
+            )
+            assert rc == 1  # collision -> non-zero exit
+            winner = DbPropertyLookup().get(prop_name, value)
+            assert winner in (actor_a, actor_b)  # one row kept, not clobbered
+        finally:
+            Property.get(actor_a, prop_name).delete()
+            Property.get(actor_b, prop_name).delete()
+            DbPropertyLookup().delete(prop_name, value)
+
+
+class TestStartupCheck:
+    def _app(self):
+        from actingweb.interface import ActingWebApp
+
+        return ActingWebApp(
+            aw_type="urn:actingweb:test:startup",
+            database="dynamodb",
+            fqdn="test.example.com",
+        )
+
+    def _run_check(self, v2_rows, prop_rows, v1_rows, caplog):
+        from actingweb.db.dynamodb import property as prop_mod
+        from actingweb.db.dynamodb import property_lookup as pl
+
+        app = self._app()
+        with (
+            mock.patch.object(pl.PropertyLookupV2, "scan", return_value=iter(v2_rows)),
+            mock.patch.object(prop_mod.Property, "scan", return_value=iter(prop_rows)),
+            mock.patch.object(pl.PropertyLookup, "scan", return_value=iter(v1_rows)),
+            caplog.at_level("ERROR", logger="actingweb.interface.app"),
+        ):
+            app._check_lookup_backfill_needed()
+        return [r.message for r in caplog.records if r.levelname == "ERROR"]
+
+    def test_fires_when_backfill_needed(self, caplog):
+        errors = self._run_check([], ["prop"], [], caplog)
+        assert any("lookup table is empty" in m for m in errors)
+
+    def test_v1_variant_message(self, caplog):
+        errors = self._run_check([], ["prop"], ["v1row"], caplog)
+        assert any("needs migration" in m for m in errors)
+
+    def test_silent_when_v2_populated(self, caplog):
+        assert self._run_check(["v2row"], ["prop"], [], caplog) == []
+
+    def test_silent_on_fresh_deployment(self, caplog):
+        assert self._run_check([], [], [], caplog) == []
+
+    def test_silent_in_legacy_mode(self, caplog):
+        app = self._app().with_legacy_property_index(enable=True)
+        from actingweb.db.dynamodb import property_lookup as pl
+
+        with (
+            mock.patch.object(pl.PropertyLookupV2, "scan") as scan_spy,
+            caplog.at_level("ERROR", logger="actingweb.interface.app"),
+        ):
+            app._check_lookup_backfill_needed()
+        scan_spy.assert_not_called()
+
+
+class TestDefaultFlip:
+    def test_config_default_is_lookup_mode(self):
+        from actingweb.config import Config
+
+        assert Config(database="dynamodb").use_lookup_table is True
+
+    def test_env_rollback_still_works(self, monkeypatch):
+        """The documented rollback: USE_PROPERTY_LOOKUP_TABLE=false."""
+        from actingweb.config import Config
+
+        monkeypatch.setenv("USE_PROPERTY_LOOKUP_TABLE", "false")
+        assert Config(database="dynamodb").use_lookup_table is False

--- a/tests/test_mcp_server_name.py
+++ b/tests/test_mcp_server_name.py
@@ -64,7 +64,9 @@ class TestWithMcpBuilderPropagation:
         assert cfg.mcp_server_name == "doctest"
 
     def test_instructions_reach_config(self) -> None:
-        cfg = self._app(enable=True, instructions="Call how_to_use() first").get_config()
+        cfg = self._app(
+            enable=True, instructions="Call how_to_use() first"
+        ).get_config()
         assert cfg.mcp_instructions == "Call how_to_use() first"
 
     def test_enable_false_reaches_config(self) -> None:

--- a/tests/test_oauth2_callback_github_normalization.py
+++ b/tests/test_oauth2_callback_github_normalization.py
@@ -48,7 +48,10 @@ def _mock_authenticator(raw_user_info: dict) -> MagicMock:
     auth.is_enabled.return_value = True
     auth.provider.name = "github"
     auth.provider.mobile_deep_link = ""  # not a -mobile provider
-    auth.exchange_code_for_token.return_value = {"access_token": "gh-at", "expires_in": 3600}
+    auth.exchange_code_for_token.return_value = {
+        "access_token": "gh-at",
+        "expires_in": 3600,
+    }
     # GitHub fetches userinfo from the endpoint (no id_token in the token response).
     auth.provider.extract_user_info_from_token_response.return_value = None
     auth.validate_token_and_get_user_info.return_value = raw_user_info

--- a/tests/test_oauth2_callback_spa_error.py
+++ b/tests/test_oauth2_callback_spa_error.py
@@ -212,9 +212,7 @@ class TestAppleSpaCallbackErrorRedirect:
             "timestamp": int(time.time()),
         }
         nonce = StateNonceStore(config).create(payload)
-        webobj = _apple_webobj(
-            {"error": "user_cancelled_authorize", "state": nonce}
-        )
+        webobj = _apple_webobj({"error": "user_cancelled_authorize", "state": nonce})
         result = OAuth2AppleCallbackHandler(webobj, config).post()
 
         assert result.get("redirect_required") is True

--- a/tests/test_oauth2_spa.py
+++ b/tests/test_oauth2_spa.py
@@ -762,9 +762,7 @@ class TestLogoutDoesNotRevokeProviderGrant:
     def _endpoints_handler(mock_webobj, mock_config):
         from unittest.mock import patch
 
-        with patch(
-            "actingweb.oauth2_server.oauth2_server.get_actingweb_oauth2_server"
-        ):
+        with patch("actingweb.oauth2_server.oauth2_server.get_actingweb_oauth2_server"):
             from actingweb.handlers.oauth2_endpoints import OAuth2EndpointsHandler
 
             return OAuth2EndpointsHandler(mock_webobj, mock_config)
@@ -778,9 +776,10 @@ class TestLogoutDoesNotRevokeProviderGrant:
 
         fake_actor = self._fake_actor()
         handler = OAuth2SPAHandler(mock_webobj, mock_config)
-        with patch("actingweb.actor.Actor", return_value=fake_actor), patch(
-            "actingweb.oauth2.create_oauth2_authenticator"
-        ) as mk_auth:
+        with (
+            patch("actingweb.actor.Actor", return_value=fake_actor),
+            patch("actingweb.oauth2.create_oauth2_authenticator") as mk_auth,
+        ):
             handler._clear_provider_token_for_actor("actor-1")
 
         # Token cleared locally so the backend can't use it any more...
@@ -795,17 +794,16 @@ class TestLogoutDoesNotRevokeProviderGrant:
     ):
         from unittest.mock import patch
 
-        with patch(
-            "actingweb.oauth2_server.oauth2_server.get_actingweb_oauth2_server"
-        ):
+        with patch("actingweb.oauth2_server.oauth2_server.get_actingweb_oauth2_server"):
             from actingweb.handlers.oauth2_endpoints import OAuth2EndpointsHandler
 
             handler = OAuth2EndpointsHandler(mock_webobj, mock_config)
 
         fake_actor = self._fake_actor()
-        with patch("actingweb.actor.Actor", return_value=fake_actor), patch(
-            "actingweb.oauth2.create_oauth2_authenticator"
-        ) as mk_auth:
+        with (
+            patch("actingweb.actor.Actor", return_value=fake_actor),
+            patch("actingweb.oauth2.create_oauth2_authenticator") as mk_auth,
+        ):
             handler._clear_provider_token_for_actor("actor-1")
 
         assert fake_actor.store.oauth_token is None
@@ -821,9 +819,10 @@ class TestLogoutDoesNotRevokeProviderGrant:
         fake_actor = self._fake_actor()
         fake_actor.store.oauth_token = None
         handler = self._spa_handler(mock_webobj, mock_config)
-        with patch("actingweb.actor.Actor", return_value=fake_actor), patch(
-            "actingweb.oauth2.create_oauth2_authenticator"
-        ) as mk_auth:
+        with (
+            patch("actingweb.actor.Actor", return_value=fake_actor),
+            patch("actingweb.oauth2.create_oauth2_authenticator") as mk_auth,
+        ):
             handler._clear_provider_token_for_actor("actor-1")
 
         assert fake_actor.store.oauth_token is None
@@ -838,9 +837,10 @@ class TestLogoutDoesNotRevokeProviderGrant:
         missing_actor.id = None
         missing_actor.store = None
         handler = self._spa_handler(mock_webobj, mock_config)
-        with patch("actingweb.actor.Actor", return_value=missing_actor), patch(
-            "actingweb.oauth2.create_oauth2_authenticator"
-        ) as mk_auth:
+        with (
+            patch("actingweb.actor.Actor", return_value=missing_actor),
+            patch("actingweb.oauth2.create_oauth2_authenticator") as mk_auth,
+        ):
             # Must not raise.
             handler._clear_provider_token_for_actor("does-not-exist")
 

--- a/tests/test_property_lookup.py
+++ b/tests/test_property_lookup.py
@@ -242,14 +242,37 @@ class TestPropertyReverseLookuWithLookupTable:
         """Test reverse lookup when legacy index is enabled."""
         property_mod = get_db_module(backend, "property")
 
+        if backend == "dynamodb":
+            # The shared test table's schema is fixed by whoever created it
+            # first (lookup mode creates it WITHOUT the legacy GSI). The
+            # legacy path needs the GSI — skip when absent; the GSI query
+            # mechanics are covered on a dedicated table in
+            # test_conditional_gsi_schema.py.
+            from actingweb.db.dynamodb.property import PropertyLegacy
+
+            try:
+                desc = PropertyLegacy._get_connection().describe_table()
+            except Exception:
+                desc = None
+            has_gsi = bool(desc and desc.get("GlobalSecondaryIndexes"))
+            if not has_gsi:
+                pytest.skip(
+                    "shared properties table was created without the legacy "
+                    "GSI (lookup-mode shape)"
+                )
+
+        # Unique value: the legacy GSI matches on value only, so residue
+        # from earlier runs could otherwise shadow this test's row.
+        legacy_value = f"github:{uuid.uuid4()}"
+
         # Set a property
         prop = property_mod.DbProperty()
-        prop.set(actor_id=test_actor_id, name="oauthId", value="github:11111")
+        prop.set(actor_id=test_actor_id, name="oauthId", value=legacy_value)
 
         # Reverse lookup should use legacy index/GSI
         prop2 = property_mod.DbProperty()
         found_actor_id = prop2.get_actor_id_from_property(
-            name="oauthId", value="github:11111"
+            name="oauthId", value=legacy_value
         )
         assert found_actor_id == test_actor_id, (
             f"Expected {test_actor_id}, got {found_actor_id}"

--- a/tests/test_property_lookup.py
+++ b/tests/test_property_lookup.py
@@ -646,8 +646,9 @@ class TestConfigurationIntegration:
             delattr(Config, "_instance")
 
         config = Config()
-        # Default should be False for backward compatibility
-        assert config.use_lookup_table is False
+        # Lookup-table mode is the default since v3.13 (legacy GSI mode is
+        # deprecated; pin it via USE_PROPERTY_LOOKUP_TABLE=false)
+        assert config.use_lookup_table is True
         # Default indexed properties
         assert "oauthId" in config.indexed_properties
         assert "email" in config.indexed_properties

--- a/tests/test_property_lookup.py
+++ b/tests/test_property_lookup.py
@@ -357,6 +357,52 @@ class TestPropertyReverseLookuWithLookupTable:
         # Cleanup
         prop.delete()
 
+    def test_update_indexed_property_via_fresh_instance_updates_lookup(
+        self, backend: str, test_actor_id: str, config_with_lookup_table
+    ):
+        """A new DbProperty per write (the PropertyStore path) must still
+        clean up the old lookup row.
+
+        PropertyStore.__setattr__ builds a fresh DbProperty for every write,
+        so self.handle is unset when set() runs. The old test reused a single
+        instance (warm handle), which hid the case where old_value could not
+        be recovered and the stale lookup row survived.
+        """
+        property_mod = get_db_module(backend, "property")
+        lookup_mod = get_db_module(backend, "property_lookup")
+
+        # v2 lookup rows are keyed globally by (name, value), so derive
+        # unique values from the actor id to stay collision-free under
+        # parallel execution.
+        old_value = f"old-{test_actor_id}@example.com"
+        new_value = f"new-{test_actor_id}@example.com"
+
+        # Set initial value with one instance...
+        property_mod.DbProperty().set(
+            actor_id=test_actor_id, name="email", value=old_value
+        )
+        assert (
+            lookup_mod.DbPropertyLookup().get(property_name="email", value=old_value)
+            == test_actor_id
+        )
+
+        # ...and update it with a brand-new instance (cold handle).
+        property_mod.DbProperty().set(
+            actor_id=test_actor_id, name="email", value=new_value
+        )
+
+        assert (
+            lookup_mod.DbPropertyLookup().get(property_name="email", value=old_value)
+            is None
+        ), "Old lookup entry should be deleted even via a fresh DbProperty"
+        assert (
+            lookup_mod.DbPropertyLookup().get(property_name="email", value=new_value)
+            == test_actor_id
+        ), "New lookup entry should be created"
+
+        # Cleanup
+        property_mod.DbProperty().set(actor_id=test_actor_id, name="email", value="")
+
     def test_delete_indexed_property_deletes_lookup(
         self, backend: str, test_actor_id: str, config_with_lookup_table
     ):

--- a/tests/test_property_lookup.py
+++ b/tests/test_property_lookup.py
@@ -167,11 +167,14 @@ class TestPropertyLookupBasicOperations:
     def test_create_duplicate_lookup(self, backend: str, test_actor_id: str):
         """Test creating a duplicate lookup entry (backend-specific behavior)."""
         lookup_mod = get_db_module(backend, "property_lookup")
+        # Unique per run: with conditional puts, a residual row from an
+        # earlier run would otherwise be (correctly) treated as a collision.
+        dup_value = f"duplicate-{uuid.uuid4()}"
 
         # Create first entry
         lookup1 = lookup_mod.DbPropertyLookup()
         result1 = lookup1.create(
-            property_name="oauthId", value="duplicate_value", actor_id=test_actor_id
+            property_name="oauthId", value=dup_value, actor_id=test_actor_id
         )
         assert result1 is True
 
@@ -179,25 +182,29 @@ class TestPropertyLookupBasicOperations:
         other_actor_id = str(uuid.uuid4())
         lookup2 = lookup_mod.DbPropertyLookup()
         result2 = lookup2.create(
-            property_name="oauthId", value="duplicate_value", actor_id=other_actor_id
+            property_name="oauthId", value=dup_value, actor_id=other_actor_id
         )
 
-        # Verify behavior based on backend
+        # Unified behavior (v2): a duplicate for a DIFFERENT actor is a
+        # collision — rejected and logged, the original entry preserved.
+        # (DynamoDB used to silently overwrite last-writer-wins; the v2
+        # conditional put aligned it with PostgreSQL.)
         lookup3 = lookup_mod.DbPropertyLookup()
-        found_actor_id = lookup3.get(property_name="oauthId", value="duplicate_value")
+        found_actor_id = lookup3.get(property_name="oauthId", value=dup_value)
 
-        if backend == "dynamodb":
-            # DynamoDB PutItem overwrites existing entry (last write wins)
-            assert result2 is True, "DynamoDB allows overwrite"
-            assert found_actor_id == other_actor_id, (
-                "DynamoDB overwrites with new value"
+        assert result2 is False, "duplicate for another actor must be rejected"
+        assert found_actor_id == test_actor_id, "original entry must be preserved"
+
+        # Re-creating the SAME mapping is idempotent
+        lookup4 = lookup_mod.DbPropertyLookup()
+        assert (
+            lookup4.create(
+                property_name="oauthId",
+                value=dup_value,
+                actor_id=test_actor_id,
             )
-        elif backend == "postgresql":
-            # PostgreSQL INSERT fails on duplicate primary key
-            assert result2 is False, "PostgreSQL rejects duplicate"
-            assert found_actor_id == test_actor_id, (
-                "PostgreSQL preserves original entry"
-            )
+            is True
+        )
 
         # Cleanup
         lookup3.delete()

--- a/tests/test_property_lookup.py
+++ b/tests/test_property_lookup.py
@@ -622,3 +622,70 @@ class TestConfigurationIntegration:
         assert "oauthId" in config.indexed_properties
         assert "email" in config.indexed_properties
         assert "externalUserId" in config.indexed_properties
+
+
+class TestBuilderConfigPrecedence:
+    """Lookup-table settings precedence: explicit builder > env var > default.
+
+    Regression tests for the bug where ActingWebApp stamped its own hardcoded
+    lookup-table defaults onto the config on every with_*() call, silently
+    clobbering the USE_PROPERTY_LOOKUP_TABLE / INDEXED_PROPERTIES env
+    overrides (the documented rollback path).
+    """
+
+    def _make_app(self):
+        from actingweb.interface import ActingWebApp
+
+        return ActingWebApp(
+            aw_type="urn:actingweb:test:precedence",
+            database="dynamodb",
+            fqdn="test.example.com",
+        )
+
+    def test_env_true_survives_builder_calls(self, monkeypatch):
+        monkeypatch.setenv("USE_PROPERTY_LOOKUP_TABLE", "true")
+        app = self._make_app().with_web_ui(enable=True).with_devtest(enable=True)
+        assert app.get_config().use_lookup_table is True
+
+    def test_env_false_survives_builder_calls(self, monkeypatch):
+        monkeypatch.setenv("USE_PROPERTY_LOOKUP_TABLE", "false")
+        app = self._make_app().with_web_ui(enable=True).with_devtest(enable=True)
+        assert app.get_config().use_lookup_table is False
+
+    def test_indexed_properties_env_survives_builder_calls(self, monkeypatch):
+        monkeypatch.setenv("INDEXED_PROPERTIES", "custom1,custom2")
+        app = self._make_app().with_web_ui(enable=True)
+        assert app.get_config().indexed_properties == ["custom1", "custom2"]
+
+    def test_explicit_builder_beats_env(self, monkeypatch):
+        monkeypatch.setenv("USE_PROPERTY_LOOKUP_TABLE", "true")
+        app = self._make_app().with_legacy_property_index(enable=True)
+        assert app.get_config().use_lookup_table is False
+        # ... and stays pinned across later builder calls
+        app.with_web_ui(enable=True)
+        assert app.get_config().use_lookup_table is False
+
+    def test_explicit_indexed_properties_beats_env(self, monkeypatch):
+        monkeypatch.setenv("INDEXED_PROPERTIES", "fromenv")
+        app = self._make_app().with_indexed_properties(["explicit1", "explicit2"])
+        assert app.get_config().indexed_properties == ["explicit1", "explicit2"]
+
+    def test_no_env_no_builder_uses_config_default(self, monkeypatch):
+        monkeypatch.delenv("USE_PROPERTY_LOOKUP_TABLE", raising=False)
+        monkeypatch.delenv("INDEXED_PROPERTIES", raising=False)
+        app = self._make_app().with_web_ui(enable=True)
+        config = app.get_config()
+        # Must match Config's own defaults (guards the future default flip:
+        # this asserts equality with Config(), not a hardcoded value)
+        if hasattr(Config, "_instance"):
+            delattr(Config, "_instance")
+        reference = Config()
+        assert config.use_lookup_table == reference.use_lookup_table
+        assert config.indexed_properties == reference.indexed_properties
+
+    def test_with_indexed_properties_no_args_leaves_env_authoritative(
+        self, monkeypatch
+    ):
+        monkeypatch.setenv("INDEXED_PROPERTIES", "fromenv")
+        app = self._make_app().with_indexed_properties()
+        assert app.get_config().indexed_properties == ["fromenv"]

--- a/tests/test_property_lookup_v2.py
+++ b/tests/test_property_lookup_v2.py
@@ -94,7 +94,9 @@ class TestWriteFailureLogging:
             pl.PropertyLookupV2, "save", side_effect=Exception("throttled")
         ):
             db = pl.DbPropertyLookup()
-            with caplog.at_level("ERROR"):
+            with caplog.at_level(
+                "ERROR", logger="actingweb.db.dynamodb.property_lookup"
+            ):
                 assert db.create("email", secret_value, actor_id) is False
         assert any("LOOKUP_CREATE_FAILED" in r.message for r in caplog.records)
         assert all(secret_value not in r.message for r in caplog.records)
@@ -133,7 +135,7 @@ class TestReverseLookupContract:
         prop = prop_mod.DbProperty(use_lookup_table=True, indexed_properties=["email"])
         with (
             mock.patch.object(prop_mod.PropertyLegacy, "property_index") as gsi,
-            caplog.at_level("WARNING"),
+            caplog.at_level("WARNING", logger="actingweb.db.dynamodb.property"),
         ):
             result = prop.get_actor_id_from_property(name="notIndexed", value="v")
         assert result is None

--- a/tests/test_property_lookup_v2.py
+++ b/tests/test_property_lookup_v2.py
@@ -1,0 +1,206 @@
+"""
+Tests for the v2 (digest-only) property lookup table.
+
+The v2 format keys rows by sha256(name + NUL + value) — a permanent data
+format — stores no plaintext values, uses conditional puts (collisions are
+logged, not silently overwritten), and has no value-size limit. These
+tests lock the format and the hardening behaviour.
+"""
+
+import uuid
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _require_dynamodb():
+    import os
+
+    if os.getenv("DATABASE_BACKEND", "dynamodb") != "dynamodb":
+        pytest.skip("DynamoDB-only test")
+
+
+@pytest.fixture
+def actor_id():
+    return f"lookupv2-{uuid.uuid4()}"
+
+
+class TestDigestFormat:
+    def test_known_answer(self):
+        """Locks the permanent data format: sha256('email' NUL 'a@b.c')."""
+        import hashlib
+
+        from actingweb.db.dynamodb.property_lookup import compute_lookup_key
+
+        expected = hashlib.sha256(b"email\x00a@b.c").hexdigest()
+        assert compute_lookup_key("email", "a@b.c") == expected
+        # 64 hex chars, always
+        assert len(expected) == 64
+
+    def test_separator_is_unambiguous(self):
+        from actingweb.db.dynamodb.property_lookup import compute_lookup_key
+
+        # Without a separator these two pairs would collide
+        assert compute_lookup_key("ab", "c") != compute_lookup_key("a", "bc")
+        # Names containing '#' or ':' are safe too
+        assert compute_lookup_key("a#b", "c") != compute_lookup_key("a", "#bc")
+
+    def test_non_ascii_values(self):
+        from actingweb.db.dynamodb.property_lookup import compute_lookup_key
+
+        key = compute_lookup_key("email", "grøger@ttwedel.nø")
+        assert len(key) == 64
+
+
+class TestNoSizeLimit:
+    def test_large_value_roundtrip(self, actor_id):
+        """v1's range key capped values at 1024 bytes; v2 has no limit."""
+        from actingweb.db.dynamodb.property_lookup import DbPropertyLookup
+
+        big_value = "x" * 5000
+        db = DbPropertyLookup()
+        assert db.create("externalUserId", big_value, actor_id) is True
+        assert db.get("externalUserId", big_value) == actor_id
+        assert db.delete("externalUserId", big_value) is True
+        assert db.get("externalUserId", big_value) is None
+
+
+class TestValueNeverStored:
+    def test_row_contains_no_value(self, actor_id):
+        from actingweb.db.dynamodb.property_lookup import (
+            DbPropertyLookup,
+            PropertyLookupV2,
+            compute_lookup_key,
+        )
+
+        secret_value = f"secret-{uuid.uuid4()}"
+        db = DbPropertyLookup()
+        assert db.create("oauthId", secret_value, actor_id) is True
+        raw = PropertyLookupV2.get(compute_lookup_key("oauthId", secret_value))
+        stored = raw.to_simple_dict()
+        assert secret_value not in str(stored)
+        assert stored["actor_id"] == actor_id
+        assert stored["property_name"] == "oauthId"
+        db.delete("oauthId", secret_value)
+
+
+class TestWriteFailureLogging:
+    def test_failure_logs_digest_never_value(self, actor_id, caplog):
+        from actingweb.db.dynamodb import property_lookup as pl
+
+        secret_value = f"secret-{uuid.uuid4()}"
+        with mock.patch.object(
+            pl.PropertyLookupV2, "save", side_effect=Exception("throttled")
+        ):
+            db = pl.DbPropertyLookup()
+            with caplog.at_level("ERROR"):
+                assert db.create("email", secret_value, actor_id) is False
+        assert any("LOOKUP_CREATE_FAILED" in r.message for r in caplog.records)
+        assert all(secret_value not in r.message for r in caplog.records)
+
+
+class TestUnchangedValueSkipsSync:
+    def test_update_lookup_entry_short_circuits(self, actor_id):
+        from actingweb.db.dynamodb.property import DbProperty
+
+        prop = DbProperty(use_lookup_table=True, indexed_properties=["email"])
+        with mock.patch(
+            "actingweb.db.dynamodb.property_lookup.DbPropertyLookup"
+        ) as accessor:
+            prop._update_lookup_entry(actor_id, "email", "same@x.y", "same@x.y")
+        accessor.assert_not_called()
+
+    def test_changed_value_syncs(self, actor_id):
+        from actingweb.db.dynamodb.property import DbProperty
+
+        prop = DbProperty(use_lookup_table=True, indexed_properties=["email"])
+        with mock.patch(
+            "actingweb.db.dynamodb.property_lookup.DbPropertyLookup"
+        ) as accessor:
+            accessor.return_value.get.return_value = actor_id
+            prop._update_lookup_entry(actor_id, "email", "old@x.y", "new@x.y")
+        accessor.return_value.delete.assert_called_once()
+        accessor.return_value.create.assert_called_once_with(
+            property_name="email", value="new@x.y", actor_id=actor_id
+        )
+
+
+class TestReverseLookupContract:
+    def test_non_indexed_name_returns_none_with_warning(self, actor_id, caplog):
+        from actingweb.db.dynamodb import property as prop_mod
+
+        prop = prop_mod.DbProperty(use_lookup_table=True, indexed_properties=["email"])
+        with (
+            mock.patch.object(prop_mod.Property, "property_index") as gsi,
+            caplog.at_level("WARNING"),
+        ):
+            result = prop.get_actor_id_from_property(name="notIndexed", value="v")
+        assert result is None
+        gsi.query.assert_not_called()
+        assert any("non-indexed" in r.message for r in caplog.records)
+
+    def test_legacy_missing_gsi_raises_actionable_error(self):
+        from actingweb.db.dynamodb import property as prop_mod
+
+        prop = prop_mod.DbProperty(use_lookup_table=False)
+        with mock.patch.object(
+            prop_mod.Property.property_index,
+            "query",
+            side_effect=Exception(
+                "ValidationException: The table does not have the specified index"
+            ),
+        ):
+            with pytest.raises(RuntimeError) as exc_info:
+                prop.get_actor_id_from_property(name="email", value="v")
+        message = str(exc_info.value)
+        assert "property-index" in message
+        assert "with_legacy_property_index" in message
+        assert "backfill_property_lookup" in message
+
+    def test_indexed_roundtrip_via_v2(self, actor_id):
+        """Set an indexed property -> reverse lookup -> delete cleans up."""
+        from actingweb.db.dynamodb.property import DbProperty
+        from actingweb.db.dynamodb.property_lookup import DbPropertyLookup
+
+        value = f"user-{uuid.uuid4()}@example.com"
+        writer = DbProperty(use_lookup_table=True, indexed_properties=["email"])
+        assert writer.set(actor_id=actor_id, name="email", value=value)
+
+        reader = DbProperty(use_lookup_table=True, indexed_properties=["email"])
+        assert reader.get_actor_id_from_property(name="email", value=value) == actor_id
+
+        # Deleting the property removes the lookup row
+        deleter = DbProperty(use_lookup_table=True, indexed_properties=["email"])
+        assert deleter.get(actor_id=actor_id, name="email") == value
+        assert deleter.delete() is True
+        assert DbPropertyLookup().get("email", value) is None
+
+
+class TestV1Fallback:
+    def test_get_v1_reads_old_format(self, actor_id):
+        from actingweb.db.dynamodb.property_lookup import (
+            DbPropertyLookup,
+            PropertyLookup,
+        )
+
+        # Simulate a pre-migration deployment: row exists only in v1.
+        # (Create the v1 table on demand for the test; the library itself
+        # never auto-creates it.)
+        if not PropertyLookup.exists():
+            PropertyLookup.create_table(wait=True)
+        value = f"v1-{uuid.uuid4()}"
+        PropertyLookup(property_name="email", value=value, actor_id=actor_id).save()
+
+        db = DbPropertyLookup()
+        assert db.get("email", value) is None  # not in v2
+        assert db.get_v1("email", value) == actor_id
+        PropertyLookup.get("email", value).delete()
+
+    def test_get_v1_missing_table_is_none(self, monkeypatch):
+        from actingweb.db.dynamodb import property_lookup as pl
+
+        with mock.patch.object(
+            pl.PropertyLookup, "get", side_effect=Exception("ResourceNotFound")
+        ):
+            assert pl.DbPropertyLookup().get_v1("email", "x") is None

--- a/tests/test_property_lookup_v2.py
+++ b/tests/test_property_lookup_v2.py
@@ -132,7 +132,7 @@ class TestReverseLookupContract:
 
         prop = prop_mod.DbProperty(use_lookup_table=True, indexed_properties=["email"])
         with (
-            mock.patch.object(prop_mod.Property, "property_index") as gsi,
+            mock.patch.object(prop_mod.PropertyLegacy, "property_index") as gsi,
             caplog.at_level("WARNING"),
         ):
             result = prop.get_actor_id_from_property(name="notIndexed", value="v")
@@ -145,7 +145,7 @@ class TestReverseLookupContract:
 
         prop = prop_mod.DbProperty(use_lookup_table=False)
         with mock.patch.object(
-            prop_mod.Property.property_index,
+            prop_mod.PropertyLegacy.property_index,
             "query",
             side_effect=Exception(
                 "ValidationException: The table does not have the specified index"

--- a/tests/test_scan_to_query.py
+++ b/tests/test_scan_to_query.py
@@ -1,0 +1,173 @@
+"""
+Tests for the scan()->query() conversion in the DynamoDB backend.
+
+Every per-actor bulk read used to Scan the whole table with a
+partition-key FilterExpression (O(table size) per call, measured at
+~2,000 RCU per property fetch in production). The conversions to
+query(actor_id) must preserve exact semantics:
+
+- delete scope: deleting actor A's rows must not touch actor B's
+  (the critical regression a botched conversion would introduce),
+- strong consistency on the trust list reads (query() defaults
+  consistent_read=False, unlike the explicit scan calls it replaced),
+- the unset-actor_id delete guard.
+"""
+
+import uuid
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _require_dynamodb():
+    import os
+
+    if os.getenv("DATABASE_BACKEND", "dynamodb") != "dynamodb":
+        pytest.skip("DynamoDB-only test")
+
+
+@pytest.fixture
+def actor_pair():
+    """Two unique actor ids for cross-actor scope tests."""
+    return f"scanq-a-{uuid.uuid4()}", f"scanq-b-{uuid.uuid4()}"
+
+
+class TestPropertyDeleteScope:
+    def test_bulk_delete_leaves_other_actor_intact(self, actor_pair):
+        from actingweb.db.dynamodb.property import DbProperty, DbPropertyList
+
+        actor_a, actor_b = actor_pair
+        for actor in (actor_a, actor_b):
+            for name in ("p1", "p2"):
+                assert DbProperty().set(actor_id=actor, name=name, value=f"v-{actor}")
+
+        lst = DbPropertyList()
+        assert lst.fetch(actor_id=actor_a)
+        assert lst.delete() is True
+
+        assert DbPropertyList().fetch(actor_id=actor_a) in (None, {})
+        remaining = DbPropertyList().fetch(actor_id=actor_b)
+        assert remaining is not None and set(remaining) == {"p1", "p2"}
+
+        # Cleanup
+        b = DbPropertyList()
+        b.fetch(actor_id=actor_b)
+        b.delete()
+
+
+class TestTrustListScope:
+    def _create_trust(self, actor_id: str, peerid: str):
+        from actingweb.db.dynamodb.trust import DbTrust
+
+        assert DbTrust().create(
+            actor_id=actor_id,
+            peerid=peerid,
+            baseuri=f"https://example.com/{peerid}",
+            peer_type="test",
+            relationship="friend",
+            secret=f"secret-{uuid.uuid4()}",
+        )
+
+    def test_bulk_delete_leaves_other_actor_intact(self, actor_pair):
+        from actingweb.db.dynamodb.trust import DbTrustList
+
+        actor_a, actor_b = actor_pair
+        self._create_trust(actor_a, "peer-1")
+        self._create_trust(actor_a, "peer-2")
+        self._create_trust(actor_b, "peer-1")
+
+        lst = DbTrustList()
+        assert len(lst.fetch(actor_a) or []) == 2
+        assert lst.delete() is True
+
+        assert DbTrustList().fetch(actor_a) == []
+        b_trusts = DbTrustList().fetch(actor_b)
+        assert b_trusts is not None and len(b_trusts) == 1
+
+        b = DbTrustList()
+        b.fetch(actor_b)
+        b.delete()
+
+    def test_fetch_and_delete_use_consistent_read(self, actor_pair):
+        from actingweb.db.dynamodb import trust as trust_mod
+
+        actor_a, _ = actor_pair
+        with mock.patch.object(
+            trust_mod.Trust, "query", return_value=iter([])
+        ) as query:
+            trust_mod.DbTrustList().fetch(actor_a)
+        query.assert_called_once_with(actor_a, consistent_read=True)
+
+        with mock.patch.object(
+            trust_mod.Trust, "query", return_value=iter([])
+        ) as query:
+            lst = trust_mod.DbTrustList()
+            lst.actor_id = actor_a
+            lst.delete()
+        query.assert_called_once_with(actor_a, consistent_read=True)
+
+    def test_delete_without_fetch_returns_false(self):
+        from actingweb.db.dynamodb.trust import DbTrustList
+
+        assert DbTrustList().delete() is False
+
+
+class TestPeerTrusteeScope:
+    def _create(self, actor_id: str, peerid: str, peer_type: str = "test-type"):
+        from actingweb.db.dynamodb.peertrustee import DbPeerTrustee
+
+        assert DbPeerTrustee().create(
+            actor_id=actor_id,
+            peerid=peerid,
+            peer_type=peer_type,
+            baseuri=f"https://example.com/{peerid}",
+            passphrase="pw",
+        )
+
+    def test_bulk_delete_leaves_other_actor_intact(self, actor_pair):
+        from actingweb.db.dynamodb.peertrustee import DbPeerTrusteeList
+
+        actor_a, actor_b = actor_pair
+        self._create(actor_a, "peer-1")
+        self._create(actor_b, "peer-1")
+
+        lst = DbPeerTrusteeList()
+        assert len(lst.fetch(actor_a) or []) == 1
+        assert lst.delete() is True
+
+        assert DbPeerTrusteeList().fetch(actor_a) == []
+        b_peers = DbPeerTrusteeList().fetch(actor_b)
+        assert b_peers is not None and len(b_peers) == 1
+
+        b = DbPeerTrusteeList()
+        b.fetch(actor_b)
+        b.delete()
+
+    def test_get_by_type_filters_within_actor(self, actor_pair):
+        from actingweb.db.dynamodb.peertrustee import DbPeerTrustee
+
+        actor_a, actor_b = actor_pair
+        self._create(actor_a, "peer-1", peer_type="type-x")
+        self._create(actor_a, "peer-2", peer_type="type-y")
+        # Same type on another actor must not leak into actor_a's lookup
+        self._create(actor_b, "peer-3", peer_type="type-x")
+
+        found = DbPeerTrustee().get(actor_id=actor_a, peer_type="type-x")
+        assert found and found["peerid"] == "peer-1"
+
+        # >1 match of the same type within one actor is ambiguous -> False
+        self._create(actor_a, "peer-4", peer_type="type-x")
+        assert DbPeerTrustee().get(actor_id=actor_a, peer_type="type-x") is False
+
+        from actingweb.db.dynamodb.peertrustee import DbPeerTrusteeList
+
+        for actor in (actor_a, actor_b):
+            lst_cleanup = DbPeerTrusteeList()
+            lst_cleanup.fetch(actor)
+            lst_cleanup.delete()
+
+    def test_delete_without_fetch_returns_false(self):
+        from actingweb.db.dynamodb.peertrustee import DbPeerTrusteeList
+
+        assert DbPeerTrusteeList().delete() is False

--- a/tests/test_user_info_normalization.py
+++ b/tests/test_user_info_normalization.py
@@ -31,7 +31,9 @@ class TestNormalizeUserInfo:
 
     def test_github_falls_back_to_login_when_name_missing(self) -> None:
         # GitHub's `name` is optional; `login` (username) is always present.
-        out = normalize_user_info("github", {"name": None, "login": "octo", "email": "o@x.com"})
+        out = normalize_user_info(
+            "github", {"name": None, "login": "octo", "email": "o@x.com"}
+        )
         assert out["display_name"] == "octo"
 
     def test_github_falls_back_to_login_when_name_absent(self) -> None:

--- a/thoughts/plans/2026-07-23-dynamodb-scalability.md
+++ b/thoughts/plans/2026-07-23-dynamodb-scalability.md
@@ -1,7 +1,7 @@
 # Implementation Plan: DynamoDB Backend Scalability (v3.13.0)
 
 **Date:** 2026-07-23
-**Status:** Ready for Implementation
+**Status:** Implemented (all 8 phases, branch `dynamodb-scalability`; pending PR + release)
 **Research:** thoughts/research/2026-07-23-dynamodb-scaling-defects.md (companion measurement doc:
 `../actingweb_mcp/thoughts/research/2026-07-23-scaling-review-apigw-lambda-dynamodb.md`)
 **Branch:** master (plan written at commit `29783f8`; implement on a feature branch)
@@ -245,7 +245,7 @@ before merge; treat any as test fixes, not code fixes.
 - [ ] Manual (optional, high-value): against DynamoDB Local, confirm via boto debug logs
       that property fetch issues `Query` not `Scan`
 
-### Implementation Status: Not Started
+### Implementation Status: Complete (branch `dynamodb-scalability`)
 
 ---
 
@@ -279,7 +279,7 @@ before merge; treat any as test fixes, not code fixes.
 - [ ] `poetry run pyright actingweb tests`; `poetry run ruff check` — clean
 - [ ] `make test-all-parallel` passes
 
-### Implementation Status: Not Started
+### Implementation Status: Complete (branch `dynamodb-scalability`)
 
 ---
 
@@ -335,7 +335,7 @@ re-read list metadata.
 - [ ] `make test-all-parallel` passes (property handlers are heavily covered — treat any
       failure as a semantics regression, not test brittleness)
 
-### Implementation Status: Not Started
+### Implementation Status: Complete (branch `dynamodb-scalability`)
 
 ---
 
@@ -425,7 +425,7 @@ v2 is a **new table**; v1 stays intact for rollback and as a Phase 8 fallback ti
 - [ ] `poetry run pyright actingweb tests`; `poetry run ruff check` — clean
 - [ ] `make test-all-parallel` passes
 
-### Implementation Status: Not Started
+### Implementation Status: Complete (branch `dynamodb-scalability`)
 
 ---
 
@@ -468,7 +468,7 @@ first use (`models.py:265-275,1059-1080`); runtime `_indexes` mutation makes
 - [ ] `poetry run pyright actingweb tests`; `poetry run ruff check` — clean
 - [ ] `make test-all-parallel` passes
 
-### Implementation Status: Not Started
+### Implementation Status: Complete (branch `dynamodb-scalability`)
 
 ---
 
@@ -592,7 +592,7 @@ Ships last, after every safety mechanism above is in place.
 - [ ] Manual: fresh-prefix end-to-end against DynamoDB Local — deploy, write indexed
       property, reverse-lookup, verify no GSI on table, verify PAY_PER_REQUEST
 
-### Implementation Status: Not Started
+### Implementation Status: Complete (branch `dynamodb-scalability`)
 
 ---
 

--- a/thoughts/plans/2026-07-23-dynamodb-scalability.md
+++ b/thoughts/plans/2026-07-23-dynamodb-scalability.md
@@ -1,0 +1,654 @@
+# Implementation Plan: DynamoDB Backend Scalability (v3.13.0)
+
+**Date:** 2026-07-23
+**Status:** Ready for Implementation
+**Research:** thoughts/research/2026-07-23-dynamodb-scaling-defects.md (companion measurement doc:
+`../actingweb_mcp/thoughts/research/2026-07-23-scaling-review-apigw-lambda-dynamodb.md`)
+**Branch:** master (plan written at commit `29783f8`; implement on a feature branch)
+
+## Overview
+
+The DynamoDB backend has two measured superlinear scaling defects (partition-key `Scan`s
+costing ~2,036 RCU per property fetch; ~1,396 `DescribeTable` calls/min from un-memoised
+existence guards), two design defects (provisioned-throughput defaults on auto-created
+tables; the legacy value-keyed GSI decoupled from the lookup-table config), and — found
+during plan evaluation — a set of hot-path N+1 read amplifiers that dominate cost once the
+scans are fixed. This plan fixes all of them in one minor release (v3.13.0), flips the
+reverse-lookup default to lookup-table mode safely (dual-read fallback + backfill script +
+loud startup check), and updates every affected doc surface.
+
+## Decisions Made
+
+- **Legacy value GSI (Defect 4)**: Conditional schema + fail-fast — fresh `_properties`
+  tables omit the `property-index` GSI in lookup-table mode; legacy path fail-fasts with an
+  actionable `RuntimeError` when the index is absent. Full GSI removal deferred to the next
+  major release, tracked in `thoughts/todo/`.
+- **Default reverse-lookup mode**: Flip `use_lookup_table` default to `True` — aligned with
+  what both known consumers already run; the legacy default is broken on pre-GSI tables.
+- **Flip safety**: One release with a **dual-read fallback** — on a lookup-table miss, fall
+  back to the legacy GSI when it exists (deprecation-logged), plus a loud startup check and
+  a shipped backfill script. Fallback removed in the next major.
+- **Auto-create control**: `AWS_DB_AUTO_CREATE_TABLES` env var (default true; matches the
+  `AWS_DB_PREFIX`/`AWS_DB_HOST` convention — NOT `AW_DB_*` as the research doc once wrote)
+  plus fluent `with_dynamodb(auto_create_tables=...)`.
+- **Billing**: Auto-created tables always `PAY_PER_REQUEST`; `Meta` capacity units removed
+  as dead config; no provisioned-billing knob (IaC owns that case).
+- **Release**: Single minor release v3.13.0 with `docs/migration/v3.13.rst`.
+- **Lookup-table key redesign (digest-only)**: Replace the `(property_name, value)`
+  composite key with a single hash key `lookup_key = sha256(canonical(name, value))`,
+  storing `actor_id` and `property_name` as attributes and **never storing the value**.
+  Fixes four design weaknesses at once: the low-cardinality hot-partition key (3 property
+  names = 3 partition keys, per-partition throughput ceiling on login bursts before
+  split-for-heat reacts), the 1024-byte range-key value cap, plaintext PII in key
+  material, and (via conditional puts) silent last-writer-wins collisions. Requires a
+  **new table** (`_property_lookup_v2`) — DynamoDB cannot change a key schema — with the
+  v1 table left intact for library-version rollback. Chosen now because the Phase 8
+  backfill will populate this table across all deployments; the format change is trivial
+  today (measured prod: 45 rows) and a full re-migration later.
+- **Flip fallback chain**: On a v2 lookup miss, fall back to the **v1 lookup table**
+  (when it exists — protects the cohort that already adopted lookup mode and has no GSI),
+  then the legacy GSI (when it exists). Both fallback tiers deprecation-logged; both
+  removed in the next major.
+- **N+1 scope**: The eight small hot-path fixes ship in this release (Phase 5). Five larger
+  items are deferred to a known-next doc: batch_write for delete loops, general
+  `ListProperty.__getitem__` N+1 and `__delitem__` O(N) shift, the 22-site
+  `consistent_read` audit, `SubscriptionDiff` seqnr key-format fix, `DbActorList`
+  pagination.
+- **Lookup-table limits**: Superseded by the digest-only redesign — a fixed-length digest
+  key has no value-size limit, so the originally planned 1024-byte validation is dropped.
+  Write failures (throttles etc.) still get loud ERROR logging instead of today's silent
+  swallow; the "no size limit" doc claim becomes true and is documented accurately.
+- **Privacy framing (honest scope)**: Digest-only is pseudonymization, not anonymization —
+  low-entropy values (emails) remain dictionary-attackable, and the *properties* table
+  still stores values in plaintext regardless. What this removes is the second plaintext
+  copy with its own IAM/backup surface. Documented as such; no overclaiming.
+- **PostgreSQL**: keeps its relational `(name, value)` lookup format — same database as
+  the properties table (no extra exposure surface), and a unique index has none of the
+  DynamoDB key problems. Behavioural parity only (contract for misses/non-indexed names).
+
+## What We're NOT Doing
+
+- Removing the legacy `property-index` GSI or the legacy code path (next major; tracked in
+  `thoughts/todo/legacy-property-gsi-removal.md`).
+- batch_write conversion of delete loops; general `ListProperty` item N+1 / `__delitem__`
+  redesign; relaxing `consistent_read=True` anywhere; `SubscriptionDiff` range-key format
+  change; `DbActorList.fetch` pagination (all documented in
+  `thoughts/todo/dynamodb-known-next.md`).
+- Changing the PostgreSQL lookup-table storage format (digest scheme is DynamoDB-only;
+  see Decisions).
+- Converting existing deployments' tables to on-demand billing (deployer runs
+  `aws dynamodb update-table --billing-mode PAY_PER_REQUEST` out-of-band; migration doc
+  covers it — **never recreate tables**, the lookup table holds live login rows).
+- PostgreSQL performance work beyond keeping the `USE_PROPERTY_LOOKUP_TABLE` /
+  `INDEXED_PROPERTIES` handling in `db/postgresql/property.py:38-51,420-434` consistent
+  with the DynamoDB changes (same default flip applies to both backends).
+- Changes to `actingwebdemo` (separate repo — coordination notes at the end of Phase 8).
+
+---
+
+## Phase 1: Builder config precedence fix (prerequisite bug fix)
+
+Today `ActingWebApp.__init__` hardcodes `_use_lookup_table = False` / `_indexed_properties`
+(app.py:78-81) and `_apply_runtime_changes_to_config()` (app.py:190-193) re-applies them on
+**every** `with_*()` call behind a dead `hasattr` guard — silently clobbering the
+`USE_PROPERTY_LOOKUP_TABLE` / `INDEXED_PROPERTIES` env overrides applied in
+`config.py:250-257`. The documented rollback (`configuration.rst:524`) does not reliably
+work. This must land before the default flip and is an independent bug fix.
+
+### Changes
+
+- `actingweb/interface/app.py` — make `_use_lookup_table: bool | None = None` and
+  `_indexed_properties: list[str] | None = None` sentinel defaults; in
+  `_apply_runtime_changes_to_config()` assign only when not `None`; in `get_config()`
+  (app.py:1242) omit the kwargs when `None` so `Config` defaults + env overrides are
+  authoritative. Resulting precedence: explicit builder call > env var > Config default.
+  `with_legacy_property_index()` / `with_indexed_properties()` keep working unchanged.
+- `CHANGELOG.rst` — own entry: env overrides for lookup-table settings were silently
+  ignored when any `with_*()` method was called after app construction.
+
+### New Tests
+
+- Unit: `USE_PROPERTY_LOOKUP_TABLE=false` (and `=true`) survives a subsequent
+  `.with_web_ui()` / `.with_devtest()` call — asserts `config.use_lookup_table`.
+- Unit: `INDEXED_PROPERTIES=custom1,custom2` survives builder calls.
+- Unit: explicit `with_legacy_property_index(enable=True)` beats the env var (builder wins).
+- Unit: no env, no builder call → `Config` default is used (guards the Phase 8 flip).
+
+### Verification
+
+- [x] `poetry run pytest tests/test_property_lookup.py -k "Precedence or Configuration" -v` — 9 passed
+- [x] `poetry run pyright` on changed files — 0 errors
+- [x] `poetry run ruff check actingweb tests` passes; format clean
+- [x] `make test-all-parallel` — 2374 passed, 5 parallel-isolation failures all pass
+      sequentially (per CLAUDE.md verification procedure)
+
+### Implementation Status: Complete (branch `dynamodb-scalability`)
+
+---
+
+## Phase 2: Table-existence memoisation + auto-create control
+
+Collapses 13 per-construction `DescribeTable` guards (measured 1,396/min at idle) to
+once-per-process-per-table, adds the missing guards, and makes auto-creation opt-out for
+IaC-managed production.
+
+### Changes
+
+- `actingweb/db/dynamodb/_ensure.py` (new) —
+  `ensure_table(model)`: double-checked module-level `set[str]` + `threading.Lock`;
+  memo key is the **model class** (not `Meta.table_name`) so Phase 7's two Property model
+  classes don't collide; `reset_ensure_cache()` test hook; `set_auto_create(bool)` module
+  override + `AWS_DB_AUTO_CREATE_TABLES` env read (default true). **When auto-create is
+  off, skip `model.exists()` entirely** (not just `create_table`) so roles without
+  `dynamodb:DescribeTable` never AccessDenied (S5). Never cache a negative; preserve the
+  existing semantics: only `ResourceInUseException` is benign, everything else re-raises
+  (swallowing AccessDenied would turn config errors into silent data loss). Log the
+  resolved flag value once at first use; `set_auto_create()` warns if `_ensured` is already
+  non-empty (called too late).
+- Replace the 13 guard blocks with `ensure_table(X)`: `actor.py:143`, `property.py:81/365`,
+  `attribute.py:334/401`, `trust.py:431/533`, `subscription.py:157/218`,
+  `subscription_diff.py:103/171`, `peertrustee.py:128`, `property_lookup.py:57`.
+- Add guards where missing (behaviour change — call out in CHANGELOG):
+  `DbPeerTrusteeList.__init__` (peertrustee.py:179) and
+  `DbSubscriptionSuspension.__init__` (subscription_suspension.py:48) — today the
+  suspension table is **never** auto-created, so first use on a fresh deployment crashes.
+- `actingweb/interface/app.py` — new fluent `with_dynamodb(auto_create_tables: bool = True)`
+  calling `_ensure.set_auto_create()` via `_apply_runtime_changes_to_config()` (tri-state,
+  per Phase 1 pattern). No other knobs in it yet; it is the future home for backend options.
+- `actingweb/interface/app.py` (`integrate_flask` / `integrate_fastapi`, near the
+  `_initialize_permission_system` call at app.py:1274/1287/1333) — flag-gated **parallel
+  pre-warm**: `ThreadPoolExecutor` over `ensure_table` for all auto-created models (after
+  Phase 6 the deprecated v1 lookup model is excluded — legacy read-only, never
+  auto-created), skipped entirely when auto-create is off. Failures degrade to the lazy path (the surrounding init already
+  swallows exceptions, app.py:1345-1355) — keep that property.
+- `tests/integration/conftest.py` — call `reset_ensure_cache()` from
+  `cleanup_dynamodb_tables()` (:127-161) so in-process table deletion can never leave the
+  memo lying; also a fixture pinning `AWS_DB_AUTO_CREATE_TABLES=true` for
+  `tests/test_db_protocols.py`-style direct constructions.
+
+### New Tests
+
+- Unit: `ensure_table` calls `Model.exists` at most once per model class across many
+  constructions (mock `exists`/`create_table`, count calls); thread-safety smoke test.
+- Unit: `reset_ensure_cache()` makes the next call re-check.
+- Unit: `AWS_DB_AUTO_CREATE_TABLES=false` → neither `exists()` nor `create_table()` called;
+  `with_dynamodb(auto_create_tables=False)` equivalent; env-vs-builder precedence.
+- Integration: fresh-prefix deployment auto-creates **all** tables including
+  `_subscription_suspensions` and peertrustees via the list wrapper (regression for the
+  previously-unguarded models).
+- Integration: pre-warm creates all tables at `integrate_flask()` time on a fresh prefix.
+
+### Verification
+
+- [ ] `poetry run pytest tests/ -k "ensure or auto_create" -v` passes
+- [ ] `poetry run pyright actingweb tests` — 0 errors; `poetry run ruff check` passes
+- [ ] `make test-all-parallel` passes (exercises `reset_ensure_cache` wiring via xdist)
+- [ ] Manual: run any integration test with `PYNAMODB_DEBUG`/boto logging and confirm
+      exactly one `DescribeTable` per table per process
+
+### Implementation Status: Not Started
+
+---
+
+## Phase 3: scan→query conversions
+
+Each conversion is mechanical (`query()` returns the same `ResultIterator`), and the target
+pattern already exists in `attribute.py`/`subscription.py`/`subscription_diff.py`.
+
+### Changes
+
+- `actingweb/db/dynamodb/property.py:381,399` — `Property.scan(Property.id == actor_id)` →
+  `Property.query(actor_id)` (`fetch`, `fetch_all_including_lists`).
+- `actingweb/db/dynamodb/property.py:418,424` — same in `DbPropertyList.delete()` (the
+  delete-scope-critical sites; see tests).
+- `actingweb/db/dynamodb/trust.py:455,521` — →
+  `Trust.query(self.actor_id, consistent_read=True)`. **`query()` defaults
+  `consistent_read=False`** — the kwarg must be passed explicitly and is asserted by test
+  (S1). Add `if not self.actor_id: return False` guard to `DbTrustList.delete()`
+  (matching `DbPropertyList.delete()` property.py:411-412).
+- `actingweb/db/dynamodb/peertrustee.py:49` —
+  `PeerTrustee.query(actor_id, filter_condition=PeerTrustee.type == peer_type)`; the
+  `count > 1` disambiguation at :56-64 is order-insensitive. `:153,171` → `query(actor_id)`;
+  add the `actor_id` guard to `DbPeerTrusteeList.delete()`.
+- `actingweb/db/dynamodb/actor.py:162` — leave `Actor.scan()` (intentional list-all); add a
+  docstring note: admin-only, O(table), unpaginated.
+- Do NOT touch the always-truthy `if self.handle:` checks in the same commit.
+
+Note: results become range-key-sorted (deterministic) for `DbTrustList.fetch` /
+`DbPeerTrusteeList.fetch` — check for order-sensitive assertions in integration tests
+before merge; treat any as test fixes, not code fixes.
+
+### New Tests
+
+- Integration (delete scope, the critical one): create properties for actors A and B,
+  `DbPropertyList(A).delete()`, assert B's properties **and** B's lookup rows intact
+  (extends `tests/test_property_lookup.py::test_bulk_delete_preserves_other_actors_lookup_row`).
+- Same shape for trust and peertrustee list deletes.
+- Unit: trust fetch/delete pass `consistent_read=True` to `query` (mock assert on kwargs).
+- Unit: `DbTrustList.delete()` / `DbPeerTrusteeList.delete()` return `False` when
+  `actor_id` unset (no fetch first).
+- Integration: peertrustee type-filtered fetch returns same results as before.
+
+### Verification
+
+- [ ] `poetry run pytest tests/test_property_lookup.py tests/integration -k "trust or peer or propert" -v`
+- [ ] `poetry run pyright actingweb tests`; `poetry run ruff check` — clean
+- [ ] `make test-all-parallel` passes
+- [ ] Manual (optional, high-value): against DynamoDB Local, confirm via boto debug logs
+      that property fetch issues `Query` not `Scan`
+
+### Implementation Status: Not Started
+
+---
+
+## Phase 4: On-demand billing default for auto-created tables
+
+### Changes
+
+- All DynamoDB model `Meta` classes get `billing_mode = PAY_PER_REQUEST_BILLING_MODE`
+  (pynamodb constant): `actor.py:38-39`, `property.py:39-40`, `property_lookup.py:27-28`,
+  `attribute.py:26-27`, `trust.py:68-69`, `peertrustee.py:18-19`, `subscription.py:20-21`,
+  `subscription_diff.py:21-22`, `subscription_suspension.py:26-27`.
+- Remove all `read_capacity_units` / `write_capacity_units` from model **and** GSI Metas
+  (`property.py:25-26` PropertyIndex, `trust.py:54-55` SecretIndex, `actor.py:24-25`
+  CreatorIndex). Do **not** add `billing_mode` to GSI Metas — index kwargs never read it
+  (billing is table-level; verified in pynamodb 6.1.0 `connection/base.py:502-517`, which
+  strips `ProvisionedThroughput` from table and every GSI when `PAY_PER_REQUEST`).
+- `CHANGELOG.rst` — explicit note: affects **newly created** tables only; existing
+  provisioned tables (typically `<prefix>_property_lookup`, `<prefix>_peertrustees`) need
+  a one-time `aws dynamodb update-table --billing-mode PAY_PER_REQUEST` (allowed once per
+  24 h; never recreate).
+
+### New Tests
+
+- Integration: on a fresh prefix against DynamoDB Local, create tables and assert
+  `describe_table` reports `BillingModeSummary.BillingMode == "PAY_PER_REQUEST"` and GSIs
+  carry no provisioned throughput.
+
+### Verification
+
+- [ ] `poetry run pytest tests/ -k billing -v` passes
+- [ ] `poetry run pyright actingweb tests`; `poetry run ruff check` — clean
+- [ ] `make test-all-parallel` passes
+
+### Implementation Status: Not Started
+
+---
+
+## Phase 5: Hot-path N+1 and duplicate-read fixes
+
+Post-scan-fix, these dominate: a 50-property GET today is ~1 partition read + 50
+strongly-consistent GetItems + 50 accessor constructions, twice-read partitions, and
+re-read list metadata.
+
+### Changes
+
+- `actingweb/interface/property_store.py:174-201` — `items()`, `values()`, `to_dict()`
+  (and `clear()`'s enumeration) read from one `_core_store.get_all()` result instead of
+  re-fetching per key via `self[key]`. `__getitem__`/`__contains__` single-key semantics
+  unchanged.
+- `actingweb/handlers/properties.py:345,416` — `listall()` performs **one**
+  `fetch_all_including_lists()` partition read serving both the simple-property dict and
+  the list enumeration (`fetch()` output is a strict subset).
+- `actingweb/handlers/properties.py:445-493` + `actingweb/property_list.py:52,71-76` —
+  pass already-fetched `list:<name>-meta` rows into `ListProperty` via its existing
+  `_meta_cache` slot (kills the per-list meta GetItem); serve `format=full` /
+  `metadata=true` item enumeration (handlers/properties.py:447,465) from the same bulk
+  read instead of `list(list_prop)`'s per-item GetItems.
+- `actingweb/property.py:101-110,162-164 area` — gate the `property_lists.exists(k)`
+  list-collision GetItem: on the read path (handlers/properties.py:162-164) only consult
+  list metadata when the simple-property read missed; on the write path, check against the
+  bulk-known state where available instead of a fresh GetItem per write.
+- `actingweb/actor.py:76,225` — drop the eager `InternalStore` construction at :76 (it is
+  unconditionally overwritten at :225 for existing actors); make the `_internal` bucket
+  load lazy so requests that never touch `store.*` skip the Query entirely.
+- `actingweb/db/dynamodb/property.py:418-427` — merge the two delete-path partition reads:
+  collect indexed property names during the single delete pass.
+- `actingweb/trust_permissions.py:467-495` — cache negative results in
+  `TrustPermissionStore.get_permissions` (the `return None` paths at :477/:486 currently
+  bypass the cache, costing one GetItem per authorised request).
+
+### New Tests
+
+- Unit: `PropertyStore.to_dict()` with N properties performs exactly one backend fetch
+  (spy on `get_all` / `DbProperty.get` call counts).
+- Integration: `GET /<actor>/properties` (plain, `?metadata=true`, `?format=full`) returns
+  byte-identical JSON to pre-change behaviour (golden-response test with lists + simple
+  properties), while backend call counts drop (instrument via patched accessors).
+- Unit: negative permission lookup hits the cache on second call.
+- Integration: actor with no store access constructs without an attributes Query
+  (lazy `InternalStore`).
+- Regression: `clear()` still deletes everything including list properties.
+
+### Verification
+
+- [ ] `poetry run pytest tests/ -k "property_store or properties or permission" -v`
+- [ ] `poetry run pyright actingweb tests`; `poetry run ruff check` — clean
+- [ ] `make test-all-parallel` passes (property handlers are heavily covered — treat any
+      failure as a semantics regression, not test brittleness)
+
+### Implementation Status: Not Started
+
+---
+
+## Phase 6: Lookup-table v2 (digest-only) + hardening
+
+The current `(property_name, value)` key design has a low-cardinality hot-partition key
+(all email rows under one partition key), a 1024-byte range-key cap its own docstring
+denies, plaintext PII in key material, and unconditional last-writer-wins puts. The v2
+model replaces the key with a fixed-length digest. DynamoDB cannot alter a key schema, so
+v2 is a **new table**; v1 stays intact for rollback and as a Phase 8 fallback tier.
+
+### Changes
+
+- `actingweb/db/dynamodb/property_lookup.py` — new `PropertyLookupV2` model:
+  - table `<prefix>_property_lookup_v2`; single hash key
+    `lookup_key = sha256_hex(canonical(property_name, value))`. Canonical encoding uses a
+    NUL separator (`f"{name}\x00{value}"`) — unambiguous even if a name ever contains
+    `#`; this is a **permanent data format**, document it in the module docstring.
+  - the value is hashed **verbatim post-write** (same exact-match contract as runtime
+    reads; no normalisation, no lowercasing) and **never stored**. Attributes:
+    `actor_id`, `property_name` (not PII; needed for stale-row verification tooling and
+    per-property row counts).
+  - `create()` uses a **conditional put** (`attribute_not_exists(lookup_key)`); on
+    condition failure, read the existing row — if `actor_id` differs, log a collision at
+    ERROR (actor ids + property name + digest prefix; never any value) instead of today's
+    silent overwrite. An explicit `overwrite=True` path serves legitimate value moves via
+    `_update_lookup_entry`.
+  - `get()`/`delete()` recompute the digest from the caller's (name, value) — same
+    single GetItem cost, `consistent_read` still available (base table).
+  - keep the v1 `PropertyLookup` model **read-only** (get/delete only) for the Phase 8
+    fallback tier and migration verification; mark it deprecated and **exclude it from
+    auto-creation** (a missing v1 table is a normal state, caught by the fallback chain —
+    fresh deployments never create it).
+  - on any write failure (throttle etc.): ERROR log with property name + actor + digest
+    prefix (never the value — credential-equivalent per `actor.py:243-246`), replacing
+    the silent swallow. No size validation needed — digests are fixed-length, so the
+    documented "no size limit" claim becomes true.
+- `actingweb/db/dynamodb/property.py` (`_update_lookup_entry`, :236-269): switch writes to
+  v2; skip the delete+put entirely when the value is unchanged (removes write
+  amplification ahead of the Phase 8 flip); value changes delete the old digest row and
+  conditionally put the new one.
+- `actingweb/db/dynamodb/property.py:172` — fail-fast: catch the missing-index error from
+  `Property.property_index.query(value)` and re-raise as `RuntimeError` (house convention:
+  no custom exception hierarchy; `RuntimeError` for runtime-state failures per
+  `actor_interface.py:138,244,322`) with the three ways out: (1) switch to lookup-table
+  mode + backfill (recommended), (2) add the GSI to the live table via `update-table`
+  (noting the 2048-byte write-rejection consequence), (3) `with_indexed_properties([])` if
+  reverse lookup is unused. Interpolate table name and prefix only — no ARNs, region, or
+  the queried value. Raised at first reverse-lookup call, never at import time.
+- `actingweb/db/dynamodb/property.py:152` — enforce the documented contract
+  (`app.py:405-407`: only indexed properties may be used with `get_from_property`): in
+  lookup mode, a **non-indexed** name no longer falls through to the legacy GSI branch —
+  log a warning naming the property and `with_indexed_properties()`, return `None`.
+  (Phase 8's dual-read fallback applies only to *indexed* names.)
+- `actingweb/db/postgresql/property.py` — mirror the non-indexed-name contract in the PG
+  branch (`:158-183` is already an unindexed sequential scan since migration
+  `c3d4e5f6a7b8` dropped `idx_properties_value` unconditionally); keep both backends'
+  env-fallback blocks (`dynamodb/property.py:92-107,344-359`;
+  `postgresql/property.py:38-51,420-434`) in lockstep. Do **not** remove the direct-
+  construction env fallback — ~40 test call sites depend on it; add a docstring warning
+  and defer removal to the next major (todo doc).
+- Docs: `docs/quickstart/configuration.rst:536-541` size table — lookup mode now
+  genuinely unlimited (digest key); `docs/reference/security.rst` — pseudonymization note
+  (digests, not plaintext, in the lookup table; honest scope: low-entropy values remain
+  dictionary-attackable and the properties table itself still stores values in plaintext;
+  what v2 removes is the second plaintext copy with its own IAM/backup surface).
+
+### New Tests
+
+- Unit: digest canonicalisation — fixed known-answer test for `lookup_key` (locks the
+  permanent data format); names/values containing separators and non-ASCII round-trip.
+- Unit: >2048-byte indexed value → lookup write succeeds in v2 (the old limits are gone).
+- Unit: collision — two actors, same (name, value): first put wins, second logs collision
+  ERROR without overwriting; explicit overwrite path works for value moves.
+- Unit: unchanged value re-set → no lookup delete/put issued (call-count spy).
+- Unit: write failure (mocked throttle) → ERROR log with digest prefix, never the value.
+- Unit: legacy mode + table without GSI → `RuntimeError` with actionable message
+  (mock/DynamoDB Local table created without the index).
+- Unit: lookup mode + non-indexed name → `None` + warning, and **no** GSI query issued.
+- Integration: set indexed property → reverse lookup resolves via v2 GetItem; delete
+  property → v2 row gone (digest recomputation on the delete path).
+- PG integration: same non-indexed-name contract.
+
+### Verification
+
+- [ ] `poetry run pytest tests/test_property_lookup.py -v` passes
+- [ ] `poetry run pyright actingweb tests`; `poetry run ruff check` — clean
+- [ ] `make test-all-parallel` passes
+
+### Implementation Status: Not Started
+
+---
+
+## Phase 7: Conditional GSI schema (two Property model classes)
+
+pynamodb builds `_indexes` at class-definition time and caches the connection schema at
+first use (`models.py:265-275,1059-1080`); runtime `_indexes` mutation makes
+`property_index.query()` raise a bare `KeyError`. Two classes is the robust route.
+
+### Changes
+
+- `actingweb/db/dynamodb/property.py` — split into `PropertyLegacy` (current shape, with
+  `property_index = PropertyIndex()`) and `Property` (no GSI), same `Meta.table_name`.
+  Selection at accessor level by resolved `use_lookup_table`: lookup mode uses the
+  GSI-less class for **table creation**; the legacy read path keeps using the GSI class.
+  Reads/writes are shape-identical (the GSI attribute does not change item schema), so no
+  data migration — only `create_table` behaviour differs.
+- `actingweb/db/dynamodb/_ensure.py` — memo key already the model class (Phase 2); ensure
+  the two classes cannot both create the table in one process with different shapes:
+  first-wins per `Meta.table_name` at creation time, tracked explicitly.
+- Existing tables are untouched (pynamodb never alters live tables) — upgraders keep
+  whatever schema they have; only fresh deployments change. Release-note line: fresh
+  lookup-mode deployments no longer pay double writes/storage for an unused GSI, and no
+  longer inherit its 2048-byte write rejection.
+- Docs: `docs/reference/database-backends.rst:371` ("`properties`: GSI on `value` field")
+  becomes mode-dependent — describe both shapes.
+
+### New Tests
+
+- Integration (fresh prefix, lookup mode): created `_properties` table has **no** GSIs
+  (`describe_table` assert); a >2048-byte property value writes successfully (empirically
+  closes the research doc's hedged claim).
+- Integration (fresh prefix, legacy mode): table created **with** `property-index`; legacy
+  reverse lookup works end-to-end.
+- Unit: both classes resolve to the same table name; ensure-cache holds one entry.
+
+### Verification
+
+- [ ] `poetry run pytest tests/ -k "gsi or schema or lookup" -v` passes
+- [ ] `poetry run pyright actingweb tests`; `poetry run ruff check` — clean
+- [ ] `make test-all-parallel` passes
+
+### Implementation Status: Not Started
+
+---
+
+## Phase 8: Default flip, backfill, migration machinery, docs
+
+Ships last, after every safety mechanism above is in place.
+
+### Changes
+
+- **Flip**: `actingweb/config.py:64` `use_lookup_table` default → `True`. With Phase 1,
+  the builder no longer overrides it; `with_legacy_property_index(enable=True)` and
+  `USE_PROPERTY_LOOKUP_TABLE=false` both still pin legacy mode (rollback works). The
+  `app.py:419` docstring ("When False (default), uses new lookup table") becomes true —
+  changelog notes the resolved inconsistency.
+- **Three-tier read fallback** (`actingweb/db/dynamodb/property.py:152-181`): in lookup
+  mode, an *indexed*-name read tries **v2 → v1 lookup table (if that table exists) →
+  legacy GSI (if the index exists on the live table)**; missing-table/missing-index cases
+  are caught → `None`. Any fallback **hit** logs a deprecation warning naming the
+  backfill script. The v1 tier is what keeps the already-adopted-lookup-mode cohort
+  (populated v1 table, no GSI — the measured production shape) logging in between upgrade
+  and backfill. Mirror the GSI-tier fallback in `db/postgresql/property.py` (its legacy
+  branch is a sequential scan — the deprecation warning is doubly motivated there; PG has
+  no v1/v2 split). Behaviour-change changelog line: legacy matching was value-only;
+  lookup matching is (name, value) — cross-name collisions the legacy path resolved now
+  return `None` once the fallbacks are removed (the fallback chain preserves old
+  behaviour meanwhile). All fallback tiers removed in the next major.
+- **Loud startup check**: modeled on `_warn_lambda_async_callbacks` (app.py:122) — at
+  integration time, lookup mode active AND `_properties` non-empty AND
+  `_property_lookup_v2` empty → `logger.error` naming
+  `scripts/backfill_property_lookup.py` (message distinguishes "v1 table found — run the
+  backfill to migrate to the v2 format, then drop v1" from "no lookup data at all — run
+  the backfill"). One cheap probe per table, once per process, behind the ensure-cache;
+  skipped when auto-create is off and tables are unreachable.
+- **Backfill script**: `scripts/backfill_property_lookup.py` —
+  - uses the config-aware factory (`actingweb.db.get_property(config)`), **never** direct
+    `DbProperty()` construction (its env fallback can disagree with app config);
+  - reads `indexed_properties` from resolved config (env/`INDEXED_PROPERTIES` respected),
+    never a hardcoded list;
+  - writes the **v2 digest format** — digests computed from stored values **verbatim**
+    (no re-encoding, no sanitisation, no lowercasing; runtime lookups are exact-match
+    against post-write strings). The properties table is the source of truth; v1 rows are
+    never read as input, only optionally counted for the post-migration verification
+    report;
+  - streaming (never accumulates the table), `--rps` rate limit, parallel
+    `scan(segment=i, total_segments=N)`, checkpointed `last_evaluated_key` resume,
+    `--dry-run`, idempotent conditional puts (not delete+put);
+  - detects and **reports** cross-actor value collisions (actor ids + property name +
+    digest prefix, never the value) instead of silently overwriting;
+  - prints a completion summary the migration doc's verification step keys off (rows
+    written / already-present / collisions), after which the operator may drop the v1
+    table;
+  - explicitly not modeled on `scripts/migrate_dynamodb_to_postgresql.py:113-127`
+    (accumulates unbounded memory).
+- **Migration doc**: `docs/migration/v3.13.rst` (conventions per v3.10/v3.11), containing:
+  the deployment-state decision tree (legacy-GSI table + implicit default; pre-GSI table;
+  explicit legacy; already-lookup-on-v1; fresh), backfill invocation + verification, the
+  v1→v2 lookup migration (run backfill → verify counts → drop `_property_lookup` v1; v1
+  is derived data, the properties table is the source of truth), the
+  `update-table --billing-mode` runbook (once-per-24h; **never recreate** the properties
+  table), how to pin legacy mode, optional post-verification GSI drop on existing tables,
+  IAM slimming (`CreateTable`/`DescribeTable` droppable with auto-create off; the role
+  needs access to the new `_property_lookup_v2` table name — IaC-managed policies with
+  per-table ARNs must add it).
+- **Docs corrections** (actively-wrong lines): `docs/quickstart/configuration.rst:414,445,
+  ~500,511,524` (defaults, rollback, backfill script name),
+  `docs/reference/database-backends.rst:371`; soften "auto-creates tables" claims with
+  "(configurable; disable in production via `AWS_DB_AUTO_CREATE_TABLES=false`)" at
+  `configuration.rst:150,200`, `database-backends.rst:19`, `local-dev-setup.rst:55-60,136`;
+  README.rst:202-210 "optional" reverse-lookup wording; document `with_dynamodb()`, the
+  env flag, and `AWS_DB_PREFIX` (currently undocumented in configuration.rst); add the
+  provisioned→on-demand runbook to `docs/guides/database-maintenance.rst`; one added
+  sentence at `docs/contributing/architecture.rst:483-492` (direct construction now
+  disagrees with the app default in the more dangerous direction).
+- **CHANGELOG.rst** — Unreleased entries for every phase, including the behaviour changes:
+  suspension/peertrustee tables now auto-created; deterministic list ordering; billing
+  default; the flip + fallback + backfill; the Phase 1 bug fix.
+- **thoughts/todo/** (note: singular `todo`, the existing dir) —
+  `legacy-property-gsi-removal.md`: next-major removal of PropertyIndex, the legacy code
+  path, the dual-read fallback, and the direct-construction env fallback;
+  `dynamodb-known-next.md`: the five deferred scalability items with the evaluator's
+  file:line inventory (batch deletes incl. `property_list.py:351-390` worst case; list
+  `__getitem__`/`__delitem__`; `consistent_read` audit list; `subscription_diff.py:50-60`
+  ordering; `DbActorList` pagination; secret-uniqueness eventual-consistency note at
+  `trust.py:273-278`); the GSI-removal doc also covers next-major removal of the v1
+  lookup model/table and both fallback tiers.
+- **Demo app coordination** (separate repo, not in this plan's diffs): keep auto-create on;
+  add comments in `serverless.yml` (why CreateTable/DescribeTable are needed, how to drop
+  them in production) and a commented-out CFN `resources:` block as canonical schema;
+  README "demo vs production" note; keep the now-default `with_legacy_property_index(
+  enable=False)` line as a teaching artifact. Also note its IAM `table/demo_*` resource
+  matches GSI ARNs only by accident of `*` spanning `/`.
+
+### New Tests
+
+- Integration (upgrade simulations, the critical ones — one per cohort):
+  (a) legacy-GSI cohort: properties + GSI table shape, no lookup tables → resolves via
+  GSI fallback with deprecation warning; after backfill, resolves from v2 without
+  fallback. (b) v1-lookup cohort (the measured production shape): properties + populated
+  v1 table, **no GSI**, empty v2 → resolves via v1 fallback with deprecation warning;
+  after backfill, resolves from v2; v1 drop leaves everything working.
+- Integration: backfill script — dry-run counts, resume from checkpoint mid-scan, verbatim
+  value fidelity (value with JSON encoding + >1024-byte value skipped-with-report),
+  collision reporting, idempotent re-run.
+- Unit: startup check fires exactly under (lookup on ∧ properties>0 ∧ lookup==0) and is
+  silent otherwise.
+- Unit: rollback path — `USE_PROPERTY_LOOKUP_TABLE=false` after flip restores legacy
+  behaviour end-to-end (depends on Phase 1).
+- Existing suite: `tests/test_property_lookup.py::TestConfigurationIntegration::
+  test_config_defaults` updated for the new default (deliberate, called out in review).
+
+### Verification
+
+- [ ] `poetry run pytest tests/test_property_lookup.py tests/integration -v` passes
+- [ ] `poetry run pyright actingweb tests` — 0 errors; `poetry run ruff check` passes
+- [ ] `make test-all-parallel` passes
+- [ ] `poetry run sphinx-build -b html docs _build 2>&1 | grep -i warning` (or the repo's
+      docs build target) — no new warnings from edited .rst files
+- [ ] Manual: fresh-prefix end-to-end against DynamoDB Local — deploy, write indexed
+      property, reverse-lookup, verify no GSI on table, verify PAY_PER_REQUEST
+
+### Implementation Status: Not Started
+
+---
+
+## Evaluation Notes
+
+Four parallel evaluations were run against the codebase at `29783f8`; all findings were
+verified with file:line evidence before incorporation.
+
+### Architecture
+Found the Phase 1 blocker: flipping `config.py:64` alone is a no-op (builder clobbers env
+via the dead `hasattr` guard, app.py:190-193) — promoted to its own prerequisite phase.
+Confirmed pynamodb 6.1.0 mechanics: `create_table` strips provisioned throughput for table
+and GSIs under PAY_PER_REQUEST; GSI-level `billing_mode` is a no-op (dropped from plan);
+runtime `_indexes` mutation is fragile → two-model-class approach chosen for Phase 7; memo
+key must be the model class. Verified all in-library Db* construction goes through
+factories; the direct-construction env fallback is dead code for the library but
+load-bearing for ~40 test call sites → kept, removal deferred to next major. PG parity:
+lookup table + Alembic migration already exist; PG's legacy branch is already an unindexed
+sequential scan (migration `c3d4e5f6a7b8` dropped the value index unconditionally), which
+strengthens the flip rationale. Flagged legacy value-only vs lookup (name,value) matching
+as a behaviour change → changelog + fallback preserves old semantics until next major.
+
+### Security
+Trust `consistent_read` downgraded from auth-bypass to correctness (auth oracle goes
+through `Trust.get`/`secret_index`, not the list fetch) — still preserved explicitly with a
+kwarg-assert test (query defaults to eventually-consistent). Lookup misses cause silent
+`None`, and duplicate-actor risk is consumer-side (`get_by_property` has no in-library
+callers) → dual-read fallback + startup check chosen. Lookup writes fail silently
+(`LOOKUP_TABLE_SYNC_FAILED` swallow) → Phase 6 loud logging; value never logged
+(credential-equivalent). Lookup `value` is a **range key** → 1024-byte cap, half the GSI's
+→ Phase 6 validation + docs. `_ensure` must gate `exists()` too, or IAM-hardened roles leak
+AccessDenied (with role ARN/account id) into authenticated `str(e)` responses → Phase 2
+requirement. Backfill: verbatim values, config-aware factory, config-resolved indexed list,
+collision reporting → Phase 8 requirements. Fail-fast message: no ARNs/region/value.
+
+### Scalability
+Post-scan-fix, the dominant waste is the property-store N+1 chain (`to_dict` re-reads every
+property; double partition read per GET; per-list meta re-reads; collision-check GetItems;
+double `InternalStore` bucket Query) → Phase 5. Cold-start residual (~8 serial
+DescribeTables) → flag-gated parallel pre-warm in Phase 2. Backfill hard requirements
+(resume, rate limit, segments, streaming) → Phase 8; existing migration script rejected as
+a template. Five larger items deferred with rationale (see Decisions); negative
+permission-cache and duplicate delete-scan promoted into Phase 5.
+
+### Post-evaluation design decision: lookup-table v2 (digest-only)
+After the four evaluations, a direct design review of `PropertyLookup` concluded the
+`(property_name, value)` key is not scale-safe: three indexed property names means three
+partition keys, concentrating all login-path traffic on single partitions (1,000 WCU /
+3,000 RCU pre-split ceiling — split-for-heat is reactive and lags burst load); the range
+key caps values at 1024 bytes while the docstring claims the opposite; PII lives in key
+material where it can never be pseudonymized without a format migration; and puts are
+unconditional last-writer-wins. User selected the **digest-only** variant (value never
+stored). Because the Phase 8 backfill will populate this table across every deployment,
+the format change was pulled into this release — the only moment it is cheap (45 rows in
+the measured production table). Consequences propagated into the plan: new
+`_property_lookup_v2` table (key schemas are immutable), v1 kept read-only for rollback,
+the dual-read fallback became three-tier (v2 → v1 → GSI) to protect the
+already-on-lookup-mode cohort whose tables have no GSI to fall back to, and the 1024-byte
+validation originally planned for Phase 6 was dropped as obsolete.
+
+### Usability
+Deployment-state matrix showed fail-fast (explicit legacy) and flip risk (implicit legacy)
+protect disjoint cohorts, leaving the largest cohort uncovered → startup `logger.error`
+made mandatory (Phase 8) and dual-read fallback chosen over the two-release split the
+evaluator preferred (user decision: single release, made safe). Fluent naming
+`with_dynamodb(auto_create_tables=)` + `AWS_DB_AUTO_CREATE_TABLES` per existing
+conventions; `RuntimeError` fail-fast (no custom exception hierarchy exists) with the
+three-ways-out message drafted in Phase 6. Six actively-wrong doc lines identified and
+scheduled with the flip (Phase 8); demo-app guidance recorded as coordination notes.
+`thoughts/todo` (singular) confirmed as the tracking location.

--- a/thoughts/plans/2026-07-23-dynamodb-scalability.md
+++ b/thoughts/plans/2026-07-23-dynamodb-scalability.md
@@ -180,13 +180,21 @@ IaC-managed production.
 
 ### Verification
 
-- [ ] `poetry run pytest tests/ -k "ensure or auto_create" -v` passes
-- [ ] `poetry run pyright actingweb tests` — 0 errors; `poetry run ruff check` passes
-- [ ] `make test-all-parallel` passes (exercises `reset_ensure_cache` wiring via xdist)
-- [ ] Manual: run any integration test with `PYNAMODB_DEBUG`/boto logging and confirm
-      exactly one `DescribeTable` per table per process
+- [x] `poetry run pytest tests/test_ensure_table.py` — 22 passed
+- [x] `poetry run pyright actingweb tests` — 0 errors; `poetry run ruff check` passes
+- [x] `make test-all-parallel` — 2399 passed; 2 known-flaky xdist tests pass sequentially
+      (same family failed on master pre-change)
+- [x] Memoisation verified by unit call-count tests (mocked exists/create_table)
 
-### Implementation Status: Not Started
+### Implementation Status: Complete
+
+**Implementation note (found the hard way):** importing anything under
+`actingweb.db.dynamodb` triggers the package `__init__`, which imports every model
+module and permanently freezes `Meta.table_name`/`host` from env. The conftest's
+`reset_ensure_cache` import tripped this before the test env was set; fixed by
+setting the backend env vars at the top of the session-scoped `setup_database`
+fixture. The same hazard applies to consumer code importing db modules before
+configuring env — added to the known-next doc (deferred table-name resolution).
 
 ---
 
@@ -544,8 +552,11 @@ Ships last, after every safety mechanism above is in place.
   file:line inventory (batch deletes incl. `property_list.py:351-390` worst case; list
   `__getitem__`/`__delitem__`; `consistent_read` audit list; `subscription_diff.py:50-60`
   ordering; `DbActorList` pagination; secret-uniqueness eventual-consistency note at
-  `trust.py:273-278`); the GSI-removal doc also covers next-major removal of the v1
-  lookup model/table and both fallback tiers.
+  `trust.py:273-278`; import-time freezing of `Meta.table_name`/`host` from env —
+  importing anything under `actingweb.db.dynamodb` binds all models permanently, a trap
+  for consumers that configure env after import; consider deferred resolution); the
+  GSI-removal doc also covers next-major removal of the v1 lookup model/table and both
+  fallback tiers.
 - **Demo app coordination** (separate repo, not in this plan's diffs): keep auto-create on;
   add comments in `serverless.yml` (why CreateTable/DescribeTable are needed, how to drop
   them in production) and a commented-out CFN `resources:` block as canonical schema;

--- a/thoughts/research/2026-07-23-dynamodb-scaling-defects.md
+++ b/thoughts/research/2026-07-23-dynamodb-scaling-defects.md
@@ -1,0 +1,489 @@
+# DynamoDB backend scaling defects: hash-key `Scan`s and per-construction `DescribeTable`
+
+Date: 2026-07-23 (reviewed same day: call sites, pynamodb behaviour and live-table state
+re-verified; implementation gotchas expanded; Defect 4 added)
+Branch: master (commit `29783f8`)
+Origin: measured in the `actingweb_mcp` production deployment (`ai.actingweb.io`,
+`eu-central-1`); companion doc at
+`../actingweb_mcp/thoughts/research/2026-07-23-scaling-review-apigw-lambda-dynamodb.md`
+
+## Summary
+
+Two independent defects in `actingweb/db/dynamodb/` dominate the scaling behaviour of any
+ActingWeb deployment on DynamoDB. Both are library-side, both are invisible at small
+scale, and both degrade **superlinearly** as data and traffic grow:
+
+1. **Eight `Model.scan()` calls filter on the partition key where `Model.query()` should
+   be used.** Every one reads the entire table and discards non-matching items
+   client-side. Measured in production: **486,322 RCU consumed in 6 hours** on a
+   16.7 MB properties table holding data for **47 actors** — ≈239 full-table scans.
+   Read cost is `O(total table size) × requests`, so each new actor makes every
+   *existing* actor's read more expensive.
+
+2. **Every `Db*.__init__` issues a live `DescribeTable` control-plane call.** The
+   `if not X.exists(): X.create_table()` guard is repeated at 13 sites across 8 model
+   modules and is not memoised; pynamodb's `exists()` never consults its own metadata
+   cache. Measured: **1,396 `DescribeTable` calls/minute** at essentially zero
+   application traffic.
+
+A third, lesser issue: tables auto-created by that same guard inherit pynamodb `Meta`
+provisioned-throughput defaults (1–26 RCU) instead of on-demand billing, silently
+creating hard throughput walls on any table not separately declared in the deployer's
+infrastructure-as-code. **Correction from review:** in the measured deployment one of
+the two affected tables (`_property_lookup`) is *live on the login path*, not dormant —
+see Defect 3.
+
+A fourth issue found in review: the `Property` model **unconditionally declares a GSI
+keyed on the property `value`** (`property-index`), while the lookup-table feature that
+was built to replace it is toggled by *config only*. Schema and config are decoupled, so
+fresh auto-created tables carry the legacy GSI (and its 2048-byte key limit and write
+amplification) even when the lookup table is enabled — and older tables created before
+the GSI existed (including the measured production table, verified live: no GSIs) crash
+the legacy fallback code path if config ever selects it. See Defect 4.
+
+None of these can be mitigated by AWS limit increases. All are fixable in this library
+without touching consumer code.
+
+---
+
+## Defect 1: `scan()` with a partition-key filter
+
+### The pattern
+
+```python
+# actingweb/db/dynamodb/property.py:381
+self.handle = Property.scan(Property.id == actor_id)
+```
+
+`Property.id` is the **hash key**:
+
+```python
+class Property(Model):
+    id    = UnicodeAttribute(hash_key=True)
+    name  = UnicodeAttribute(range_key=True)
+    value = UnicodeAttribute()
+```
+
+pynamodb's `scan(condition)` issues a DynamoDB `Scan` with a `FilterExpression`. DynamoDB
+applies filters *after* reading, so the read cost is the full table regardless of how few
+items match. `Property.query(actor_id)` reads only the target partition.
+
+### Full call-site inventory
+
+| File | Line | Call | Verdict |
+| --- | --- | --- | --- |
+| `property.py` | 381 | `Property.scan(Property.id == actor_id)` — `DbPropertyList.fetch` | **Defect** → `query` |
+| `property.py` | 399 | `Property.scan(Property.id == actor_id)` — `fetch_all_including_lists` | **Defect** → `query` |
+| `property.py` | 418 | `Property.scan(Property.id == self.actor_id)` — `delete`, indexed collect | **Defect** → `query` |
+| `property.py` | 424 | `Property.scan(Property.id == self.actor_id)` — `delete`, main | **Defect** → `query` |
+| `trust.py` | 455 | `Trust.scan(Trust.id == self.actor_id, consistent_read=True)` | **Defect** → `query` (2× cost, see below) |
+| `trust.py` | 521 | `Trust.scan(Trust.id == self.actor_id, consistent_read=True)` | **Defect** → `query` (2× cost) |
+| `peertrustee.py` | 153 | `PeerTrustee.scan(PeerTrustee.id == self.actor_id)` | **Defect** → `query` |
+| `peertrustee.py` | 171 | `PeerTrustee.scan(PeerTrustee.id == self.actor_id)` | **Defect** → `query` |
+| `peertrustee.py` | 49 | `scan((PeerTrustee.id == actor_id) & (PeerTrustee.type == peer_type))` | **Defect** → `query(actor_id, filter_condition=...)` |
+| `actor.py` | 162 | `Actor.scan()` — `DbActorList.fetch`, no condition | **Intentional** (list-all); see caveat |
+
+All of `Property`, `Trust` and `PeerTrustee` use `id` (the actor id) as hash key, so all
+eight are mechanical `scan(...)` → `query(...)` conversions.
+
+The conversion pattern is already proven in this codebase: `attribute.py`,
+`subscription.py` and `subscription_diff.py` — the same hash/range shape — use
+`Model.query(actor_id, ...)` throughout, including with `consistent_read=True`. The
+eight scan sites are the stragglers, not a different design.
+
+The two `trust.py` sites are the worst per-call: `consistent_read=True` doubles RCU
+consumption (1.0 rather than 0.5 per 4 KB), so a strongly-consistent full-table scan costs
+twice the already-inflated figure.
+
+`actor.py:162` is a deliberate "list every actor" operation and cannot become a `query`.
+It is not a defect, but it is `O(table)` and unpaginated — worth documenting as an
+admin-only call and a candidate for pagination, since it will eventually time out.
+
+### Production evidence
+
+Live table (`AI_properties`), key schema confirmed via `describe-table`:
+
+```json
+KeySchema:      [{"AttributeName":"id","KeyType":"HASH"},
+                 {"AttributeName":"name","KeyType":"RANGE"}]
+TableSizeBytes: 16,678,841
+ItemCount:      2,567
+```
+
+Cost per scan: 16,678,841 B ÷ 4 KB ≈ 4,072 blocks × 0.5 ≈ **2,036 RCU per call**, versus
+~1 RCU for the equivalent `query`.
+
+`ConsumedReadCapacityUnits`, peak 5-minute sums, same window, same deployment:
+
+| Table | Peak 5-min Sum | Access pattern |
+| --- | --- | --- |
+| `AI_properties` | **152,073** | `Scan` |
+| `AI_attributes` | 1,246 | mixed (no scan sites) |
+| `AI_actors` | 87 | `Query` / `Get` |
+
+**1,748×** between the scanned and the queried table — for 47 actors.
+
+Six-hour aggregate on `AI_properties`:
+
+```
+6h total RCU:      486,322
+projected/day:   1,945,286
+avg sustained:        22.5 RCU/s
+scan-equivalents:      239 full-table scans in 6h
+```
+
+### Why this is the dominant scaling constraint
+
+Read cost is `O(total table size) × requests` — superlinear in users. At ~2,036 RCU per
+fetch, a table's on-demand read ceiling is reached at roughly **20 property fetches per
+second**, and that ceiling *halves every time the table doubles in size*. This binds well
+before any API Gateway or Lambda concurrency limit, and unlike those it is not raisable by
+support ticket.
+
+> The "20/s" figure infers from the documented default on-demand per-table maximum
+> (40,000 RCU) and was **not** verified against the measured account's Service Quotas. The
+> 2,036 RCU/fetch and 486,322 RCU/6h figures are directly measured.
+
+Secondary effect: DynamoDB paginates `Scan` at 1 MB, so a 16.7 MB table means ~17
+sequential round trips per logical fetch — a latency cost that holds a caller's execution
+slot open (in Lambda deployments, a concurrency slot).
+
+### Proposed fix
+
+Mechanical, per call site:
+
+```python
+# before
+self.handle = Property.scan(Property.id == actor_id)
+# after
+self.handle = Property.query(actor_id)
+
+# before (peertrustee.py:49)
+PeerTrustee.scan((PeerTrustee.id == actor_id) & (PeerTrustee.type == peer_type))
+# after
+PeerTrustee.query(actor_id, filter_condition=PeerTrustee.type == peer_type)
+```
+
+`query()` returns the same `ResultIterator`, so the surrounding iteration code is
+unchanged. `consistent_read=True` is a valid `query()` kwarg, so `trust.py` keeps its
+semantics.
+
+**Behavioural caveats to check during implementation** (expanded in review):
+
+1. **Delete scope.** `scan()` returns items across all partitions; `query()` is scoped
+   to one. For these eight sites the filter already restricts to a single `id`, so
+   results should be identical — but `property.py:418/424` (`delete`) is the one to
+   verify carefully, since a silent scope change there would mean under-deletion. Worth
+   a test asserting that deleting actor A's properties leaves actor B's intact, which is
+   exactly the case the current scan-based code gets right by accident and a buggy
+   conversion could break.
+2. **Result ordering changes.** `Scan` returns items in arbitrary order; `Query` returns
+   them sorted by range key (`name` / `peerid`). `DbPropertyList.fetch` builds a dict so
+   this is invisible there, but `DbTrustList.fetch` and `DbPeerTrusteeList.fetch` return
+   arrays whose order becomes deterministic after the change. Harmless — arguably an
+   improvement — but observable to consumers and to any order-sensitive test.
+3. **Unguarded `None` hash key.** `DbTrustList.delete()` (trust.py:521) and
+   `DbPeerTrusteeList.delete()` (peertrustee.py:171) use `self.actor_id` without
+   checking it was set by a prior `fetch()`. Today `scan(Trust.id == None)` fails at
+   condition serialisation; `query(None)` fails too, just with a different exception.
+   Not a regression either way, but add the `if not self.actor_id: return False` guard
+   (which `DbPropertyList.delete()` already has) while touching these lines.
+4. **Truthiness is unchanged.** Both `scan()` and `query()` return a lazily-evaluated
+   `ResultIterator`, which is always truthy — so the various `if self.handle:` checks
+   behave identically before and after (they never detected emptiness in the first
+   place).
+
+## Defect 2: `DescribeTable` on every accessor construction
+
+### The pattern
+
+Repeated verbatim at 13 sites across 8 model modules — `actor.py:143`, `property.py:81`
+and `:365`, `attribute.py:334` and `:401`, `trust.py:431` and `:533`,
+`subscription.py:157` and `:218`, `subscription_diff.py:103` and `:171`,
+`peertrustee.py:128`, `property_lookup.py:57`. (One wrapper, `DbPeerTrusteeList`, has
+*no* guard — an existing inconsistency that the centralised fix below erases rather than
+preserves.)
+
+```python
+def __init__(self):
+    self.handle = None
+    if not Property.exists():
+        try:
+            Property.create_table(wait=True)
+        except Exception as e:
+            if "ResourceInUseException" in str(e):
+                pass
+            else:
+                raise
+```
+
+### Why it is not free
+
+Verified against installed pynamodb 6.1.0:
+
+```python
+# pynamodb/models.py:752
+@classmethod
+def exists(cls) -> bool:
+    try:
+        cls._get_connection().describe_table()
+        return True
+    except TableDoesNotExist:
+        return False
+
+# pynamodb/connection/base.py:650
+def describe_table(self, table_name: str) -> Dict:
+    data = self.dispatch(DESCRIBE_TABLE, operation_kwargs)   # <- always a network call
+    ...
+    if meta_table.table_name not in self._tables:
+        self.add_meta_table(meta_table)
+```
+
+`describe_table` *populates* the `_tables` metadata cache but never reads from it first.
+There is no short-circuit. So every accessor construction blocks on a control-plane round
+trip before any application work begins.
+
+### Production evidence
+
+CloudTrail `DescribeTable`, per-minute histogram:
+
+```
+14:01  1,290/min
+14:07  1,396/min
+14:11  1,307/min
+```
+
+≈23 calls/second with almost no application traffic. Caller identity:
+
+```
+principal: arn:aws:sts::…:assumed-role/…-lambdaRole/actingweb-mcp-prod-app
+userAgent: Botocore/1.43.40 … os/linux … lang/python#3.11.15
+table:     AI_attributes
+```
+
+The distribution is bursty — 50+ calls inside 2 seconds, then idle — consistent with one
+request constructing many accessors, each firing its own `DescribeTable`.
+
+### Framing of the harm
+
+The provable, primary harm is a **latency tax per constructed object**, scaling with
+`traffic × objects-per-request`. In serverless deployments it is worse than the raw number
+suggests: a cold container runs the whole sweep serially on its first request, so this
+cost lands precisely during a scale-up burst.
+
+Control-plane throttling is a plausible secondary risk. This document deliberately asserts
+no `DescribeTable` quota figure, as none was verified.
+
+### Proposed fix
+
+Collapse from per-object to once-per-process-per-table with a module-level guard, keeping
+the developer-convenience auto-create behaviour intact:
+
+```python
+# actingweb/db/dynamodb/_ensure.py  (new)
+import threading
+
+_ensured: set[str] = set()
+_lock = threading.Lock()
+
+def ensure_table(model) -> None:
+    """Create the model's table if absent — at most once per process per table."""
+    name = model.Meta.table_name
+    if name in _ensured:
+        return
+    with _lock:
+        if name in _ensured:
+            return
+        if not model.exists():
+            try:
+                model.create_table(wait=True)
+            except Exception as e:
+                if "ResourceInUseException" not in str(e):
+                    raise
+        _ensured.add(name)
+```
+
+Each `__init__` block becomes `ensure_table(Property)`. This removes ~99% of the calls
+while preserving current semantics.
+
+**Gotchas found in review:**
+
+1. **Test isolation.** The integration test harness deletes tables in-process
+   (`tests/integration/conftest.py:154`, `cleanup_dynamodb_tables`, invoked from
+   session-scoped fixtures). Today the deletions happen at session boundaries, so the
+   memoised set is safe with the current suite — but any future fixture that drops
+   tables mid-process would silently break: `_ensured` would still claim the table
+   exists. Ship a `reset_ensure_cache()` (or make `_ensured` clearable) and call it from
+   the cleanup helper, so the invariant is enforced rather than accidental.
+2. **Cold start still pays a serial sweep.** With the guard, a fresh process still
+   issues one `DescribeTable` per table (~8) on its first request — tens of
+   milliseconds each, serially. That is why the opt-out flag below matters for
+   serverless deployments, where it takes the residual cost to zero.
+3. **Multi-prefix processes.** Keying `_ensured` by `Meta.table_name` is correct today
+   because the prefix is baked into `table_name` at import time from `AWS_DB_PREFIX`;
+   a process can only ever see one prefix. If table names ever become dynamic, the key
+   must follow.
+
+Worth doing alongside it (not just "considering"): an opt-out env flag (e.g.
+`AW_DB_AUTO_CREATE_TABLES`, default on) so production deployments that manage tables via
+CloudFormation/Terraform can skip the check entirely. Auto-creating tables from
+application code is convenient in development but is arguably wrong in production, where
+it also demands `dynamodb:CreateTable` (and this pattern, `dynamodb:DescribeTable`) in
+the runtime IAM role — with the flag off, both can be dropped from the policy.
+
+## Defect 3 (minor): provisioned-throughput defaults on auto-created tables
+
+Because Defect 2's guard creates tables from application code, those tables inherit the
+pynamodb `Meta` defaults rather than the deployer's intent:
+
+```python
+class Property(Model):
+    class Meta:
+        read_capacity_units = 26
+        write_capacity_units = 2
+
+class PropertyIndex(GlobalSecondaryIndex[Any]):
+    class Meta:
+        read_capacity_units = 2
+        write_capacity_units = 1
+```
+
+Observed in the production account, where every table declared in the consumer's
+CloudFormation is `PAY_PER_REQUEST` but the two auto-created ones are not:
+
+```
+AI_property_lookup   PROVISIONED   2 RCU / 1 WCU
+AI_peertrustees      PROVISIONED   1 RCU / 1 WCU
+(all others)         PAY_PER_REQUEST
+```
+
+1 WCU is one write per second. `property_lookup` backs email / `oauthId` → actor
+resolution, i.e. the login path — and **in the measured deployment it is already
+enabled and live** (review correction: the consumer enables it via
+`.with_legacy_property_index(enable=False)` in its app builder, which sets
+`config.use_lookup_table = True`; the `USE_PROPERTY_LOOKUP_TABLE` env var is only one
+of three ways the flag can be set — see the config-plumbing note below). Verified
+against the live table: 45 items, 4 RCU / 5 WCU consumed over 24 h. So this is not a
+dormant landmine: it is a **live 2 RCU / 1 WCU wall on the login path**, currently
+invisible only because traffic is tiny and DynamoDB burst credits absorb spikes. Nothing
+in the library warns about it.
+
+**Proposed fix:** set `billing_mode = PAY_PER_REQUEST_BILLING_MODE` in each model `Meta`
+so auto-created tables scale by default, and treat the `*_capacity_units` values as dead
+configuration to be removed. On-demand is the correct default for a library that cannot
+know its consumer's traffic shape. Verified against installed pynamodb 6.1.0: when
+`billing_mode == PAY_PER_REQUEST`, `Connection.create_table` omits
+`ProvisionedThroughput` for both the table and every GSI, so the stale
+`*_capacity_units` values in `Meta` and index `Meta` classes become inert.
+
+**For already-created tables** the fix is an in-place conversion, *not* a recreate:
+
+```bash
+aws dynamodb update-table --table-name <prefix>_property_lookup \
+  --billing-mode PAY_PER_REQUEST
+```
+
+Recreating would destroy live data (the measured deployment's lookup table holds the
+login-path rows). Note the AWS constraint: a table's billing mode can only be switched
+once per 24 hours.
+
+**Config-plumbing wart (related, minor):** `use_lookup_table` has three sources of
+truth — the `Config` default, the `USE_PROPERTY_LOOKUP_TABLE` env override
+(`config.py:254`), and the fluent `with_legacy_property_index()` setter. Core paths get
+the resolved value injected via the `actingweb.db.get_property()` factory, but
+`DbProperty` / `DbPropertyList` constructed *directly* with no arguments silently fall
+back to reading the env var (`property.py:96`), which can disagree with the app-level
+setting. All in-library call sites use the factory today; the direct-construction
+fallback is a trap for consumer scripts and should either be removed or made to raise.
+
+## Defect 4 (design, found in review): the legacy `value` GSI is schema, but the toggle is config
+
+The `Property` model unconditionally declares a GSI whose **hash key is the property
+value**:
+
+```python
+# actingweb/db/dynamodb/property.py:18
+class PropertyIndex(GlobalSecondaryIndex[Any]):
+    class Meta:
+        index_name = "property-index"
+        projection = AllProjection()
+    value = UnicodeAttribute(default="0", hash_key=True)
+
+class Property(Model):
+    ...
+    property_index = PropertyIndex()
+```
+
+The lookup-table feature (`use_lookup_table` / `with_legacy_property_index(False)`) was
+introduced precisely to escape this GSI's 2048-byte key limit — the library's own
+docstring says the legacy path is "limited to 2048 bytes". But the flag only selects
+which *code path* `get_actor_id_from_property()` takes. The GSI itself is part of the
+model schema, and `create_table` always includes all declared indexes. The schema and
+the config can therefore disagree in both directions:
+
+1. **Fresh deployments get the legacy GSI even in lookup-table mode.** A newly
+   auto-created `_properties` table carries `property-index` with `AllProjection`,
+   which means (a) every property write is duplicated into the GSI — double write cost
+   and double storage for a table that the lookup-table mode never reads — and (b) per
+   DynamoDB's documented limit, **a write whose `value` exceeds 2048 bytes is rejected
+   outright** (`ValidationException`), regardless of which lookup mode the app runs in.
+   List/memory properties routinely exceed 2 KB. *Caveat: the write-rejection behaviour
+   is asserted from AWS documentation and the library's own docstring; it was not
+   empirically reproduced in this pass (no local DynamoDB was running) — verify with a
+   >2 KB property write against a freshly auto-created table before treating it as
+   confirmed.*
+2. **Old tables lack the GSI, and the legacy code path assumes it exists.** The
+   measured production table was created before `PropertyIndex` existed and has **no
+   GSIs at all** (verified live: `GlobalSecondaryIndexes: null`). pynamodb never adds
+   indexes to existing tables. On such a table, any config that selects the legacy path
+   (`use_lookup_table = False`, the library default) makes
+   `Property.property_index.query(value)` fail at runtime on the missing index. The
+   library default configuration is therefore broken on this class of table.
+
+The likely explanation for why production large-value writes work today is exactly (2):
+the table predates the GSI, so the limit never applied there. That is luck, not design.
+
+**Proposed direction:** stop declaring `PropertyIndex` on the model unconditionally.
+Options, in rough preference order: (a) drop the GSI from the model and make
+lookup-table mode the only reverse-lookup mechanism, with a migration/release note for
+legacy-GSI users; (b) keep the legacy code path but build the index list dynamically at
+table-creation time so lookup-table deployments create tables without the GSI; (c) at
+minimum, fail fast with a clear error when the legacy path is selected but the index is
+absent from the live table. Whichever is chosen, the invariant to restore is: *the
+schema a deployment creates matches the code path its config selects.*
+
+(`Trust.secret_index` and `Actor.creator_index` are also model-declared GSIs, but both
+are keyed on short, code-generated values and are actively used by their query paths —
+no equivalent problem.)
+
+## Suggested sequencing
+
+1. **Defect 2** first — smallest diff, no behavioural risk, immediate and large win.
+2. **Defect 1** next — mechanical but wants the per-site delete-scope tests described
+   above.
+3. **Defect 3** — trivial code change, but note it only affects *newly* created tables;
+   existing provisioned tables must be converted out-of-band by the deployer via
+   `update-table --billing-mode PAY_PER_REQUEST` (in place, once per 24 h — never by
+   recreate, which loses data), so it needs a release-note line.
+4. **Defect 4** — needs a design decision (deprecate the legacy GSI vs. conditional
+   schema) before code; the fail-fast guard in option (c) is a cheap interim step that
+   can ship with Defect 1.
+
+All four are library-internal; no consumer API changes are implied beyond a possible
+deprecation note for the legacy GSI path. Nothing in this document has been
+implemented — it is a research pass only.
+
+## Reproduction commands
+
+```bash
+aws cloudtrail lookup-events \
+  --lookup-attributes AttributeKey=EventName,AttributeValue=DescribeTable \
+  --start-time <iso> --region <region>
+
+aws cloudwatch get-metric-statistics --namespace AWS/DynamoDB \
+  --metric-name ConsumedReadCapacityUnits \
+  --dimensions Name=TableName,Value=<prefix>_properties \
+  --start-time <iso> --end-time <iso> --period 300 --statistics Sum
+
+aws dynamodb describe-table --table-name <prefix>_properties --region <region>
+```

--- a/thoughts/todo/dynamodb-known-next.md
+++ b/thoughts/todo/dynamodb-known-next.md
@@ -1,0 +1,73 @@
+# DynamoDB scalability: known-next items (deferred from v3.13)
+
+**Created:** 2026-07-23. Source: the plan-evaluation pass for
+`thoughts/plans/2026-07-23-dynamodb-scalability.md` (scalability
+evaluator findings, verified against the code at the time). These were
+deliberately deferred — each needs design work or carries behavioural
+risk disproportionate to the v3.13 release. Line references are from
+commit `29783f8`; re-verify before implementing.
+
+## 1. batch_write for delete loops
+`batch_write`/`BatchWriteItem` is used nowhere. Item-by-item serial
+delete loops: `DbPropertyList.delete()`, `DbTrustList.delete()`,
+`attribute.py` `delete_bucket`/`DbAttributeBucketList.delete`/
+`delete_by_chain`, and worst `ListProperty.clear()/delete()` (per item:
+fresh accessor + GetItem + DeleteItem — a 1000-item list delete is 1000
+serial round-trip pairs). `Actor.delete()` cascades through all of them.
+Needs 25-item chunking + unprocessed-item retry; lookup-row cleanup and
+property hooks stay per-item, so batching covers only the raw deletes.
+
+## 2. General ListProperty item N+1 and __delitem__ O(N) shift
+`ListProperty.__getitem__` does a fresh accessor + GetItem per item
+(iteration = N serial GetItems); `__delitem__` shifts every subsequent
+item down with ~3 round trips each. v3.13 fixed the handler-level cases
+(bulk-read serving) — the general fix needs an instance-level item cache
+with staleness semantics, and `__delitem__` needs a key-layout redesign
+(tombstones or stable item ids instead of positional `list:<name>-<i>`).
+
+## 3. consistent_read audit (~22 sites)
+Strongly-consistent reads cost 2× RCU and exclude DAX. Candidates for
+relaxation: bulk list fetches (`property.py` fetch/fetch_all, trust
+list, attribute bucket list, subscriptions). NOT candidates: CAS paths
+(`conditional_update_attr`), read-after-write within a request, the
+post-lookup property load. Deferred because eventual consistency in
+list reads is a behavioural change the test suite and some same-request
+flows may depend on.
+
+## 4. SubscriptionDiff seqnr ordering / unbounded backlog read
+`subscription_diff.py` `get()` without seqnr queries the whole
+`subid:` prefix and scans in memory for the lowest seqnr — the range key
+is a lexicographic string (`"<subid>:<seqnr>"`, unpadded), so numeric
+order ≠ sort order and `limit=1` cannot work. Fixing needs a key-format
+change (zero-padded seqnr or numeric range key) = data migration for
+existing diff rows. A large diff backlog is re-read entirely on every
+fetch until then.
+
+## 5. DbActorList.fetch pagination
+`actor.py` `DbActorList.fetch()` is an unpaginated full-table scan
+materialised into a list. No in-library callers (public API only, docs
+note added in v3.13) — add a limit/cursor API before anyone uses it at
+scale.
+
+## 6. Import-time freezing of Meta.table_name / host
+Every DynamoDB model binds `AWS_DB_PREFIX` / `AWS_DB_HOST` /
+`AWS_DEFAULT_REGION` at class-definition time, and importing ANYTHING
+under `actingweb.db.dynamodb` (the package `__init__` imports every
+model module) freezes all of them. Consumers that configure env after
+import silently talk to the wrong tables/endpoint (bit the test harness
+during v3.13 development). Consider deferred resolution (resolve names
+at first connection, or a `configure()` entry point that fails loudly on
+late changes).
+
+## 7. Trust secret-uniqueness check is eventually consistent
+`trust.py` `is_token_in_db` checks secret uniqueness via the
+`secret-index` GSI (GSIs cannot be strongly consistent), so a
+just-written duplicate secret can be missed. Pre-existing; needs a
+conditional-write uniqueness scheme if it matters.
+
+## 8. Lookup-table write path amplification
+`_update_lookup_entry` on a value change = ownership-check GetItem +
+delete + conditional put. Fine at current scale; a transactional
+(TransactWriteItems) property+lookup write would also close the
+"property saved, lookup write failed" inconsistency window that today
+is only logged (LOOKUP_TABLE_SYNC_FAILED / LOOKUP_CREATE_FAILED).

--- a/thoughts/todo/legacy-property-gsi-removal.md
+++ b/thoughts/todo/legacy-property-gsi-removal.md
@@ -1,0 +1,40 @@
+# Remove the legacy property reverse-lookup machinery (next major release)
+
+**Created:** 2026-07-23 (v3.13 development)
+**Trigger:** the next major version bump
+
+v3.13 made lookup-table (v2, digest-keyed) reverse lookup the default and
+deprecated everything below. One major release later, remove:
+
+1. **`PropertyLegacy` model + `PropertyIndex` GSI class**
+   (`actingweb/db/dynamodb/property.py`) — with it, the legacy-mode table
+   creation branch in `DbProperty.__init__` / `DbPropertyList.__init__`
+   and the fail-fast RuntimeError for missing GSIs.
+2. **The legacy code path in `get_actor_id_from_property`** (both
+   backends): the `use_lookup_table=False` branch, and in PG the
+   value-only sequential-scan fallback.
+3. **The fallback tiers** in the lookup-mode read path:
+   - tier 1: v1 lookup-table reads (`DbPropertyLookup.get_v1`, the v1
+     `PropertyLookup` model, and the `_property_lookup` table docs),
+   - tier 2: legacy GSI reads via `PropertyLegacy.property_index`.
+4. **`use_lookup_table` config surface** — once there is only one
+   mechanism, the flag, `with_legacy_property_index()`,
+   `USE_PROPERTY_LOOKUP_TABLE`, and the mode-conditional in the pre-warm
+   can all go (keep `with_indexed_properties()`).
+5. **The direct-construction env fallback** in `DbProperty` /
+   `DbPropertyList` (`USE_PROPERTY_LOOKUP_TABLE` read in `__init__`) —
+   make config injection via the `actingweb.db` factories mandatory
+   (raise on missing), per
+   `docs/contributing/architecture.rst` "Avoid Direct Instantiation".
+   ~40 test call sites construct accessors directly and need updating.
+
+Release notes must tell legacy-GSI holdouts to migrate BEFORE upgrading
+(the backfill script must still exist in the release they migrate on),
+and remind GSI-cohort deployments they can drop the `property-index` GSI
+from `<prefix>_properties` and the `<prefix>_property_lookup` (v1) table.
+
+Related test surfaces to remove/simplify: the fallback tests in
+`tests/test_lookup_migration.py`, the v1 tests in
+`tests/test_property_lookup_v2.py::TestV1Fallback`, the legacy-mode
+tests in `tests/test_property_lookup.py`, and the legacy-shape tests in
+`tests/test_conditional_gsi_schema.py`.


### PR DESCRIPTION
## DynamoDB backend scalability (v3.13.0)

Fixes the DynamoDB backend's measured superlinear scaling defects and hardens the property reverse-lookup path. See `thoughts/plans/2026-07-23-dynamodb-scalability.md` for the full plan and `docs/migration/v3.13.rst` for the per-deployment migration decision tree.

### What changed

- **Scans → partition queries.** Per-actor property/attribute fetches no longer `Scan` the partition key (~2,036 RCU per fetch); they use `Query`.
- **Memoised table-existence checks.** Eliminates ~1,396 `DescribeTable`/min from un-memoised existence guards. Auto-creation can now be disabled (`AWS_DB_AUTO_CREATE_TABLES=false` / `with_dynamodb(auto_create_tables=False)`) so `DescribeTable`/`CreateTable` IAM permissions can be dropped for IaC-managed deployments.
- **On-demand billing default.** Auto-created tables are always `PAY_PER_REQUEST`; dead provisioned-capacity `Meta` config removed.
- **Lookup-table mode is now the default reverse-lookup mechanism** (`use_lookup_table` defaults to `True`; pin legacy with `with_legacy_property_index(True)` / `USE_PROPERTY_LOOKUP_TABLE=false`). Dual-read fallback + loud startup check + `scripts/backfill_property_lookup.py` make the flip safe for upgrading deployments.
- **Reverse-lookup table redesigned (v2, digest keys).** New `<prefix>_property_lookup_v2` table keyed by `sha256(name, value)`; plaintext value no longer stored. Removes the hot-partition key, the undocumented value-size cap, and plaintext PII in key material. Writes are conditional (collisions logged, not silently overwritten); write failures now logged at ERROR instead of swallowed.
- **Conditional GSI schema.** Fresh `_properties` tables omit the legacy value-keyed `property-index` GSI in lookup-table mode (was paying double write/storage and rejecting values >2 KB). Legacy mode still creates it. Existing tables are never altered.
- **Hot-path N+1 read amplification removed** across the property and actor paths.

### Migration

Upgrading deployments keep resolving reverse lookups through deprecated fallbacks (v1 table, then legacy GSI) with per-hit warnings and a startup ERROR until `scripts/backfill_property_lookup.py` is run. Note the semantic change: lookup-table matching is per `(property name, value)`; the legacy GSI matched on value alone.

### Testing

New test suites: `test_billing_mode`, `test_conditional_gsi_schema`, `test_ensure_table`, `test_hot_path_n_plus_one`, `test_lookup_migration`, `test_property_lookup_v2`, `test_scan_to_query`, plus extended `test_property_lookup`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
