### PR TITLE
Make MCP structuredContent opt-in (v3.13.0rc4)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,7 +75,12 @@ ADDED
   schema has never caused structured output to be emitted, and the library still
   does not validate ``structuredContent`` against a declared schema.
 - **MCP: a warning when ``structuredContent`` is set to a non-object.** MCP
-  requires a JSON object there; a list or string was previously dropped silently.
+  requires a JSON object there; a list, string or number was previously dropped
+  silently. ``None`` is exempt and stays silent — it carries no payload, both
+  reference clients read a null ``structuredContent`` as absent, and
+  ``{"structuredContent": value or None}`` is a legitimate way to express
+  "nothing structured this time". In that case the key is omitted from the
+  response rather than emitted as ``null``.
 
 v3.13.0rc3: August 1, 2026
 --------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ CHANGELOG
 Unreleased
 ----------
 
+v3.13.0rc4: August 3, 2026
+--------------------------
+
 .. note::
 
    This release changes documented MCP behaviour that shipped in the stable

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,75 @@ CHANGELOG
 Unreleased
 ----------
 
+.. note::
+
+   This release changes documented MCP behaviour that shipped in the stable
+   ``v3.11.0`` and ``v3.12.0`` releases. If you expose MCP tools, read
+   ``docs/migration/v3.13.rst`` before upgrading. The migration is a no-op
+   against the older releases, so you can update your hooks first and upgrade
+   afterwards.
+
+CHANGED
+~~~~~~~
+
+- **MCP ``structuredContent`` is now opt-in.** ``tools/call`` results emit
+  ``structuredContent`` only when a tool hook sets that key explicitly, and only
+  when its value is a JSON object. Extra top-level keys are **no longer promoted**
+  into ``structuredContent``.
+
+  Why this changed: at least one major MCP client discards **every** text content
+  block when ``structuredContent`` is present on a result. Under the previous
+  behaviour, adding a single scalar key to a hook's return value silently deleted
+  that tool's entire prose payload — the model received only the promoted keys,
+  and nothing in the protocol reported the loss to either side. Neither reference
+  server implementation promotes individual keys: the SDK's low-level server emits
+  ``structuredContent`` only when ``content`` is its exact serialization, and
+  FastMCP only for a declared return model.
+
+  This is also a hardening improvement. A hook doing
+  ``return {"content": [...], **rel.to_dict()}`` was shipping the trust row's
+  ``secret`` to the model; ``properties.to_dict()`` can likewise carry
+  ``oauth_token`` / ``oauth_refresh_token``. Only an explicitly named
+  ``structuredContent`` now leaves the process. Note the win is scoped to the
+  ``content`` branch — the legacy text-wrap path still stringifies the whole dict.
+
+  Migration: nest the data you want structured under an explicit
+  ``structuredContent`` key, and keep the same object serialized in a text
+  ``content`` block (the spec's backwards-compatibility guidance — some clients
+  ignore ``structuredContent`` entirely). For tools whose payload is prose, drop
+  the extras instead. The explicit passthrough already exists in ``v3.11.0`` and
+  ``v3.12.0``, so migrated hooks produce identical output on both, and no
+  coordinated deploy is needed.
+
+FIXED
+~~~~~
+
+- **MCP: an explicit ``isError`` is now honoured on the legacy text-wrap path.**
+  A hook returning ``{"isError": True, "error": "boom"}`` with no ``content`` key
+  previously reached the wire with no ``isError`` field at all, so the failure was
+  reported to the client as a **success**. ``isError`` is honoured only when the
+  hook sets it — it is never inferred from an ``"error"`` key or any other shape
+  heuristic, so applications that return ``{"error": ...}`` on their normal error
+  path see no change. The ``str(result)`` text serialization is unchanged, so
+  ``isError`` appears both inside that text and as a wire field.
+
+ADDED
+~~~~~
+
+- **MCP: a warning when a tool declares ``output_schema`` but returns no
+  ``structuredContent``.** Spec-conforming clients reject such a result outright
+  (``Tool X has an output schema but did not return structured content``), which
+  was already broken before this release for anyone declaring a schema — the
+  library advertises ``outputSchema`` in ``tools/list`` but never consulted it at
+  call time. The warning fires once per tool per process, at call time, and only
+  when the negotiated protocol version supports structured content, so a
+  correctly-written hook talking to an older client never trips it.
+  ``output_schema`` and ``structuredContent`` remain independent: declaring a
+  schema has never caused structured output to be emitted, and the library still
+  does not validate ``structuredContent`` against a declared schema.
+- **MCP: a warning when ``structuredContent`` is set to a non-object.** MCP
+  requires a JSON object there; a list or string was previously dropped silently.
+
 v3.13.0rc3: August 1, 2026
 --------------------------
 
@@ -746,6 +815,13 @@ MCP:
   an explicit ``structuredContent`` from the hook is passed through, and a
   hook-supplied ``_meta`` is preserved. For older negotiated versions
   ``structuredContent`` is omitted (the payload is still carried by ``content``).
+
+  .. warning::
+
+     **The promotion described above was removed in v3.13.0rc4.**
+     ``structuredContent`` is now emitted only when a hook sets that key
+     explicitly; extra top-level keys are no longer promoted. See the
+     ``v3.13.0rc4`` entry and ``docs/migration/v3.13.rst``.
 - **MCP tool per-actor visibility**: ``@mcp_tool`` accepts a
   ``visibility_predicate(actor) -> bool`` to omit tools from ``tools/list`` for
   actors that should not see them (fail-closed on predicate errors). Note:
@@ -809,10 +885,14 @@ CHANGED
 - Token-exchange, token-refresh, token-revocation, and userinfo error logs now
   redact ``client_secret`` / ``assertion`` / ``id_token`` / ``client_assertion``
   and truncate the response body.
-- **MCP ``tools/call`` results always include ``isError``** (defaulting to
-  ``false``) per the MCP spec, where previously a hook returning
-  ``{"content": [...]}`` without ``isError`` was passed through verbatim. Clients
-  doing strict equality on the result object may observe the added field.
+- **MCP ``tools/call`` results include ``isError``** (defaulting to ``false``)
+  per the MCP spec **when the hook returns a dict containing ``content``**,
+  where previously such a hook returning ``{"content": [...]}`` without
+  ``isError`` was passed through verbatim. Clients doing strict equality on the
+  result object may observe the added field. This does not apply to the legacy
+  text-wrap path (a hook returning a dict with no ``content`` key, or a bare
+  value), which emits no ``isError`` at all; see the ``v3.13.0rc4`` entry,
+  which makes that path honour an explicitly set ``isError``.
 - **MCP server name no longer includes ``actor_id``**: the announced server name
   defaults to ``"actingweb"`` instead of ``"actingweb-{actor_id}"``. Each MCP
   connection is already per-actor, so disambiguation in the name was unnecessary

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.0rc3"
+__version__ = "3.13.0rc4"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/handlers/async_mcp.py
+++ b/actingweb/handlers/async_mcp.py
@@ -192,7 +192,10 @@ class AsyncMCPHandler(MCPHandler):
                                     "jsonrpc": "2.0",
                                     "id": request_id,
                                     "result": format_call_tool_result(
-                                        result, self._negotiated_version
+                                        result,
+                                        self._negotiated_version,
+                                        output_schema=metadata.get("output_schema"),
+                                        tool_name=tool_name,
                                     ),
                                 }
                             except Exception as e:

--- a/actingweb/handlers/mcp.py
+++ b/actingweb/handlers/mcp.py
@@ -127,28 +127,98 @@ def _evict_trust_entries_for_actor(actor_id: str) -> None:
         _trust_cache.pop(key, None)
 
 
-# Keys that are part of the CallToolResult wire shape and must not be swept
-# into structuredContent. The MCP wire field is ``_meta`` (the SDK maps
-# ``_meta`` <-> ``.meta``), so reserve ``_meta`` rather than ``meta``.
-_CALL_TOOL_RESERVED_KEYS = frozenset(
-    {"content", "isError", "_meta", "structuredContent"}
-)
+# Tools already warned about a declared output_schema with no structuredContent,
+# so the warning fires once per tool per process rather than on every call.
+_output_schema_warned: set[str] = set()
 
 
-def format_call_tool_result(result: Any, negotiated_version: str) -> dict[str, Any]:
+def _warn_missing_structured_content_once(tool_name: str | None) -> None:
+    """Warn once per tool that it declares an output schema but returns none.
+
+    Spec-conforming clients reject such a result outright with
+    ``Tool X has an output schema but did not return structured content``, so
+    this is an unambiguous author error rather than a style preference.
+    """
+    key = tool_name or "<unknown>"
+    if key in _output_schema_warned:
+        return
+    _output_schema_warned.add(key)
+    logger.warning(
+        "Tool '%s' declares an output_schema but returned no 'structuredContent'. "
+        "Strict MCP clients reject this result. Return an explicit "
+        "'structuredContent' key from the hook (and serialize the same object "
+        "into a text content block for clients that ignore it).",
+        key,
+    )
+
+
+def _warn_if_output_schema_unsatisfied(
+    out: dict[str, Any],
+    negotiated_version: str,
+    output_schema: dict[str, Any] | None,
+    tool_name: str | None,
+) -> None:
+    """Warn when a schema-declaring tool produced a result a client will reject.
+
+    The ``supports_structured_content`` clause is load-bearing. Below
+    2025-06-18 the version gate suppresses ``structuredContent`` even when the
+    hook sets it explicitly, so without this clause every *correctly written*
+    tool would warn on every call from every old client — training authors to
+    ignore the warning, which is exactly why it lives at call time rather than
+    at ``tools/list``. Below that revision there is nothing the author can fix
+    and nothing the client will reject.
+
+    Errors are exempt because both reference clients skip output-schema
+    validation entirely when ``isError`` is set.
+    """
+    if (
+        output_schema
+        and supports_structured_content(negotiated_version)
+        and not out.get("isError")
+        and "structuredContent" not in out
+    ):
+        _warn_missing_structured_content_once(tool_name)
+
+
+def format_call_tool_result(
+    result: Any,
+    negotiated_version: str,
+    output_schema: dict[str, Any] | None = None,
+    tool_name: str | None = None,
+) -> dict[str, Any]:
     """Normalize a tool hook's return value into a ``CallToolResult`` shape.
 
     Shared by the sync (Flask) and async (FastAPI) handlers so both format
     ``tools/call`` responses identically.
 
+    ``output_schema`` and ``tool_name`` are optional and used only to warn when
+    a tool declares a schema but returns no ``structuredContent``. They default
+    to ``None`` so existing two-argument calls keep working unchanged.
+
     - A dict containing ``content`` is treated as MCP-formatted: ``content`` and
       ``isError`` are forwarded, and a hook-supplied ``_meta`` is preserved.
-      When the negotiated protocol version supports structured output
-      (>= 2025-06-18), an explicit ``structuredContent`` is passed through;
-      otherwise any extra top-level keys are promoted into ``structuredContent``.
-      For older negotiated versions ``structuredContent`` is omitted (the
-      payload is already carried by ``content``).
+      ``structuredContent`` is emitted **only** when the hook sets that key
+      explicitly, and only when it is a JSON object (a dict) — MCP requires an
+      object there. Extra top-level keys are never promoted: a hook that wants
+      structured output must name it. Per the spec's backwards-compatibility
+      guidance, a hook emitting ``structuredContent`` should also serialize the
+      same data into a text ``content`` block, since some clients ignore
+      ``structuredContent`` entirely and others discard text blocks when it is
+      present.
+    - The version gate suppresses ``structuredContent`` entirely below
+      2025-06-18 — **including an explicit one**. A request with no
+      ``MCP-Protocol-Version`` header negotiates 2025-03-26, so the text
+      ``content`` block is the only payload that always arrives.
     - Anything else is wrapped as a single text content item (legacy behavior).
+      This branch honours exactly one wire field: an ``isError`` the hook set
+      explicitly. It is never *inferred* — a dict carrying an ``"error"`` key
+      but no ``"isError"`` is still reported as a success, because inferring it
+      would silently change the shape of every app that returns
+      ``{"error": ...}`` on its normal error path. Note two asymmetries with the
+      content branch, both deliberate: ``_meta`` is **not** preserved here, and
+      the text is ``str(result)`` of the *whole* dict, so an honoured ``isError``
+      also appears inside that text. The text serialization is deliberately left
+      byte-identical to previous releases.
     """
     if isinstance(result, dict) and "content" in result:
         out: dict[str, Any] = {
@@ -163,18 +233,34 @@ def format_call_tool_result(result: Any, negotiated_version: str) -> dict[str, A
             explicit_struct = result.get("structuredContent")
             if isinstance(explicit_struct, dict):
                 out["structuredContent"] = explicit_struct
-            else:
-                extras = {
-                    k: v for k, v in result.items() if k not in _CALL_TOOL_RESERVED_KEYS
-                }
-                if extras:
-                    out["structuredContent"] = extras
+            elif explicit_struct is not None:
+                logger.warning(
+                    "Tool result set 'structuredContent' to %s, but MCP requires a JSON "
+                    "object; the field was dropped.",
+                    type(explicit_struct).__name__,
+                )
+        _warn_if_output_schema_unsatisfied(
+            out, negotiated_version, output_schema, tool_name
+        )
         return out
 
     # Legacy handling: wrap non-MCP results in a text content item.
+    # Read isError before the rebind below, which replaces a non-dict result
+    # with a wrapper dict that has no isError key.
+    is_error = (
+        result["isError"] if isinstance(result, dict) and "isError" in result else None
+    )
     if not isinstance(result, dict):
         result = {"result": result}
-    return {"content": [{"type": "text", "text": str(result)}]}
+    # str(result) is unchanged from previous releases on purpose; consumers wrap
+    # batch responses around this exact serialization.
+    out = {"content": [{"type": "text", "text": str(result)}]}
+    if is_error is not None:
+        out["isError"] = bool(is_error)
+    _warn_if_output_schema_unsatisfied(
+        out, negotiated_version, output_schema, tool_name
+    )
+    return out
 
 
 class MCPHandler(BaseHandler):
@@ -995,7 +1081,10 @@ class MCPHandler(BaseHandler):
                                     "jsonrpc": "2.0",
                                     "id": request_id,
                                     "result": format_call_tool_result(
-                                        result, self._negotiated_version
+                                        result,
+                                        self._negotiated_version,
+                                        output_schema=metadata.get("output_schema"),
+                                        tool_name=tool_name,
                                     ),
                                 }
                             except Exception as e:

--- a/actingweb/handlers/mcp.py
+++ b/actingweb/handlers/mcp.py
@@ -199,7 +199,14 @@ def format_call_tool_result(
       ``isError`` are forwarded, and a hook-supplied ``_meta`` is preserved.
       ``structuredContent`` is emitted **only** when the hook sets that key
       explicitly, and only when it is a JSON object (a dict) — MCP requires an
-      object there. Extra top-level keys are never promoted: a hook that wants
+      object there. A non-object value is dropped with a warning, except
+      ``None``, which is treated as equivalent to omitting the key: it carries
+      no payload, both reference clients read a null ``structuredContent`` as
+      absent, and ``{"structuredContent": x or None}`` is a legitimate way to
+      express "nothing structured this time". The key is left off the response
+      entirely rather than emitted as ``null`` — some clients discard text
+      blocks whenever the key is *present*, null included.
+      Extra top-level keys are never promoted: a hook that wants
       structured output must name it. Per the spec's backwards-compatibility
       guidance, a hook emitting ``structuredContent`` should also serialize the
       same data into a text ``content`` block, since some clients ignore

--- a/actingweb/interface/app.py
+++ b/actingweb/interface/app.py
@@ -1092,10 +1092,12 @@ class ActingWebApp:
             description: Human-readable description of what the method does
             input_schema: JSON schema describing expected input parameters
             output_schema: JSON schema describing the expected return value.
-                For a hook exposed as an MCP tool this is advertised as
-                ``outputSchema``, but it does NOT cause ``structuredContent``
-                to be emitted -- only a ``structuredContent`` key in the
-                returned dict does that.
+                This describes the ActingWeb ``/actions`` / ``/methods``
+                discovery surface only. It is NOT forwarded to MCP: a tool's
+                ``outputSchema`` comes solely from
+                ``@mcp_tool(output_schema=...)``. And neither one causes
+                ``structuredContent`` to be emitted -- only a
+                ``structuredContent`` key in the returned dict does that.
             annotations: Safety/behavior hints (e.g., readOnlyHint, idempotentHint)
         """
 
@@ -1129,10 +1131,12 @@ class ActingWebApp:
             description: Human-readable description of what the action does
             input_schema: JSON schema describing expected input parameters
             output_schema: JSON schema describing the expected return value.
-                For a hook exposed as an MCP tool this is advertised as
-                ``outputSchema``, but it does NOT cause ``structuredContent``
-                to be emitted -- only a ``structuredContent`` key in the
-                returned dict does that.
+                This describes the ActingWeb ``/actions`` / ``/methods``
+                discovery surface only. It is NOT forwarded to MCP: a tool's
+                ``outputSchema`` comes solely from
+                ``@mcp_tool(output_schema=...)``. And neither one causes
+                ``structuredContent`` to be emitted -- only a
+                ``structuredContent`` key in the returned dict does that.
             annotations: Safety/behavior hints (e.g., destructiveHint, readOnlyHint)
         """
 

--- a/actingweb/interface/app.py
+++ b/actingweb/interface/app.py
@@ -1091,7 +1091,11 @@ class ActingWebApp:
             method_name: Name of method to hook ("*" for all methods)
             description: Human-readable description of what the method does
             input_schema: JSON schema describing expected input parameters
-            output_schema: JSON schema describing the expected return value
+            output_schema: JSON schema describing the expected return value.
+                For a hook exposed as an MCP tool this is advertised as
+                ``outputSchema``, but it does NOT cause ``structuredContent``
+                to be emitted -- only a ``structuredContent`` key in the
+                returned dict does that.
             annotations: Safety/behavior hints (e.g., readOnlyHint, idempotentHint)
         """
 
@@ -1124,7 +1128,11 @@ class ActingWebApp:
             action_name: Name of action to hook ("*" for all actions)
             description: Human-readable description of what the action does
             input_schema: JSON schema describing expected input parameters
-            output_schema: JSON schema describing the expected return value
+            output_schema: JSON schema describing the expected return value.
+                For a hook exposed as an MCP tool this is advertised as
+                ``outputSchema``, but it does NOT cause ``structuredContent``
+                to be emitted -- only a ``structuredContent`` key in the
+                returned dict does that.
             annotations: Safety/behavior hints (e.g., destructiveHint, readOnlyHint)
         """
 

--- a/actingweb/interface/hooks.py
+++ b/actingweb/interface/hooks.py
@@ -243,10 +243,12 @@ class HookMetadata:
         description: Human-readable description of what the hook does
         input_schema: JSON schema describing expected input parameters
         output_schema: JSON schema describing the expected return value.
-            For a hook exposed as an MCP tool this is advertised as
-            ``outputSchema``, but it does NOT cause ``structuredContent``
-            to be emitted -- only a ``structuredContent`` key in the
-            returned dict does that.
+            This describes the ActingWeb ``/actions`` / ``/methods``
+            discovery surface only. It is NOT forwarded to MCP: a tool's
+            ``outputSchema`` comes solely from
+            ``@mcp_tool(output_schema=...)``. And neither one causes
+            ``structuredContent`` to be emitted -- only a
+            ``structuredContent`` key in the returned dict does that.
         annotations: Safety/behavior hints (e.g., readOnlyHint, destructiveHint)
     """
 
@@ -1397,10 +1399,12 @@ def method_hook(
         description: Human-readable description of what the method does
         input_schema: JSON schema describing expected input parameters
         output_schema: JSON schema describing the expected return value.
-            For a hook exposed as an MCP tool this is advertised as
-            ``outputSchema``, but it does NOT cause ``structuredContent``
-            to be emitted -- only a ``structuredContent`` key in the
-            returned dict does that.
+            This describes the ActingWeb ``/actions`` / ``/methods``
+            discovery surface only. It is NOT forwarded to MCP: a tool's
+            ``outputSchema`` comes solely from
+            ``@mcp_tool(output_schema=...)``. And neither one causes
+            ``structuredContent`` to be emitted -- only a
+            ``structuredContent`` key in the returned dict does that.
         annotations: Safety/behavior hints (e.g., readOnlyHint, idempotentHint)
 
     Example:
@@ -1453,10 +1457,12 @@ def action_hook(
         description: Human-readable description of what the action does
         input_schema: JSON schema describing expected input parameters
         output_schema: JSON schema describing the expected return value.
-            For a hook exposed as an MCP tool this is advertised as
-            ``outputSchema``, but it does NOT cause ``structuredContent``
-            to be emitted -- only a ``structuredContent`` key in the
-            returned dict does that.
+            This describes the ActingWeb ``/actions`` / ``/methods``
+            discovery surface only. It is NOT forwarded to MCP: a tool's
+            ``outputSchema`` comes solely from
+            ``@mcp_tool(output_schema=...)``. And neither one causes
+            ``structuredContent`` to be emitted -- only a
+            ``structuredContent`` key in the returned dict does that.
         annotations: Safety/behavior hints (e.g., destructiveHint, readOnlyHint)
 
     Example:

--- a/actingweb/interface/hooks.py
+++ b/actingweb/interface/hooks.py
@@ -242,7 +242,11 @@ class HookMetadata:
     Attributes:
         description: Human-readable description of what the hook does
         input_schema: JSON schema describing expected input parameters
-        output_schema: JSON schema describing the expected return value
+        output_schema: JSON schema describing the expected return value.
+            For a hook exposed as an MCP tool this is advertised as
+            ``outputSchema``, but it does NOT cause ``structuredContent``
+            to be emitted -- only a ``structuredContent`` key in the
+            returned dict does that.
         annotations: Safety/behavior hints (e.g., readOnlyHint, destructiveHint)
     """
 
@@ -1392,7 +1396,11 @@ def method_hook(
         method_name: Name of method to hook ("*" for all methods)
         description: Human-readable description of what the method does
         input_schema: JSON schema describing expected input parameters
-        output_schema: JSON schema describing the expected return value
+        output_schema: JSON schema describing the expected return value.
+            For a hook exposed as an MCP tool this is advertised as
+            ``outputSchema``, but it does NOT cause ``structuredContent``
+            to be emitted -- only a ``structuredContent`` key in the
+            returned dict does that.
         annotations: Safety/behavior hints (e.g., readOnlyHint, idempotentHint)
 
     Example:
@@ -1444,7 +1452,11 @@ def action_hook(
         action_name: Name of action to hook ("*" for all actions)
         description: Human-readable description of what the action does
         input_schema: JSON schema describing expected input parameters
-        output_schema: JSON schema describing the expected return value
+        output_schema: JSON schema describing the expected return value.
+            For a hook exposed as an MCP tool this is advertised as
+            ``outputSchema``, but it does NOT cause ``structuredContent``
+            to be emitted -- only a ``structuredContent`` key in the
+            returned dict does that.
         annotations: Safety/behavior hints (e.g., destructiveHint, readOnlyHint)
 
     Example:

--- a/actingweb/mcp/decorators.py
+++ b/actingweb/mcp/decorators.py
@@ -77,6 +77,8 @@ def mcp_tool(
         present, so only sending both reaches every client.
 
     Example:
+        import json
+
         @action_hook("delete_note")
         @mcp_tool(
             description="Delete a note permanently",

--- a/actingweb/mcp/decorators.py
+++ b/actingweb/mcp/decorators.py
@@ -36,7 +36,13 @@ def mcp_tool(
         client_descriptions: Client-specific descriptions for safety/clarity.
                            Example: {"chatgpt": "Search your personal notes", "claude": "Search and store information"}
         title: Human-readable title for the tool (optional)
-        output_schema: JSON schema describing the tool's output (optional)
+        output_schema: JSON schema describing the tool's output (optional).
+                    Advertised as ``outputSchema`` in tools/list. It does **not**
+                    cause ``structuredContent`` to be emitted — only a
+                    ``structuredContent`` key in the hook's return value does
+                    that. Declaring a schema and returning no
+                    ``structuredContent`` is rejected by spec-conforming
+                    clients, so ActingWeb logs a warning when it sees that.
         annotations: Safety and behavior annotations for the tool.
                     IMPORTANT: ChatGPT uses these for safety evaluation.
                     Example: {
@@ -59,6 +65,17 @@ def mcp_tool(
                     information leakage to actors without the feature. Predicate
                     exceptions are logged and treated as None (fall back to default).
 
+    Return shape:
+        The canonical return value is a dict with a ``content`` list, plus an
+        optional ``isError`` and an optional ``structuredContent``. Anything
+        else is wrapped as a single text block containing ``str(result)``,
+        which is rarely what you want.
+
+        When you return ``structuredContent``, also serialize the same object
+        into a text ``content`` block: some clients ignore
+        ``structuredContent``, and others discard text blocks whenever it is
+        present, so only sending both reaches every client.
+
     Example:
         @action_hook("delete_note")
         @mcp_tool(
@@ -66,7 +83,10 @@ def mcp_tool(
             annotations={"destructiveHint": True, "readOnlyHint": False}
         )
         def handle_delete(actor, action_name, data):
-            return {"status": "deleted"}
+            return {
+                "content": [{"type": "text", "text": "Note deleted."}],
+                "isError": False,
+            }
 
         @action_hook("search")
         @mcp_tool(
@@ -74,7 +94,12 @@ def mcp_tool(
             annotations={"readOnlyHint": True, "destructiveHint": False}
         )
         def handle_search(actor, action_name, data):
-            return {"results": [...]}
+            payload = {"results": [...]}
+            return {
+                "structuredContent": payload,
+                "content": [{"type": "text", "text": json.dumps(payload)}],
+                "isError": False,
+            }
     """
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:

--- a/docs/guides/mcp-applications.rst
+++ b/docs/guides/mcp-applications.rst
@@ -345,6 +345,8 @@ present differently per actor:
    time inside the hook (as ``beta_export`` does above) — do not rely on
    visibility filtering for authorization.
 
+.. _mcp-structured-tool-output:
+
 Structured Tool Output
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -355,31 +357,62 @@ follows:
 
 - A dict containing ``content`` is treated as MCP-formatted. ``content`` and
   ``isError`` are forwarded, and a hook-supplied ``_meta`` is preserved.
-- On a version that supports structured output, an explicit
-  ``structuredContent`` key is passed through unchanged; otherwise any *extra*
-  top-level keys (anything besides ``content``, ``isError``, ``_meta`` and
-  ``structuredContent``) are promoted into ``structuredContent``.
-- On older negotiated versions ``structuredContent`` is omitted entirely (the
-  payload is already carried by ``content``).
+- ``structuredContent`` is **opt-in**: it is emitted only when your hook sets
+  that key explicitly, and only when the value is a JSON object (a dict).
+  Extra top-level keys are **not** promoted — they are dropped.
+- On older negotiated versions ``structuredContent`` is omitted entirely, even
+  when you set it explicitly.
+
+.. important::
+
+   Declaring ``output_schema`` does **not** cause ``structuredContent`` to be
+   emitted. The two are independent: ``output_schema`` is advertised in
+   ``tools/list``, while ``structuredContent`` comes only from the key your hook
+   returns. A tool that declares a schema and returns no ``structuredContent``
+   is rejected outright by spec-conforming clients, so ActingWeb logs a warning
+   when it sees that combination.
+
+Return both representations of the same object — the structured value under
+``structuredContent``, and its serialization in a text ``content`` block. The
+MCP specification asks for this for backwards compatibility, and it is what
+makes a tool work everywhere: some clients ignore ``structuredContent``
+entirely, and others discard text blocks whenever it is present.
 
 .. code-block:: python
 
-    @app.action_hook("search")
+    import json
+
+    @app.action_hook("get_weather")
     @mcp_tool(
-        description="Search your notes",
+        description="Get current weather",
         output_schema={
             "type": "object",
-            "properties": {"results": {"type": "array"}, "count": {"type": "integer"}},
+            "properties": {
+                "temperature": {"type": "number"},
+                "conditions": {"type": "string"},
+                "humidity": {"type": "integer"},
+            },
+            "required": ["temperature", "conditions", "humidity"],
         },
     )
-    def search(actor, action_name, params):
-        results = [...]
+    def get_weather(actor, action_name, params):
+        payload = {"temperature": 22.5, "conditions": "Partly cloudy", "humidity": 65}
         return {
-            "content": [{"type": "text", "text": f"Found {len(results)} results"}],
-            # Promoted into structuredContent on >= 2025-06-18:
-            "results": results,
-            "count": len(results),
+            # Named explicitly — nothing is promoted for you.
+            "structuredContent": payload,
+            # The same object serialized, so clients that ignore
+            # structuredContent still receive the data.
+            "content": [{"type": "text", "text": json.dumps(payload)}],
+            "isError": False,
         }
+
+.. warning::
+
+   Do not put prose in ``content`` and *different* data in
+   ``structuredContent``. Clients that drop text blocks when
+   ``structuredContent`` is present will show the model only the structured
+   value, and your prose is lost with no error on either side. If a tool's real
+   payload is prose, return prose alone and set no ``structuredContent``.
 
 The ``title`` and ``output_schema`` set on ``@mcp_tool`` also surface in the
 ``tools/list`` response as the ``title`` and ``outputSchema`` fields.
@@ -401,6 +434,15 @@ On requests after ``initialize``, the handler honors the
 - Header present but unsupported: respond with HTTP 400.
 - Header present and supported: use that version for version-gated response
   fields such as ``structuredContent``.
+
+.. warning::
+
+   A request with **no** ``MCP-Protocol-Version`` header negotiates
+   ``2025-03-26``, which suppresses ``structuredContent`` — *including one your
+   hook set explicitly*. This trips up manual verification with ``curl``: send
+   ``-H 'MCP-Protocol-Version: 2025-06-18'`` or you will see no
+   ``structuredContent`` and conclude your hook is broken when it is not. The
+   text ``content`` block is the only payload that always arrives.
 
 Negotiation is backward compatible with clients that speak only
 ``2024-11-05``.
@@ -738,6 +780,53 @@ Unit Testing Tools and Prompts
             # Check that note was stored
             notes = [k for k in self.actor.properties.keys() if k.startswith("note_")]
             self.assertTrue(len(notes) > 0)
+
+.. _testing-the-wire-shape:
+
+Testing the Wire Shape
+~~~~~~~~~~~~~~~~~~~~~~
+
+``execute_action_hooks`` returns your hook's value **before** ActingWeb
+normalizes it. It therefore cannot tell you whether ``structuredContent``
+reaches the client — a suite built only on it stays green while the wire output
+regresses.
+
+Assert on ``format_call_tool_result`` as well. It is the single formatter shared
+by the sync and async ``tools/call`` paths, and it takes the negotiated protocol
+version, so you can pin the version-gated behaviour too:
+
+.. code-block:: python
+
+    import json
+    from actingweb.handlers.mcp import format_call_tool_result
+
+    def test_weather_tool_wire_shape():
+        result = get_weather(actor, "get_weather", {})
+
+        out = format_call_tool_result(result, "2025-06-18")
+        assert out["structuredContent"] == {
+            "temperature": 22.5,
+            "conditions": "Partly cloudy",
+            "humidity": 65,
+        }
+        # The text block carries the same object, for clients that ignore
+        # structuredContent.
+        assert json.loads(out["content"][0]["text"]) == out["structuredContent"]
+
+    def test_prose_tool_keeps_its_text():
+        out = format_call_tool_result(
+            {"content": [{"type": "text", "text": "A long report."}], "run_id": "r1"},
+            "2025-06-18",
+        )
+        # Extras are not promoted, so the prose is what the client receives.
+        assert "structuredContent" not in out
+        assert out["content"] == [{"type": "text", "text": "A long report."}]
+
+    def test_old_client_gets_no_structured_content():
+        out = format_call_tool_result(
+            {"content": [...], "structuredContent": {"a": 1}}, "2025-03-26"
+        )
+        assert "structuredContent" not in out
 
 Integration Testing with FastAPI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/guides/mcp-quickstart.rst
+++ b/docs/guides/mcp-quickstart.rst
@@ -118,9 +118,12 @@ token returns HTTP 401 with a ``WWW-Authenticate: Bearer`` header:
      -H 'Authorization: Bearer <token>' \
      -d '{"jsonrpc":"2.0","id":2,"method":"tools/list"}'
 
+   # Send MCP-Protocol-Version, or the request negotiates 2025-03-26 and the
+   # response carries no structuredContent even when your hook sets it.
    curl -s http://localhost:5000/mcp \
      -H 'Content-Type: application/json' \
      -H 'Authorization: Bearer <token>' \
+     -H 'MCP-Protocol-Version: 2025-06-18' \
      -d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"create_note","arguments":{"title":"Hello","content":"World"}}}'
 
 A bearer token that authenticates but does not resolve to a trust
@@ -135,6 +138,13 @@ relationship now returns an **empty** ``tools/list`` (not an error) and a
    ``app.hooks.execute_action_hooks("create_note", actor, {...})``. Real MCP
    clients (ChatGPT, Claude) perform the OAuth2 flow and send the bearer token
    automatically.
+
+   Note that this checks your hook's **return value**, not the JSON the client
+   receives: it bypasses ``format_call_tool_result``, so it cannot see whether
+   ``structuredContent`` is emitted or suppressed. To assert on the wire shape,
+   test the formatter as well — see
+   :ref:`testing-the-wire-shape <testing-the-wire-shape>` in
+   :doc:`mcp-applications`.
 
 Tool Safety Annotations
 -----------------------

--- a/docs/guides/troubleshooting.rst
+++ b/docs/guides/troubleshooting.rst
@@ -63,6 +63,46 @@ MCP client sees an empty tool list or ``-32003`` after upgrading
   request) so its trust row is recreated with the ``oauth_client_id`` the
   new resolver requires.
 
+MCP tool's structured data disappeared after upgrading
+--------------------------------------------------------
+
+- **Symptom**: After upgrading to ``v3.13.0rc4`` or newer, a tool that used to
+  deliver structured fields to the model now delivers only its text, and
+  ``structuredContent`` is absent from the ``tools/call`` response.
+- **Cause**: ``structuredContent`` is now opt-in. Extra top-level keys returned
+  alongside ``content`` used to be promoted into ``structuredContent``
+  automatically; that promotion was removed because clients that discard text
+  blocks when ``structuredContent`` is present were silently dropping the tool's
+  entire prose payload. Dropped extras are **not** logged — they are a
+  deliberate migration, not an error.
+- **Fix**: Nest the data under an explicit ``structuredContent`` key, and keep
+  the same object serialized in a text ``content`` block so clients that ignore
+  ``structuredContent`` still receive it. See the ``rc4`` section of
+  ``docs/migration/v3.13.rst``. If the tool's real payload is prose, returning
+  prose alone is now the correct shape.
+- **Note when verifying with ``curl``**: a request with no
+  ``MCP-Protocol-Version`` header negotiates ``2025-03-26``, which suppresses
+  ``structuredContent`` *even when set explicitly*. Send
+  ``-H 'MCP-Protocol-Version: 2025-06-18'`` or you will misread a working hook
+  as broken.
+
+MCP client rejects a tool with "has an output schema but did not return structured content"
+---------------------------------------------------------------------------------------------
+
+- **Symptom**: A spec-conforming client (Claude Code, the reference Python
+  client) errors on every call to one tool with ``Tool X has an output schema
+  but did not return structured content``. The server log carries a matching
+  ``WARNING`` naming the tool.
+- **Cause**: The tool declares ``output_schema`` on ``@mcp_tool`` — so
+  ``outputSchema`` is advertised in ``tools/list`` — but its hook returns no
+  ``structuredContent``. Declaring a schema does **not** cause structured output
+  to be emitted; the two are independent. Once a schema is advertised, clients
+  treat structured output as mandatory on every non-error result.
+- **Fix**: Either return an explicit ``structuredContent`` conforming to the
+  declared schema, or remove ``output_schema`` from the decorator. The warning
+  is logged once per tool per process, so check the log from around process
+  start rather than only the moment you reproduce it.
+
 Property changes not visible in Web UI
 --------------------------------------
 

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -22,6 +22,12 @@ Contents
 Version Migrations
 ==================
 
+**v3.13 Migration**
+   Guide for upgrading to ActingWeb 3.13, covering the DynamoDB scalability
+   work (``rc1``/``rc2``), the MCP trust-cache authorization fix (``rc3``), and
+   the MCP ``structuredContent`` behaviour change in ``rc4`` — tool hooks no
+   longer have extra top-level keys promoted into ``structuredContent``.
+
 **v3.11 Migration**
    Guide for upgrading to ActingWeb 3.11, covering the one new PostgreSQL
    migration (chain_id index), DynamoDB TTL for token cleanup, SPA/mobile

--- a/docs/migration/v3.11.rst
+++ b/docs/migration/v3.11.rst
@@ -122,9 +122,13 @@ Behavioral Changes to Verify
   ``"actingweb"`` (was ``"actingweb-{actor_id}"``). Each MCP connection is already
   per-actor. Clients keyed on the old name or relying on actor-specific tool
   prefixes should be re-checked. Override with ``with_mcp(server_name=...)``.
-- **MCP ``tools/call`` results always include ``isError``** (default ``false``)
-  per spec. Clients doing strict-equality comparison on the result object will see
-  the added field.
+- **MCP ``tools/call`` results include ``isError``** (default ``false``) per
+  spec **when the hook returns a dict containing ``content``**. Clients doing
+  strict-equality comparison on the result object will see the added field.
+  Results that take the legacy text-wrap path (a hook returning a dict with no
+  ``content`` key, or a bare value) carry no ``isError`` field; from
+  ``v3.13.0rc4`` that path emits one when — and only when — the hook sets
+  ``isError`` explicitly.
 - **Logout no longer revokes the upstream identity-provider grant.** ``/oauth/logout``
   (and the SPA session-token revoke) now clears the stored provider token *locally*
   instead of calling the provider's revocation endpoint. This is correct for
@@ -164,6 +168,14 @@ Adopt these only if you want them; none change existing behavior:
 - **MCP enhancements** — protocol version negotiation, ``structuredContent`` tool
   output, per-actor tool visibility/descriptions, and
   ``with_mcp(server_name=..., instructions=...)``.
+
+  .. note::
+
+     ``structuredContent`` behaviour **changed in v3.13.0rc4**. In this release
+     extra top-level keys returned by a tool hook were promoted into
+     ``structuredContent`` automatically; from ``v3.13.0rc4`` it is opt-in and
+     only an explicit ``structuredContent`` key is emitted. See
+     :doc:`v3.13` before upgrading past that boundary.
 
 Backward Compatibility
 ======================

--- a/docs/migration/v3.13.rst
+++ b/docs/migration/v3.13.rst
@@ -2,6 +2,105 @@
 Migrating to ActingWeb 3.13
 ===========================
 
+Behaviour change in rc4: MCP ``structuredContent`` is now opt-in
+=================================================================
+
+.. note::
+
+   This section covers the ``v3.13.0rc4`` behaviour change. It is independent
+   of the ``rc3`` security fix and the ``rc1``/``rc2`` DynamoDB-scalability
+   steps below — read every section that falls between the version you are on
+   and the version you are upgrading to. It applies only if you expose MCP
+   tools; if you do not, skip to the next section.
+
+What changed
+------------
+
+Previously, a tool hook returning a dict with ``content`` plus extra top-level
+keys had those extras **promoted** into ``structuredContent`` automatically.
+That promotion is removed. ``structuredContent`` is now emitted only when your
+hook sets that key explicitly, and only when its value is a JSON object.
+
+Why: at least one major MCP client discards **every** text content block when
+``structuredContent`` is present. Under the old behaviour, adding a single
+scalar key to a hook's return value silently deleted that tool's entire prose
+payload — the model received only the promoted keys, with no error on either
+side. Neither reference server implementation promotes keys this way.
+
+Are you affected?
+-----------------
+
+You are affected if any tool hook returns a dict with a ``content`` key **and**
+other top-level keys besides ``isError``, ``_meta`` and ``structuredContent``.
+Those extras were being serialized into ``structuredContent``; now they are
+dropped.
+
+You are **not** affected if your hooks already set ``structuredContent``
+explicitly, return ``content`` alone, or return dicts with no ``content`` key
+(those take the legacy text-wrap path, which never emitted
+``structuredContent``).
+
+How to migrate
+--------------
+
+The migration is a no-op against the old release, so you can **migrate first
+and upgrade afterwards** — no coordinated deploy window. The explicit
+passthrough already exists in ``v3.11.0``/``v3.12.0``, so a hook updated as
+below produces byte-identical output on both.
+
+For a tool whose payload is genuinely structured, name the key and serialize
+the same object into the text block:
+
+.. code-block:: python
+
+    # Before — relied on promotion
+    return {
+        "content": [{"type": "text", "text": f"Found {len(results)} results"}],
+        "results": results,
+        "count": len(results),
+    }
+
+    # After — explicit, and the text carries the same object
+    payload = {"results": results, "count": len(results)}
+    return {
+        "structuredContent": payload,
+        "content": [{"type": "text", "text": json.dumps(payload)}],
+    }
+
+For a tool whose payload is **prose**, drop the extras instead of promoting
+them. That is the case the old behaviour broke, and returning prose alone is
+now correct.
+
+Two caveats the library cannot enforce for you
+-----------------------------------------------
+
+1. **Some clients ignore ``structuredContent`` entirely** (see
+   ``modelcontextprotocol#1411``). Always keep the same data serialized in a
+   text content block, per the specification's backwards-compatibility
+   guidance. The text block is the only thing that always arrives.
+2. **A request with no ``MCP-Protocol-Version`` header negotiates
+   ``2025-03-26``**, where ``structuredContent`` is suppressed *even when set
+   explicitly*. If you verify with ``curl``, send
+   ``-H 'MCP-Protocol-Version: 2025-06-18'`` or you will wrongly conclude your
+   migrated hook is broken.
+
+Two related fixes in the same release
+--------------------------------------
+
+- **An explicit ``isError`` is now honoured on the legacy text-wrap path.** A
+  hook returning ``{"isError": True, ...}`` with no ``content`` key previously
+  reached the wire with no ``isError`` field at all, so the failure was
+  reported to the client as a success. ``isError`` is honoured only when you
+  set it — it is never inferred from an ``"error"`` key or any other heuristic,
+  so apps that return ``{"error": ...}`` on their normal error path see no
+  change. The text serialization is unchanged.
+- **A warning now fires when a tool declares ``output_schema`` but returns no
+  ``structuredContent``.** Spec-conforming clients reject that result outright
+  (``Tool X has an output schema but did not return structured content``). This
+  was already broken before this release; it is now visible in your logs. Note
+  that ``output_schema`` and ``structuredContent`` are independent — declaring
+  a schema has never caused structured output to be emitted.
+
 Security fix in rc3: MCP trust-cache authorization bypass
 ===========================================================
 
@@ -9,8 +108,9 @@ Security fix in rc3: MCP trust-cache authorization bypass
 
    This section covers the ``v3.13.0rc3`` security fix. It applies **in
    addition to** the DynamoDB-scalability migration steps later in this
-   document (``rc1``/``rc2``) — read both if you are upgrading past either
-   boundary. If you are only running MCP with a single client per actor,
+   document (``rc1``/``rc2``) and the ``rc4`` MCP change above — read every
+   section between the version you are on and the version you are upgrading
+   to. If you are only running MCP with a single client per actor,
    most of this section does not apply to you, but the ``resources/read``
    and resolver-matching items below can still be relevant; read the
    summary before skipping ahead.
@@ -101,9 +201,10 @@ Overview
 .. note::
 
    This "Overview" and everything below it describes the ``rc1``/``rc2``
-   DynamoDB-scalability content of the 3.13 line. The ``rc3`` security fix
-   covered above is a separate, later addition to the same release line —
-   read both sections if you are upgrading from before ``rc1``.
+   DynamoDB-scalability content of the 3.13 line. The ``rc3`` security fix and
+   the ``rc4`` MCP ``structuredContent`` change covered above are separate,
+   later additions to the same release line — read all three sections if you
+   are upgrading from before ``rc1``.
 
 ActingWeb 3.13 is a **DynamoDB scalability release**. It fixes two measured
 superlinear cost defects (full-table scans on per-actor reads; a

--- a/docs/reference/hooks-reference.rst
+++ b/docs/reference/hooks-reference.rst
@@ -375,6 +375,14 @@ Explicit schemas always take precedence over auto-generated ones. Supported type
 include ``str``, ``int``, ``float``, ``bool``, ``list``, ``dict``, ``None``,
 ``Optional[...]``, and nested TypedDict classes.
 
+.. note::
+
+   For a hook also exposed as an MCP tool, an ``output_schema`` — whether you
+   write it or it is auto-generated from a TypedDict return annotation — does
+   **not** make the tool emit ``structuredContent``. Only a
+   ``structuredContent`` key in the returned dict does that. See
+   :ref:`Structured Tool Output <mcp-structured-tool-output>`.
+
 Action Hooks
 ============
 
@@ -389,7 +397,10 @@ Signature: ``func(actor, action_name: str, data: dict) -> Any``
 
 - ``description``: Human-readable description of what the action does
 - ``input_schema``: JSON schema describing expected input parameters
-- ``output_schema``: JSON schema describing the expected return value
+- ``output_schema``: JSON schema describing the expected return value. For an
+  action also exposed via ``@mcp_tool``, this is advertised as ``outputSchema``
+  but does **not** cause ``structuredContent`` to be emitted — see
+  :ref:`Structured Tool Output <mcp-structured-tool-output>`.
 - ``annotations``: Safety/behavior hints (e.g., ``destructiveHint``, ``readOnlyHint``)
 
 **Example with Metadata**:

--- a/docs/reference/hooks-reference.rst
+++ b/docs/reference/hooks-reference.rst
@@ -377,10 +377,15 @@ include ``str``, ``int``, ``float``, ``bool``, ``list``, ``dict``, ``None``,
 
 .. note::
 
-   For a hook also exposed as an MCP tool, an ``output_schema`` — whether you
-   write it or it is auto-generated from a TypedDict return annotation — does
-   **not** make the tool emit ``structuredContent``. Only a
-   ``structuredContent`` key in the returned dict does that. See
+   Auto-generation feeds the ``/methods`` and ``/actions`` discovery surface
+   only. It does **not** reach MCP: ``tools/list`` reads the ``@mcp_tool``
+   metadata exclusively, so a TypedDict-derived ``output_schema`` is never
+   advertised as ``outputSchema``. To declare an output schema for an MCP tool,
+   pass it to ``@mcp_tool(output_schema=...)`` explicitly.
+
+   Note also that an ``output_schema`` — however it is supplied — does not make
+   a tool emit ``structuredContent``. Only a ``structuredContent`` key in the
+   returned dict does that. See
    :ref:`Structured Tool Output <mcp-structured-tool-output>`.
 
 Action Hooks
@@ -397,9 +402,11 @@ Signature: ``func(actor, action_name: str, data: dict) -> Any``
 
 - ``description``: Human-readable description of what the action does
 - ``input_schema``: JSON schema describing expected input parameters
-- ``output_schema``: JSON schema describing the expected return value. For an
-  action also exposed via ``@mcp_tool``, this is advertised as ``outputSchema``
-  but does **not** cause ``structuredContent`` to be emitted — see
+- ``output_schema``: JSON schema describing the expected return value. This
+  describes the ``/actions`` discovery surface only — it is **not** forwarded to
+  MCP. A tool's ``outputSchema`` comes solely from
+  ``@mcp_tool(output_schema=...)``; passing it to ``action_hook`` leaves MCP
+  unaware of it. Neither one causes ``structuredContent`` to be emitted — see
   :ref:`Structured Tool Output <mcp-structured-tool-output>`.
 - ``annotations``: Safety/behavior hints (e.g., ``destructiveHint``, ``readOnlyHint``)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.13.0rc3"
+version = "3.13.0rc4"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@actingweb.io>"]
 maintainers = ["Greger Wedel <support@actingweb.io>"]

--- a/tests/integration/test_mcp_tools.py
+++ b/tests/integration/test_mcp_tools.py
@@ -488,18 +488,24 @@ class TestMCPToolResponseFormatRegression:
     """
     Regression tests for tool response format handling.
 
-    These tests ensure critical response metadata (isError, structured payload)
-    is preserved through ActingWeb's live ``format_call_tool_result`` — the
-    shared formatter used by both the sync and async ``tools/call`` paths.
+    These tests ensure critical response metadata (isError) is preserved
+    through ActingWeb's live ``format_call_tool_result`` — the shared formatter
+    used by both the sync and async ``tools/call`` paths — and that extra
+    top-level keys are **not** turned into ``structuredContent``.
+
+    ``structuredContent`` is opt-in: only a hook that names the key gets it.
+    Promoting extras silently replaced the prose payload on clients that drop
+    text blocks whenever ``structuredContent`` is present.
     """
 
     def test_preserves_is_error_field_success(self):
         """
-        isError=false must survive formatting.
+        isError=false must survive formatting, and extras must not be promoted.
 
         Regression: a storage-confirmation tool returning ``isError: false``
         plus extra keys must keep ``isError`` (so clients like ChatGPT don't
-        misread success as error) and surface the extras as structuredContent.
+        misread success as error) while its prose ``content`` survives intact
+        and the extras are dropped rather than promoted.
         """
         from actingweb.handlers.mcp import format_call_tool_result
 
@@ -514,10 +520,7 @@ class TestMCPToolResponseFormatRegression:
 
         assert out["isError"] is False
         assert out["content"][0]["text"] == "✅ Successfully stored: test data"
-        assert out["structuredContent"] == {
-            "success": True,
-            "memory_type": "memory_test",
-        }
+        assert "structuredContent" not in out
 
     def test_preserves_is_error_field_failure(self):
         """isError=true must survive formatting (companion to the success case)."""
@@ -536,10 +539,23 @@ class TestMCPToolResponseFormatRegression:
 
         assert out["isError"] is True
         assert "❌" in out["content"][0]["text"]
-        assert out["structuredContent"] == {
-            "success": False,
-            "error": "Validation failed",
+        assert "structuredContent" not in out
+
+    def test_explicit_structured_content_still_emitted(self):
+        """A hook that names ``structuredContent`` still gets it on the wire."""
+        from actingweb.handlers.mcp import format_call_tool_result
+
+        tool_response = {
+            "content": [{"type": "text", "text": '{"success": true}'}],
+            "isError": False,
+            "structuredContent": {"success": True},
+            "dropped_extra": "not promoted",
         }
+
+        out = format_call_tool_result(tool_response, "2025-06-18")
+
+        assert out["structuredContent"] == {"success": True}
+        assert out["content"][0]["text"] == '{"success": true}'
 
     def test_tool_response_without_is_error_field(self):
         """A content-only response gets isError defaulted to False, no structuredContent."""

--- a/tests/test_mcp_tool_result_format.py
+++ b/tests/test_mcp_tool_result_format.py
@@ -100,6 +100,30 @@ class TestFormatCallToolResult:
         assert "MCP requires a JSON object" in caplog.text
         assert type(bad_value).__name__ in caplog.text
 
+    def test_explicit_none_structured_content_is_absent_and_silent(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """``structuredContent: None`` means "nothing structured", not an error.
+
+        Unlike a list or string, ``None`` carries no payload, so nothing is
+        lost by dropping it, and ``{"structuredContent": x or None}`` is a
+        legitimate way to express an absent value. Both reference clients read
+        a null ``structuredContent`` as absent. Warning here would be a false
+        positive, so this is deliberate — but the key must be omitted entirely
+        rather than emitted as ``null``, because some clients discard text
+        blocks whenever the key is present at all.
+        """
+        caplog.set_level(logging.WARNING, logger="actingweb.handlers.mcp")
+        result = {
+            "content": [{"type": "text", "text": "ok"}],
+            "structuredContent": None,
+            "extra": 1,
+        }
+        out = format_call_tool_result(result, "2025-11-25")
+        assert "structuredContent" not in out
+        assert out["content"] == [{"type": "text", "text": "ok"}]
+        assert caplog.text == ""
+
     def test_explicit_structured_content_suppressed_on_old_version(self) -> None:
         """The version gate suppresses even an explicitly-set structuredContent."""
         result = {

--- a/tests/test_mcp_tool_result_format.py
+++ b/tests/test_mcp_tool_result_format.py
@@ -1,19 +1,29 @@
-"""Tests for the shared tools/call result formatter (Phase 2).
+"""Tests for the shared tools/call result formatter.
+
+``structuredContent`` is **opt-in**: it is emitted only when a hook sets that
+key explicitly, and only when it is a JSON object. Extra top-level keys are
+never promoted.
 
 Covers:
-- structuredContent promotion of extra top-level keys (>= 2025-06-18).
-- structuredContent omitted for older negotiated versions.
-- explicit structuredContent pass-through and _meta preservation.
+- extra top-level keys are NOT promoted into structuredContent.
+- explicit structuredContent pass-through, and its object-only requirement.
+- structuredContent omitted for older negotiated versions, even when explicit.
+- _meta preservation.
 - legacy text wrapping for non-content results.
 - sync (MCPHandler) / async (AsyncMCPHandler) parity.
 """
 
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
 
 from actingweb.handlers.async_mcp import AsyncMCPHandler
-from actingweb.handlers.mcp import MCPHandler, format_call_tool_result
+from actingweb.handlers.mcp import (
+    MCPHandler,
+    _output_schema_warned,
+    format_call_tool_result,
+)
 from actingweb.interface import ActingWebApp
 from actingweb.interface.actor_interface import ActorInterface
 from actingweb.mcp import mcp_tool
@@ -25,7 +35,8 @@ from tests.mcp_helpers import make_mcp_config, make_mcp_webobj
 class TestFormatCallToolResult:
     """Unit tests on the pure formatter."""
 
-    def test_content_with_extras_promotes_structured_content(self) -> None:
+    def test_content_with_extras_does_not_promote_structured_content(self) -> None:
+        """Extras are dropped, never swept into structuredContent."""
         result = {
             "content": [{"type": "text", "text": "ok"}],
             "isError": False,
@@ -33,14 +44,71 @@ class TestFormatCallToolResult:
             "memory_type": "note",
         }
         out = format_call_tool_result(result, "2025-06-18")
+        # The text payload must survive byte-for-byte...
         assert out["content"] == [{"type": "text", "text": "ok"}]
         assert out["isError"] is False
-        assert out["structuredContent"] == {"success": True, "memory_type": "note"}
+        # ...and the non-empty extras must NOT appear anywhere.
+        assert "structuredContent" not in out
+        assert "success" not in out
+        assert "memory_type" not in out
 
-    def test_latest_version_promotes_structured_content(self) -> None:
+    def test_latest_version_does_not_promote_structured_content(self) -> None:
+        """Even on the newest revision, extras are not promoted."""
         result = {"content": [{"type": "text", "text": "ok"}], "count": 3}
         out = format_call_tool_result(result, "2025-11-25")
-        assert out["structuredContent"] == {"count": 3}
+        assert "structuredContent" not in out
+        assert out["content"] == [{"type": "text", "text": "ok"}]
+
+    def test_extras_alongside_explicit_structured_content(self) -> None:
+        """Only the explicit key is emitted; extras are never merged in.
+
+        Guards the deleted promotion branch from returning: if extras were
+        swept, ``sibling`` would appear in the output.
+        """
+        result = {
+            "content": [{"type": "text", "text": "ok"}],
+            "structuredContent": {"explicit": 1},
+            "sibling": "should-not-appear",
+        }
+        out = format_call_tool_result(result, "2025-11-25")
+        assert out["structuredContent"] == {"explicit": 1}
+        assert "sibling" not in out["structuredContent"]
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        [
+            [{"item": 1}],
+            "a string",
+            42,
+        ],
+        ids=["list", "str", "int"],
+    )
+    def test_non_dict_structured_content_dropped_with_warning(
+        self, bad_value: object, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """MCP requires structuredContent to be an object; anything else warns."""
+        caplog.set_level(logging.WARNING, logger="actingweb.handlers.mcp")
+        result = {
+            "content": [{"type": "text", "text": "ok"}],
+            "structuredContent": bad_value,
+            "extra": 1,
+        }
+        out = format_call_tool_result(result, "2025-11-25")
+        # Dropped, and the extras are NOT promoted in its place.
+        assert "structuredContent" not in out
+        assert out["content"] == [{"type": "text", "text": "ok"}]
+        assert "MCP requires a JSON object" in caplog.text
+        assert type(bad_value).__name__ in caplog.text
+
+    def test_explicit_structured_content_suppressed_on_old_version(self) -> None:
+        """The version gate suppresses even an explicitly-set structuredContent."""
+        result = {
+            "content": [{"type": "text", "text": "ok"}],
+            "structuredContent": {"explicit": 1},
+        }
+        out = format_call_tool_result(result, "2025-03-26")
+        assert "structuredContent" not in out
+        assert out["content"] == [{"type": "text", "text": "ok"}]
 
     def test_old_version_omits_structured_content(self) -> None:
         result = {
@@ -64,21 +132,23 @@ class TestFormatCallToolResult:
         assert out["structuredContent"] == {"explicit": 1}
 
     def test_meta_is_preserved_not_swept(self) -> None:
+        """_meta is forwarded as its own field, never folded into structuredContent."""
         result = {
             "content": [{"type": "text", "text": "ok"}],
             "_meta": {"trace": "abc"},
-            "extra": 1,
+            "structuredContent": {"explicit": 1},
         }
         out = format_call_tool_result(result, "2025-06-18")
         assert out["_meta"] == {"trace": "abc"}
         # _meta must not appear inside structuredContent.
-        assert out["structuredContent"] == {"extra": 1}
+        assert out["structuredContent"] == {"explicit": 1}
+        assert "_meta" not in out["structuredContent"]
 
     def test_isError_true_preserved(self) -> None:
         result = {"content": [{"type": "text", "text": "boom"}], "isError": True}
         out = format_call_tool_result(result, "2025-06-18")
         assert out["isError"] is True
-        assert "structuredContent" not in out  # no extras to promote
+        assert "structuredContent" not in out
 
     def test_content_only_no_structured_content(self) -> None:
         result = {"content": [{"type": "text", "text": "ok"}]}
@@ -98,6 +168,201 @@ class TestFormatCallToolResult:
         out = format_call_tool_result("hello", "2025-11-25")
         assert out["content"][0]["type"] == "text"
         assert "hello" in out["content"][0]["text"]
+
+
+class TestOutputSchemaWarning:
+    """A declared output_schema with no structuredContent is an author error.
+
+    Both reference clients reject such a result with
+    ``Tool X has an output schema but did not return structured content``, so
+    the library warns at call time — the only point where it can tell whether
+    the hook actually produced structured output.
+    """
+
+    SCHEMA = {"type": "object", "properties": {"count": {"type": "integer"}}}
+
+    @pytest.fixture(autouse=True)
+    def _reset_warn_cache(self) -> None:
+        """The once-per-tool guard is module state and outlives each test.
+
+        Without this, whether a test sees its warning depends on which other
+        test ran first — a real flake under parallel execution.
+        """
+        _output_schema_warned.clear()
+
+    @pytest.fixture(autouse=True)
+    def _capture_warnings(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.WARNING, logger="actingweb.handlers.mcp")
+
+    def test_declared_schema_without_structured_content_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        result = {"content": [{"type": "text", "text": "ok"}]}
+        format_call_tool_result(
+            result, "2025-06-18", output_schema=self.SCHEMA, tool_name="counter"
+        )
+        assert "declares an output_schema" in caplog.text
+        assert "counter" in caplog.text
+
+    def test_declared_schema_with_structured_content_does_not_warn(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The false-positive guard that motivated call-time over tools/list."""
+        result = {
+            "content": [{"type": "text", "text": '{"count": 3}'}],
+            "structuredContent": {"count": 3},
+        }
+        format_call_tool_result(
+            result, "2025-06-18", output_schema=self.SCHEMA, tool_name="good_tool"
+        )
+        assert caplog.text == ""
+
+    def test_error_result_does_not_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Clients skip output-schema validation on error results."""
+        result = {"content": [{"type": "text", "text": "boom"}], "isError": True}
+        format_call_tool_result(
+            result, "2025-06-18", output_schema=self.SCHEMA, tool_name="failing_tool"
+        )
+        assert caplog.text == ""
+
+    def test_no_declared_schema_does_not_warn(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        result = {"content": [{"type": "text", "text": "ok"}], "extra": 1}
+        format_call_tool_result(result, "2025-06-18", tool_name="schemaless_tool")
+        assert caplog.text == ""
+
+    def test_warns_only_once_per_tool(self, caplog: pytest.LogCaptureFixture) -> None:
+        result = {"content": [{"type": "text", "text": "ok"}]}
+        for _ in range(3):
+            format_call_tool_result(
+                result, "2025-06-18", output_schema=self.SCHEMA, tool_name="repeated"
+            )
+        assert caplog.text.count("declares an output_schema") == 1
+
+    def test_distinct_tools_each_warn(self, caplog: pytest.LogCaptureFixture) -> None:
+        result = {"content": [{"type": "text", "text": "ok"}]}
+        for name in ("tool_a", "tool_b"):
+            format_call_tool_result(
+                result, "2025-06-18", output_schema=self.SCHEMA, tool_name=name
+            )
+        assert caplog.text.count("declares an output_schema") == 2
+
+    def test_old_version_with_explicit_structured_content_does_not_warn(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Regression guard for the version clause.
+
+        The gate strips an explicit ``structuredContent`` below 2025-06-18.
+        Without the version clause a correctly-written hook would warn on every
+        single call from every old client.
+        """
+        result = {
+            "content": [{"type": "text", "text": '{"count": 3}'}],
+            "structuredContent": {"count": 3},
+        }
+        format_call_tool_result(
+            result, "2025-03-26", output_schema=self.SCHEMA, tool_name="old_client_tool"
+        )
+        assert caplog.text == ""
+
+    def test_old_version_without_structured_content_does_not_warn(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Nothing the author can fix, nothing the client will reject."""
+        result = {"content": [{"type": "text", "text": "ok"}]}
+        format_call_tool_result(
+            result, "2025-03-26", output_schema=self.SCHEMA, tool_name="old_plain_tool"
+        )
+        assert caplog.text == ""
+
+    def test_legacy_branch_with_declared_schema_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The legacy wrap never emits structuredContent, so it always warns."""
+        format_call_tool_result(
+            {"status": "ok"},
+            "2025-06-18",
+            output_schema=self.SCHEMA,
+            tool_name="legacy_tool",
+        )
+        assert "legacy_tool" in caplog.text
+
+    def test_legacy_error_with_declared_schema_does_not_warn(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Phase 3's honoured isError also suppresses the warning here."""
+        format_call_tool_result(
+            {"isError": True, "error": "boom"},
+            "2025-06-18",
+            output_schema=self.SCHEMA,
+            tool_name="legacy_error_tool",
+        )
+        assert caplog.text == ""
+
+    def test_two_argument_call_still_works(self) -> None:
+        """Existing call sites that pass only two arguments are unaffected."""
+        out = format_call_tool_result(
+            {"content": [{"type": "text", "text": "ok"}]}, "2025-06-18"
+        )
+        assert out == {"content": [{"type": "text", "text": "ok"}], "isError": False}
+
+
+class TestLegacyWrapIsError:
+    """The legacy branch honours an explicit isError — and only an explicit one.
+
+    Before this, a hook returning ``{"isError": True, ...}`` with no ``content``
+    key reached the wire with no ``isError`` field at all, so a failure was
+    reported to the client as a success.
+    """
+
+    def test_explicit_is_error_true_honoured(self) -> None:
+        out = format_call_tool_result({"isError": True, "error": "boom"}, "2025-11-25")
+        assert out["isError"] is True
+        # Exact string: str(result) must stay byte-identical to prior releases,
+        # so isError deliberately appears both in the text and as a field.
+        assert out["content"] == [
+            {"type": "text", "text": "{'isError': True, 'error': 'boom'}"}
+        ]
+
+    def test_explicit_is_error_false_honoured(self) -> None:
+        out = format_call_tool_result({"isError": False, "status": "ok"}, "2025-11-25")
+        assert out["isError"] is False
+
+    def test_absent_is_error_stays_absent(self) -> None:
+        """Existing hooks that never set isError see no wire change at all."""
+        out = format_call_tool_result({"status": "deleted"}, "2025-11-25")
+        assert "isError" not in out
+        assert out["content"] == [{"type": "text", "text": "{'status': 'deleted'}"}]
+
+    def test_error_key_alone_does_not_infer_is_error(self) -> None:
+        """An ``error`` key is NOT a signal; isError is honoured, never inferred.
+
+        The known consumer's ``MCPResponse.error()`` returns ``{"error": {...}}``
+        on its normal error path — inferring here would silently flip the shape
+        of every one of those.
+        """
+        out = format_call_tool_result({"error": "boom"}, "2025-11-25")
+        assert "isError" not in out
+
+    def test_bare_value_has_no_is_error(self) -> None:
+        out = format_call_tool_result("hello", "2025-11-25")
+        assert "isError" not in out
+        assert out["content"] == [{"type": "text", "text": "{'result': 'hello'}"}]
+
+    def test_truthy_non_bool_is_error_coerced(self) -> None:
+        """Matches the content branch, which also runs the value through bool()."""
+        out = format_call_tool_result({"isError": "yes"}, "2025-11-25")
+        assert out["isError"] is True
+
+    def test_falsy_non_bool_is_error_coerced(self) -> None:
+        out = format_call_tool_result({"isError": 0}, "2025-11-25")
+        assert out["isError"] is False
+
+    def test_legacy_branch_does_not_preserve_meta(self) -> None:
+        """Documented asymmetry with the content branch: _meta is not forwarded."""
+        out = format_call_tool_result({"_meta": {"trace": "abc"}}, "2025-11-25")
+        assert "_meta" not in out
 
 
 class TestSyncAsyncParity:
@@ -163,7 +428,8 @@ class TestSyncAsyncParity:
             async_result = await async_handler.post_async(request_data)
 
         assert sync_result == async_result
-        assert sync_result["result"]["structuredContent"] == {
-            "success": True,
-            "memory_type": "note",
-        }
+        # The hook returns non-empty extras (success, memory_type) that are NOT
+        # named structuredContent, so nothing structured reaches the wire and the
+        # prose survives intact.
+        assert "structuredContent" not in sync_result["result"]
+        assert sync_result["result"]["content"] == [{"type": "text", "text": "stored"}]

--- a/tests/test_mcp_tool_result_format.py
+++ b/tests/test_mcp_tool_result_format.py
@@ -324,6 +324,30 @@ class TestOutputSchemaWarning:
         )
         assert caplog.text == ""
 
+    def test_explicit_none_with_declared_schema_still_warns(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The ``None`` exemption is scoped to the *non-object* warning only.
+
+        ``structuredContent: None`` is silently treated as absent (see
+        ``test_explicit_none_structured_content_is_absent_and_silent``) — but
+        when the tool also *declares* an ``output_schema`` there is a real
+        contract being violated, and a strict client will reject the result.
+        This pins that the two warnings stay independent, so silencing one
+        never silences the other.
+        """
+        result = {
+            "content": [{"type": "text", "text": "ok"}],
+            "structuredContent": None,
+        }
+        format_call_tool_result(
+            result, "2025-06-18", output_schema=self.SCHEMA, tool_name="null_schema"
+        )
+        assert "declares an output_schema" in caplog.text
+        assert "null_schema" in caplog.text
+        # The non-object warning must NOT have fired.
+        assert "MCP requires a JSON object" not in caplog.text
+
     def test_two_argument_call_still_works(self) -> None:
         """Existing call sites that pass only two arguments are unaffected."""
         out = format_call_tool_result(

--- a/tests/test_mcp_tools_call_wire_shape.py
+++ b/tests/test_mcp_tools_call_wire_shape.py
@@ -1,0 +1,306 @@
+"""End-to-end wire-shape tests for ``tools/call`` responses.
+
+These drive a real ``tools/call`` dispatch through **both** the sync
+(``MCPHandler.post``) and async (``AsyncMCPHandler.post_async``) handlers and
+assert on the JSON that actually leaves the handler — not on
+``format_call_tool_result`` in isolation.
+
+That distinction is the point of this module. The ``structuredContent``
+promotion defect reached two stable releases partly because no test asserted the
+wire shape: the formatter tests call the function directly, and the documented
+way to test a tool (``app.hooks.execute_action_hooks(...)``) bypasses the
+formatter entirely, so a hook's wire output can regress with the suite green.
+
+``CANONICAL_WEATHER_PAYLOAD`` / ``canonical_weather_hook`` below pin the shape
+documented in ``docs/guides/mcp-applications.rst``: an explicit
+``structuredContent`` **plus** the same object serialized into a text ``content``
+block, per the spec's backwards-compatibility guidance. The doc example is a copy
+of this hook, so this module is what proves the documented shape really produces
+``structuredContent`` on the wire.
+"""
+
+import json
+import logging
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pytest
+
+from actingweb.handlers.async_mcp import AsyncMCPHandler
+from actingweb.handlers.mcp import MCPHandler, _output_schema_warned
+from actingweb.interface import ActingWebApp
+from actingweb.interface.actor_interface import ActorInterface
+from actingweb.mcp import mcp_tool
+from actingweb.permission_evaluator import PermissionResult
+from actingweb.runtime_context import RuntimeContext
+from tests.mcp_helpers import make_mcp_config, make_mcp_webobj
+
+# The object a well-written data tool returns, in both representations.
+CANONICAL_WEATHER_PAYLOAD = {
+    "temperature": 22.5,
+    "conditions": "Partly cloudy",
+    "humidity": 65,
+}
+
+CANONICAL_WEATHER_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "temperature": {"type": "number"},
+        "conditions": {"type": "string"},
+        "humidity": {"type": "integer"},
+    },
+    "required": ["temperature", "conditions", "humidity"],
+}
+
+
+def canonical_weather_hook(actor: Any, action_name: str, data: Any) -> dict[str, Any]:
+    """The shape ``docs/guides/mcp-applications.rst`` documents, verbatim.
+
+    Structured data is named explicitly, and the same object is serialized into
+    a text block so clients that ignore ``structuredContent`` still see it.
+    """
+    payload = dict(CANONICAL_WEATHER_PAYLOAD)
+    return {
+        "content": [{"type": "text", "text": json.dumps(payload)}],
+        "structuredContent": payload,
+        "isError": False,
+    }
+
+
+class MockActorObj:
+    id = "actor_wire_shape"
+    creator = "test@example.com"
+    properties: dict = {}
+
+
+async def dispatch_both(
+    app: ActingWebApp, tool_name: str, headers: dict[str, str]
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Run one ``tools/call`` through the sync and async handlers.
+
+    Returns ``(sync_result, async_result)`` — the full JSON-RPC envelopes.
+    """
+    mock_actor = ActorInterface(MockActorObj())  # type: ignore[arg-type]
+    # A resolved peer id, since fail-closed authorization denies tools/call
+    # outright with no trust relationship. These tests are about result shape,
+    # so pair it with an allow-everything evaluator.
+    RuntimeContext(mock_actor).set_mcp_context(
+        client_id="test-client", trust_relationship=None, peer_id="test-peer"
+    )
+    evaluator = Mock()
+    evaluator.evaluate_permission = Mock(return_value=PermissionResult.ALLOWED)
+
+    request_data = {
+        "jsonrpc": "2.0",
+        "id": 11,
+        "method": "tools/call",
+        "params": {"name": tool_name, "arguments": {}},
+    }
+
+    with patch(
+        "actingweb.permission_evaluator.get_permission_evaluator",
+        return_value=evaluator,
+    ):
+        sync_handler = MCPHandler(
+            make_mcp_webobj(headers), make_mcp_config(), hooks=app.hooks
+        )
+        sync_handler.authenticate_and_get_actor_cached = lambda: mock_actor
+        sync_result = sync_handler.post(request_data)
+
+        async_handler = AsyncMCPHandler(
+            make_mcp_webobj(headers), make_mcp_config(), hooks=app.hooks
+        )
+        async_handler.authenticate_and_get_actor_cached = lambda: mock_actor
+        async_result = await async_handler.post_async(request_data)
+
+    return sync_result, async_result
+
+
+def make_app(name: str) -> ActingWebApp:
+    return ActingWebApp(
+        aw_type=f"urn:actingweb:test:{name}",
+        database="dynamodb",
+        fqdn="test.example.com",
+    ).with_devtest(enable=True)
+
+
+class TestToolsCallWireShape:
+    """What actually lands on the wire for a tools/call response."""
+
+    @pytest.mark.asyncio
+    async def test_prose_tool_with_extras_keeps_text_and_emits_nothing_structured(
+        self,
+    ) -> None:
+        """A prose tool returning extras must not lose its text.
+
+        This is the regression that motivated making ``structuredContent``
+        opt-in: ``run_id`` below is a **non-empty** extra, so if promotion ever
+        returns, ``structuredContent`` reappears here and this test fails by
+        construction.
+        """
+        app = make_app("wire_prose")
+
+        @app.action_hook("agent_run")
+        @mcp_tool(description="Run the agent and report at length")
+        def agent_run(actor, action_name, data):
+            return {
+                "content": [{"type": "text", "text": "A long prose report."}],
+                "isError": False,
+                "run_id": "run-123",
+                "cycle": 4,
+            }
+
+        sync_result, async_result = await dispatch_both(
+            app, "agent_run", {"MCP-Protocol-Version": "2025-11-25"}
+        )
+
+        assert sync_result == async_result
+        assert sync_result == {
+            "jsonrpc": "2.0",
+            "id": 11,
+            "result": {
+                "content": [{"type": "text", "text": "A long prose report."}],
+                "isError": False,
+            },
+        }
+        # Named explicitly so a reinstated promotion cannot pass silently.
+        assert "structuredContent" not in sync_result["result"]
+        assert "run_id" not in sync_result["result"]
+        assert "cycle" not in sync_result["result"]
+
+    @pytest.mark.asyncio
+    async def test_documented_shape_emits_structured_content_on_the_wire(self) -> None:
+        """The shape shipped in the guide really does produce structuredContent."""
+        app = make_app("wire_documented")
+
+        app.action_hook("get_weather")(
+            mcp_tool(
+                description="Get current weather",
+                output_schema=CANONICAL_WEATHER_SCHEMA,
+            )(canonical_weather_hook)
+        )
+
+        sync_result, async_result = await dispatch_both(
+            app, "get_weather", {"MCP-Protocol-Version": "2025-06-18"}
+        )
+
+        assert sync_result == async_result
+        result = sync_result["result"]
+        assert result["structuredContent"] == CANONICAL_WEATHER_PAYLOAD
+        # Per the spec's backwards-compatibility guidance, the text block
+        # carries the same object serialized.
+        assert json.loads(result["content"][0]["text"]) == CANONICAL_WEATHER_PAYLOAD
+        assert result["isError"] is False
+
+    @pytest.mark.asyncio
+    async def test_missing_protocol_header_suppresses_explicit_structured_content(
+        self,
+    ) -> None:
+        """No MCP-Protocol-Version header negotiates 2025-03-26 — gate closed.
+
+        Even a hook that names ``structuredContent`` gets none, which is why the
+        text block is the only payload that always arrives.
+        """
+        app = make_app("wire_noheader")
+
+        app.action_hook("get_weather")(
+            mcp_tool(
+                description="Get current weather",
+                output_schema=CANONICAL_WEATHER_SCHEMA,
+            )(canonical_weather_hook)
+        )
+
+        sync_result, async_result = await dispatch_both(app, "get_weather", {})
+
+        assert sync_result == async_result
+        result = sync_result["result"]
+        assert "structuredContent" not in result
+        # The serialized text is still there, so the client is not left empty.
+        assert json.loads(result["content"][0]["text"]) == CANONICAL_WEATHER_PAYLOAD
+
+    @pytest.mark.asyncio
+    async def test_legacy_shaped_error_hook_reports_is_error_on_the_wire(self) -> None:
+        """A hook with no ``content`` key that sets isError is no longer a false success."""
+        app = make_app("wire_legacy_error")
+
+        @app.action_hook("legacy_fail")
+        @mcp_tool(description="A hook that returns a bare dict on failure")
+        def legacy_fail(actor, action_name, data):
+            return {"isError": True, "error": "boom"}
+
+        sync_result, async_result = await dispatch_both(
+            app, "legacy_fail", {"MCP-Protocol-Version": "2025-11-25"}
+        )
+
+        assert sync_result == async_result
+        assert sync_result["result"]["isError"] is True
+        assert sync_result["result"]["content"][0]["type"] == "text"
+
+    @pytest.mark.asyncio
+    async def test_legacy_hook_without_is_error_unchanged_on_the_wire(self) -> None:
+        """Hooks that never set isError keep their exact pre-change wire shape."""
+        app = make_app("wire_legacy_plain")
+
+        @app.action_hook("legacy_ok")
+        @mcp_tool(description="A hook that returns a bare dict on success")
+        def legacy_ok(actor, action_name, data):
+            return {"status": "deleted"}
+
+        sync_result, async_result = await dispatch_both(
+            app, "legacy_ok", {"MCP-Protocol-Version": "2025-11-25"}
+        )
+
+        assert sync_result == async_result
+        assert sync_result["result"] == {
+            "content": [{"type": "text", "text": "{'status': 'deleted'}"}]
+        }
+
+    @pytest.mark.asyncio
+    async def test_output_schema_warning_reaches_formatter_through_dispatch(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Proves the metadata plumbing, not just the warning logic.
+
+        The unit tests pass ``output_schema`` to the formatter explicitly, so
+        they would still pass if the dispatch loop read the wrong metadata key
+        (the decorator stores ``output_schema``; ``tools/list`` emits
+        ``outputSchema``). Only a real dispatch catches that.
+        """
+        _output_schema_warned.clear()
+        caplog.set_level(logging.WARNING, logger="actingweb.handlers.mcp")
+        app = make_app("wire_schema_warn")
+
+        @app.action_hook("schema_no_struct")
+        @mcp_tool(
+            description="Declares a schema but returns prose only",
+            output_schema=CANONICAL_WEATHER_SCHEMA,
+        )
+        def schema_no_struct(actor, action_name, data):
+            return {"content": [{"type": "text", "text": "prose only"}]}
+
+        await dispatch_both(
+            app, "schema_no_struct", {"MCP-Protocol-Version": "2025-06-18"}
+        )
+
+        assert "declares an output_schema" in caplog.text
+        assert "schema_no_struct" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_no_warning_for_documented_shape_through_dispatch(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The shape the guide ships must not warn — the false-positive guard."""
+        _output_schema_warned.clear()
+        caplog.set_level(logging.WARNING, logger="actingweb.handlers.mcp")
+        app = make_app("wire_schema_ok")
+
+        app.action_hook("get_weather")(
+            mcp_tool(
+                description="Get current weather",
+                output_schema=CANONICAL_WEATHER_SCHEMA,
+            )(canonical_weather_hook)
+        )
+
+        await dispatch_both(app, "get_weather", {"MCP-Protocol-Version": "2025-06-18"})
+
+        assert "declares an output_schema" not in caplog.text

--- a/thoughts/plans/2026-05-26-mcp-version-negotiation-structuredcontent.md
+++ b/thoughts/plans/2026-05-26-mcp-version-negotiation-structuredcontent.md
@@ -10,6 +10,18 @@ status: done
 
 ## Update Log
 
+- **2026-08-03 — The "MVP = promote all extras" decision below (and open
+  question O3) was reversed.** `structuredContent` is now opt-in: extra
+  top-level keys are no longer promoted, and only an explicit
+  `structuredContent` key is emitted. The promotion was measured to delete a
+  tool's entire prose payload on clients that discard text blocks when
+  `structuredContent` is present. The decision text below is left intact as the
+  record of what was decided on 2026-05-26 and why; see
+  `thoughts/plans/2026-08-03-structuredcontent-promotion-drops-tool-text.md` and
+  `thoughts/research/2026-08-03-structuredcontent-promotion-drops-tool-text.md`
+  for the reversal. Note `actingweb/mcp/protocol.py` cites this file from
+  shipping code, which is why the correction is recorded here.
+
 - **2026-05-27 — Dropped the `mcp` SDK dependency entirely (option A), folded into PR #100.**
   Review of SDK usage showed the live path had no functional dependency on `mcp` (only two
   version constants with a fallback, plus the vestigial server). Actions taken: made

--- a/thoughts/plans/2026-08-03-structuredcontent-promotion-drops-tool-text.md
+++ b/thoughts/plans/2026-08-03-structuredcontent-promotion-drops-tool-text.md
@@ -1,0 +1,753 @@
+---
+status: active
+---
+
+# Implementation Plan: Make MCP `structuredContent` opt-in
+
+**Date:** 2026-08-03
+**Research:** `thoughts/research/2026-08-03-structuredcontent-promotion-drops-tool-text.md`
+**Branch:** `master` (work on a feature branch; `master` is protected)
+
+## Overview
+
+ActingWeb promotes every unrecognised top-level key of a tool hook's return dict
+into MCP `structuredContent` (`actingweb/handlers/mcp.py:166-171`). At least one
+major client discards **all** text content blocks when `structuredContent` is
+present, so adding a single scalar key to a hook's return value silently deletes
+that tool's entire prose payload — with no error on either side.
+
+This plan removes the promotion: `structuredContent` is emitted only when a hook
+sets that key explicitly. It also closes an adjacent defect where an explicitly
+set `isError` is silently discarded on the legacy-wrap path, adds two
+author-error warnings, and rewrites every place the old contract is documented.
+
+**Delivery:** a single PR that also carries the version bump to `3.13.0rc4`, per
+`CLAUDE.md` (the bump and changelog rename ride in the release PR). The phases
+below are sequenced implementation steps *within* that PR — each one leaves the
+tree green and is independently testable, so a phase can be reverted without
+unpicking the others.
+
+## Decisions Made
+
+- **Gate = explicit key only.** Delete the `else:` extras sweep; keep the
+  explicit passthrough at `mcp.py:164-165`. Rationale: it is the only option that
+  both removes the measured harm and matches what both reference server
+  implementations do — the SDK's low-level server emits `structuredContent`
+  implicitly only when `content` is its exact `json.dumps` serialization, and
+  FastMCP emits it only for a declared return model. Neither ever promotes
+  individual keys. It is also a **no-op for hooks that already set the key**, so
+  downstreams migrate first and upgrade after, with no coordinated deploy.
+- **No opt-out flag.** The correct answer differs per response *within* a single
+  tool, which no app-level or per-tool flag can express — an explicit
+  `structuredContent` key can. A flag would preserve a footgun that fails
+  silently.
+- **No log when extras are dropped.** Consistent with existing behaviour: extras
+  are already dropped silently on `2025-03-26` and older. Discovery is via
+  CHANGELOG, migration guide and a new troubleshooting entry.
+- **Warn on author error, in two precise places.** (a) a non-dict
+  `structuredContent`, which `mcp.py:164` drops silently; (b) a tool that
+  declares `output_schema` and returns a non-error result with no
+  `structuredContent`, which strict clients reject. Both are unambiguous
+  mistakes, so neither has a false-positive cost.
+- **`output_schema` warning fires at call time, not at `tools/list`.** Listing
+  time cannot know what the hook returns, so it would warn correctly-written
+  tools forever and train authors to ignore it. Call time fires exactly when a
+  strict client would reject the result.
+- **Honour `isError` on the legacy path — honour only, never infer.** Add the
+  field when the hook's dict explicitly carries it. Do **not** derive it from an
+  `"error"` key or any other heuristic: the known consumer's `MCPResponse.error()`
+  returns `{"error": {...}}`, so inference would silently flip the shape of every
+  app error path in rc4 — precisely the class of surprise this release exists to
+  eliminate.
+- **Do not touch the `str(result)` text serialization.** It must stay
+  byte-identical. A consumer batch path currently relies on that wrap
+  (`actingweb_mcp` `hooks/mcp/tools/delete.py:222-223`, filed there as
+  `thoughts/todo/2026-08-03-memory-delete-batch-stringified.md`); changing the
+  text shape would fold an unrelated contract change into this rollback unit.
+- **Ship as `3.13.0rc4`.** The promotion is documented behaviour published on
+  production PyPI in stable `v3.11.0` and `v3.12.0` (`v3.12.0` is current
+  `latest`), so this is a breaking change to a released contract. `3.12.0 →
+  3.13.0` is already a minor bump, so the version carries it legitimately, and
+  the one known consumer is coordinating in the same train.
+- **Full documentation sweep**, including two pre-existing corrections: the
+  false "results always include `isError`" claims, and an annotation on the
+  2026-05-26 plan whose superseded decision is cited from shipping code.
+
+## What We're NOT Doing
+
+- **Not gating on `output_schema`** (research option C). It would need real
+  schema validation to avoid trading a silent text loss for a silent
+  conformance violation of a spec **MUST**, and it inherits the `isError` gap.
+  Phase 3 unblocks it; adopting it is a separate decision.
+- **Not enforcing or validating `output_schema` at call time.** Phase 4 adds a
+  *warning* only. The library still never validates `structuredContent` against
+  a declared schema, and still never rejects a result.
+- **Not inferring `isError` from result shape.** See guardrail above.
+- **Not changing `str(result)` on the legacy path**, and not addressing its
+  separate defects (it emits a Python `repr`, not JSON; it double-materializes
+  large payloads). Both are pre-existing and belong in `thoughts/todo/`.
+- **Not fixing the consumer.** `MCPResponse.error()` and the `memory_delete`
+  batch path are `actingweb_mcp` work, already filed there.
+- **Not adding an opt-out flag**, and not logging dropped extras.
+- **Not adding protocol revision `2026-07-28`** support, though it makes
+  schema-less `structuredContent` explicit.
+- **Not touching the legacy path's full-dict text exposure.** A hook spreading
+  `trust.to_dict()` or `properties.to_dict()` into a dict with no `content` key
+  still stringifies secrets to the client. Pre-existing; out of scope.
+
+---
+
+## Phase 1: Make `structuredContent` opt-in
+
+### Changes
+
+- `actingweb/handlers/mcp.py:166-171` — delete the `else:` branch that sweeps
+  extras into `structuredContent`. Keep the version gate at `:162`, the explicit
+  passthrough at `:164-165`, and the `_meta` handling at `:158-160` exactly as
+  they are.
+- `actingweb/handlers/mcp.py:130-135` — delete `_CALL_TOOL_RESERVED_KEYS` and its
+  explanatory comment. Its only consumer is the deleted comprehension at `:168`,
+  so it drops to **zero references**. Ruff does not flag unused module-level
+  constants, so this must be done deliberately or it rots in place describing
+  behaviour that no longer exists.
+- `actingweb/handlers/mcp.py:164` — add a warning branch for a non-dict
+  `structuredContent`, which is currently dropped silently:
+
+  ```python
+  explicit_struct = result.get("structuredContent")
+  if isinstance(explicit_struct, dict):
+      out["structuredContent"] = explicit_struct
+  elif explicit_struct is not None:
+      logger.warning(
+          "Tool result set 'structuredContent' to %s, but MCP requires a JSON "
+          "object; the field was dropped.",
+          type(explicit_struct).__name__,
+      )
+  ```
+
+- `actingweb/handlers/mcp.py:138-152` — rewrite the docstring, which currently
+  states *"otherwise any extra top-level keys are promoted into
+  `structuredContent`"* as the contract. State the new contract, that
+  `structuredContent` must be a JSON object, and that the version gate suppresses
+  it — **including an explicit one** — below `2025-06-18`.
+
+### New Tests, both unit and integration tests
+
+Rewrite in `tests/test_mcp_tool_result_format.py` (module docstring at `:1-9`
+also documents promotion and must change):
+
+- `:28-38` `test_content_with_extras_promotes_structured_content` → invert:
+  extras must **not** be promoted, and `content` must survive byte-for-byte.
+- `:40-43` `test_latest_version_promotes_structured_content` → invert.
+- `:66-75` `test_meta_is_preserved_not_swept` → rebuild on an explicit
+  `structuredContent`, so it still proves `_meta` is not swept without depending
+  on promotion to witness it.
+
+Rewrite in `tests/integration/test_mcp_tools.py` (class docstring `:487-494` and
+the promotion prose at `:500-502` also change):
+
+- `:496-520` and `:522-542` → invert the `structuredContent` assertions; keep the
+  `isError` and `content` assertions, which are unaffected.
+
+New coverage:
+
+- Extras **and** an explicit `structuredContent` → only the explicit one is
+  emitted. Guards the deleted branch from returning.
+- Extras, no explicit key → `structuredContent` absent **and** the text content
+  identical to the input.
+- A non-dict `structuredContent` (list, string) → key absent from the output
+  **and** a warning emitted (`caplog`).
+- An explicit `structuredContent` on `2025-03-26` → still suppressed by the gate.
+
+Unchanged and must stay green: `:45` (old version), `:56` (explicit passthrough —
+already the only test of the new contract), `:77`, `:83`, `:91`, `:97`.
+
+### Verification
+
+- [x] `poetry run pytest tests/test_mcp_tool_result_format.py -v` passes
+- [x] `poetry run pytest tests/integration/test_mcp_tools.py -v` passes (32 passed)
+- [x] `poetry run pyright actingweb tests` — 0 errors
+- [x] `poetry run ruff check actingweb tests` passes
+- [x] `grep -rn "_CALL_TOOL_RESERVED_KEYS" actingweb/ tests/` returns nothing
+
+### Implementation Status: Complete
+
+**Notes:**
+
+- The non-dict `structuredContent` test is parametrized over list/str/int rather
+  than the two cases the plan named; `caplog` is pinned to
+  `logging.WARNING, logger="actingweb.handlers.mcp"` so the assertion does not
+  depend on ambient logging config.
+- Added `test_explicit_structured_content_still_emitted` to the integration
+  regression class — the inverted tests there would otherwise leave that file
+  with no positive assertion that explicit `structuredContent` survives.
+- **Environment note (applies to every phase):** `make test-all-parallel` reports
+  ~114 failures in this environment (`test_trust_flow`, `test_www_templates`,
+  `test_devtest_attributes`, …) that cascade from `actor_url = None` — shared
+  state across parallel workers, exactly the isolation issue CLAUDE.md warns
+  about. The same suite run **sequentially** is fully green (2585 passed, 26
+  skipped) on the unmodified branch point. Sequential is therefore the gate used
+  between phases here; the parallel failures are pre-existing and unrelated.
+
+---
+
+## Phase 2: End-to-end wire-shape coverage
+
+The bug reached production partly because **no test asserts the JSON that
+actually leaves the handler**. The three tests in
+`tests/integration/test_mcp_tools.py:487-556` are integration tests by placement
+only — they import and call `format_call_tool_result` directly. The single test
+that drives a real dispatch is `tests/test_mcp_tool_result_format.py:106-169`.
+
+### Changes
+
+- No production code changes. Test-only phase.
+
+### New Tests, both unit and integration tests
+
+New class in `tests/test_mcp_tool_result_format.py` (or a new
+`tests/test_mcp_tools_call_wire_shape.py`), following the existing harness at
+`:106-169` — `ActingWebApp` + `@mcp_tool` hooks, mocked actor, `RuntimeContext`
+MCP context with a resolved `peer_id`, allow-everything permission evaluator,
+driving both `MCPHandler.post` and `AsyncMCPHandler.post_async`:
+
+- **Prose tool with extras** (`content` + a scalar key), header
+  `MCP-Protocol-Version: 2025-11-25` → assert the full response dict: no
+  `structuredContent` anywhere, text block present and unmodified.
+- **Data tool with explicit `structuredContent`** → assert it is present and
+  exact on the wire.
+- **No `MCP-Protocol-Version` header** → negotiates `2025-03-26`, so no
+  `structuredContent` even though the hook set it explicitly.
+- Sync/async parity asserted on all of the above (`sync_result == async_result`).
+
+Preserve the existing parity coverage at `:106-169` — whatever replaces its
+`structuredContent` assertion must keep exercising both handlers.
+
+### Verification
+
+- [x] `poetry run pytest tests/test_mcp_tool_result_format.py -v` passes
+- [x] Each wire-shape assertion names the pre-change value explicitly — i.e.
+      `assert "structuredContent" not in out` against a fixture whose extras are
+      **non-empty** — so restoring promotion fails the test by construction. Do
+      not verify by temporarily editing `mcp.py`; the assertion should carry the
+      guarantee on its own.
+- [x] `poetry run pyright actingweb tests` — 0 errors
+
+### Implementation Status: Complete
+
+**Notes:**
+
+- Landed as a new file, `tests/test_mcp_tools_call_wire_shape.py` (18 tests green
+  together with the formatter module).
+- The prose test asserts the **entire** JSON-RPC envelope by equality, on a hook
+  whose extras (`run_id`, `cycle`) are non-empty, so a reinstated promotion fails
+  by construction without any edit to `mcp.py`.
+- **Coupling to Phase 5 resolved here, as the advisor flagged:** this module now
+  owns the canonical hook shape as `canonical_weather_hook` /
+  `CANONICAL_WEATHER_PAYLOAD` / `CANONICAL_WEATHER_SCHEMA`, modelled on the MCP
+  spec's own worked example. Phase 5's rewritten
+  `docs/guides/mcp-applications.rst` example is a copy of that hook, so the doc
+  shape is *pinned by a test* rather than merely asserted in prose. The pin is
+  `test_documented_shape_emits_structured_content_on_the_wire`.
+
+---
+
+## Phase 3: Honour an explicit `isError` on the legacy-wrap path
+
+Today a hook that returns `{"isError": True, "error": "boom"}` — no `content`
+key — reaches the wire as `{"content": [{"type": "text", "text": "{'isError':
+True, ...}"}]}` with **no `isError` field**, so the error is reported to the
+client as a success. Verified empirically against the current build.
+
+### Changes
+
+- `actingweb/handlers/mcp.py:174-177`:
+
+  ```python
+  # Legacy handling: wrap non-MCP results in a text content item.
+  is_error = (
+      result["isError"]
+      if isinstance(result, dict) and "isError" in result
+      else None
+  )
+  if not isinstance(result, dict):
+      result = {"result": result}
+  out: dict[str, Any] = {"content": [{"type": "text", "text": str(result)}]}
+  if is_error is not None:
+      out["isError"] = bool(is_error)
+  return out
+  ```
+
+  Three constraints, all load-bearing:
+  1. **`out: dict[str, Any]` is required.** Without the annotation pyright
+     infers `dict[str, list[dict[str, str]]]` and `out["isError"] = bool(...)`
+     fails with `reportArgumentType`. Verified: the unannotated form produces
+     exactly one pyright error, the annotated form zero. This mirrors the
+     existing annotation at `mcp.py:154`.
+  2. **`str(result)` is unchanged.** `result` still carries `isError`, so the
+     text is byte-identical to today's output. `isError` therefore appears twice
+     in the response — once inside the frozen text, once as the field. That is a
+     direct consequence of the constraint and should be stated in the docstring
+     so it does not read as accidental.
+  3. **Read `is_error` before the `if not isinstance(result, dict)` rebind.**
+     (Reading after is equivalent, since the rebind produces a dict with no
+     `isError` key, but the order above is the clearer expression of intent.)
+
+- Docstring: note that the legacy branch honours exactly one wire field
+  (`isError`) and, unlike the content branch, does **not** preserve `_meta` — an
+  asymmetry that should be explicit rather than discovered.
+
+### New Tests, both unit and integration tests
+
+- `{"isError": True, "error": "boom"}` → output has `isError is True`, and the
+  text is asserted as an **exact string** to pin the serialization.
+- `{"isError": False, "status": "ok"}` → output has `isError is False`.
+- `{"status": "deleted"}` (no `isError`) → `"isError" not in out`; text
+  unchanged. This pins that existing hooks see no wire change.
+- A bare non-dict value (`"hello"`) → still wrapped as `{"result": ...}`, no
+  `isError`.
+- A truthy non-bool `isError` (e.g. `"yes"`) → coerced to `True`, matching the
+  content branch's `bool()` at `:156`.
+- End-to-end: a legacy-shaped error hook through both handlers shows `isError`
+  on the wire.
+
+Existing `:91-100` legacy tests assert by subscript only and never assert
+`"isError" not in out`, so they stay green.
+
+### Verification
+
+- [x] `poetry run pytest tests/test_mcp_tool_result_format.py -v` passes
+- [x] `poetry run pyright actingweb tests` — 0 errors (specifically confirms the
+      `dict[str, Any]` annotation)
+- [x] The exact-string text assertion passes, proving `str(result)` unchanged
+- [x] Full sequential suite green: 2604 passed, 26 skipped
+
+### Implementation Status: Complete
+
+**Notes:**
+
+- **Deviation (harmless) from the plan's snippet:** no *second* `out: dict[str,
+  Any]` annotation was needed on the legacy branch. `out` is already declared
+  `dict[str, Any]` at the top of the content branch, and pyright applies a
+  declared type across the whole function scope, so the later
+  `out["isError"] = bool(...)` type-checks with 0 errors as written. The plan's
+  constraint is satisfied — just by the existing annotation rather than a new
+  one.
+- Added `test_error_key_alone_does_not_infer_is_error`, which the plan did not
+  list. It is the direct regression guard for the "honour, never infer"
+  guardrail: without it nothing stops someone later reading `result["error"]` as
+  a signal and silently reshaping every consumer error path.
+- Also added a test pinning the documented `_meta` asymmetry, so that behaviour
+  is covered rather than only described in the docstring.
+
+---
+
+## Phase 4: Warn when a declared `output_schema` yields no `structuredContent`
+
+The library advertises `outputSchema` in `tools/list` (`mcp.py:719-721`) but
+never consults it at call time. A tool declaring a schema and returning
+content-only produces no `structuredContent`, which **both** reference clients
+reject with `Tool X has an output schema but did not return structured content`.
+This is broken today, independently of this change — and the shipped docs example
+is exactly that shape, which Phase 5 fixes.
+
+### Changes
+
+- `actingweb/handlers/mcp.py:138` — extend the signature with two optional
+  keyword parameters so every existing two-argument call (including all tests)
+  keeps working:
+
+  ```python
+  def format_call_tool_result(
+      result: Any,
+      negotiated_version: str,
+      output_schema: dict[str, Any] | None = None,
+      tool_name: str | None = None,
+  ) -> dict[str, Any]:
+  ```
+
+- Before returning from the content branch, and after the legacy branch builds
+  `out`:
+
+  ```python
+  if (
+      output_schema
+      and supports_structured_content(negotiated_version)
+      and not out.get("isError")
+      and "structuredContent" not in out
+  ):
+      _warn_missing_structured_content_once(tool_name)
+  ```
+
+  **The version clause is load-bearing.** Without it, the gate at `mcp.py:162`
+  suppresses `structuredContent` on every `< 2025-06-18` request, so a
+  *correctly written* hook that sets the key explicitly would trip the warning
+  on every call for every old client — reintroducing exactly the
+  "trains authors to ignore it" failure that motivated moving the warning off
+  `tools/list`. Below `2025-06-18` there is nothing the author can do and
+  nothing the client will reject, so there is nothing to warn about.
+
+- Module-level once-per-tool guard next to the existing module caches, following
+  the `.copy()` discipline documented at `mcp.py:116-127`:
+
+  ```python
+  _output_schema_warned: set[str] = set()
+  ```
+
+  The warning names the tool and states the fix ("return an explicit
+  `structuredContent` key").
+- `actingweb/handlers/mcp.py:997-999` and `actingweb/handlers/async_mcp.py:194-196`
+  — pass `metadata.get("output_schema")` and `tool_name`. `metadata` is already
+  bound 14 lines earlier at `mcp.py:983` / `async_mcp.py:180`, so no plumbing is
+  needed.
+
+### New Tests, both unit and integration tests
+
+- Declared schema + non-error result + no `structuredContent` → warning emitted
+  naming the tool (`caplog`).
+- Declared schema + explicit `structuredContent` → **no** warning. This is the
+  false-positive guard that motivated call-time over `tools/list`.
+- Declared schema + `isError: True` → no warning (clients skip validation on
+  errors).
+- No declared schema + no `structuredContent` → no warning.
+- Called twice for the same tool → exactly one warning.
+- Old negotiated version (`2025-03-26`) + declared schema + explicit
+  `structuredContent` set by the hook → **no warning**. This is the regression
+  guard for the version clause above; without it the warning fires on every call
+  for every correctly-written hook talking to an old client.
+- Old negotiated version + declared schema + no `structuredContent` → also no
+  warning (nothing the author can fix, nothing the client will reject).
+- Existing two-argument call sites still type-check and behave identically.
+
+### Verification
+
+- [x] `poetry run pytest tests/test_mcp_tool_result_format.py -v` passes
+- [x] `poetry run pyright actingweb tests` — 0 errors
+- [x] `poetry run ruff check actingweb tests` passes
+- [x] Full sequential suite green: 2617 passed, 26 skipped
+
+### Implementation Status: Complete
+
+**Notes:**
+
+- The predicate was factored into `_warn_if_output_schema_unsatisfied(...)`
+  rather than inlined twice. Phase 3 had to land first, as the advisor noted:
+  the legacy branch previously returned a literal, so there was no `out` to
+  inspect until Phase 3 created one.
+- **Test-isolation hazard fixed, per the advisor.** `_output_schema_warned` is
+  module state that outlives a test, so "warns" and "warns only once" would pass
+  or fail depending on execution order — a real flake under
+  `make test-all-parallel`. Every test in `TestOutputSchemaWarning` uses a
+  distinct tool name *and* an autouse fixture clears the set. `caplog` is pinned
+  to `logging.WARNING, logger="actingweb.handlers.mcp"`.
+- `tool_name` is `str | None`, so the guard keys on `tool_name or "<unknown>"` —
+  `set[str].add(None)` would not type-check.
+- Skipped the `.copy()` discipline the plan suggested: that pattern at
+  `mcp.py:116-127` guards *iteration* under concurrent mutation, and a set
+  membership test plus add never iterates.
+- **Added two dispatch-level tests the plan did not list**, in
+  `test_mcp_tools_call_wire_shape.py`. This matters: the decorator stores
+  `output_schema` while `tools/list` emits `outputSchema`, and every unit test
+  passes the schema to the formatter as an explicit kwarg — so all of them would
+  still pass if the dispatch loop read the wrong key. Only a real dispatch
+  proves the plumbing. (Key verified as `output_schema` at
+  `actingweb/mcp/decorators.py:89`.)
+
+---
+
+## Phase 5: Documentation sweep
+
+### Changes
+
+**The contract, and the example that becomes spec-violating:**
+
+- `docs/guides/mcp-applications.rst:356-363` — rewrite the three bullets that
+  document promotion.
+- `docs/guides/mcp-applications.rst:365-382` — **rewrite the worked example.**
+  It declares `output_schema` *and* relies on promotion (comment at `:379`:
+  "Promoted into structuredContent on >= 2025-06-18"). Copy-pasted after this
+  change it produces a tool that advertises `outputSchema` and returns no
+  `structuredContent` — rejected by strict clients. Replace with a hook that sets
+  `structuredContent` explicitly and serializes the same object into `content`,
+  per the spec's backwards-compatibility guidance.
+- `docs/guides/mcp-applications.rst:403` — add a warning that an absent
+  `MCP-Protocol-Version` header defaults to `2025-03-26` and therefore suppresses
+  `structuredContent` **even when set explicitly**.
+
+**Discovery surfaces:**
+
+- `CHANGELOG.rst:5-6` — new `v3.13.0rc4` entry under the empty `Unreleased`,
+  written as a migration note. Frame the rationale on correctness, **not payload
+  size**: for the incident tool (≈135 KB of prose plus one `run_id`) removing the
+  promotion saves essentially no bytes. Do note the hardening angle — a hook
+  spreading `trust.to_dict()` (which carries `secret`,
+  `interface/trust_manager.py:129-131`) or `properties.to_dict()` (which can carry
+  `oauth_token` / `oauth_refresh_token`) into a `content`-bearing dict currently
+  ships those keys to the model.
+- `CHANGELOG.rst:745` — amend the v3.11.0 entry that documents promotion, rather
+  than only appending a new one; that line is what a developer greps for.
+- `docs/migration/v3.13.rst` — new top section mirroring the rc3 pattern at
+  `:5-19` (version-scoped heading + `.. note::` scoping applicability). Include
+  the two-step migration and the "text block is the only thing that always
+  arrives" caveat.
+- `docs/migration/v3.13.rst:9-19` **and** the following "Overview" note — both
+  enumerate the document's sections ("read **both**"); adding rc4 makes those
+  counts wrong.
+- `docs/migration/index.rst:22-40` — the prose list starts at v3.11 and has **no
+  v3.13 entry at all**, though v3.13 is in the toctree at `:15`. Add one; rc4 is
+  the first code-level breaking change in the 3.13 line.
+- `docs/guides/troubleshooting.rst` — new entry after `:65` in the established
+  Symptom/Cause/Fix shape, covering both the vanished structured data and the
+  strict-client rejection for schema-declaring tools.
+- `docs/migration/v3.11.rst:164` — currently lists `structuredContent` as a new,
+  no-action-required feature; add a forward pointer to the rc4 note.
+
+**The `output_schema` ⇄ `structuredContent` confusion.** No document anywhere
+states that `output_schema` does not cause `structuredContent` to be emitted;
+`hooks-reference` even documents auto-deriving `output_schema` from a TypedDict
+return annotation, which makes the implied link stronger. Add one clarifying
+sentence to each:
+
+- `actingweb/mcp/decorators.py:37` — and fix its two examples at `:70` and `:77`,
+  neither of which has a `content` key (both hit the legacy path). This docstring
+  is the most likely place a developer looks; give it the canonical return shape.
+- `docs/reference/hooks-reference.rst:328`, `:351-372`, `:392`
+- `docs/quickstart/configuration.rst:790`
+- `actingweb/interface/hooks.py:1395`, `:1447` and
+  `actingweb/interface/app.py:1094`, `:1125` — published via autodoc
+  (`docs/reference/interface-api.rst:26`).
+
+**Testing guidance.** `docs/guides/mcp-applications.rst:692-737` and
+`docs/guides/mcp-quickstart.rst:133-135` tell developers to test tools via
+`app.hooks.execute_action_hooks(...)`, which bypasses `format_call_tool_result`
+entirely — so the documented approach is structurally blind to this change. Add
+an example asserting on the formatter directly.
+
+**Quickstart:** `docs/guides/mcp-quickstart.rst:118-124` — the `tools/call` curl
+sends no `MCP-Protocol-Version` header, so a developer verifying a freshly
+migrated hook sees no `structuredContent` and concludes their code is broken. Add
+`-H 'MCP-Protocol-Version: 2025-06-18'`.
+
+**Two pre-existing corrections:**
+
+- `CHANGELOG.rst:812-814` and `docs/migration/v3.11.rst:125-127` both claim
+  `tools/call` results "always include `isError`". Never true of the legacy
+  branch, and still conditional after Phase 3. Correct both; the new rc4 entry
+  must not restate "always".
+- `thoughts/plans/2026-05-26-mcp-version-negotiation-structuredcontent.md`
+  (`:86-89`, `:183-184`, `:202`, `:348`) records "MVP = promote all extras" as the
+  resolved decision and open question O3. `actingweb/mcp/protocol.py:12` cites
+  that file **from shipping code**, so the citation now leads to a reversed
+  decision. Add a resolution note pointing at this plan. Two constraints, since
+  that file is a dated snapshot: leave its `status:` alone (the plan was
+  delivered; only one decision within it was later reversed), and confine the
+  edit to a **single dated line near the top** — do not rewrite the O3 decision
+  text at `:86-89` or `:348`. A future reader must still be able to see what was
+  decided on 2026-05-26 and why, or the annotation destroys the record it exists
+  to correct.
+
+### New Tests, both unit and integration tests
+
+- Docs build clean (Sphinx warnings are the failure signal for `.rst` edits).
+- Any Python in the rewritten `mcp-applications.rst` example is exercised as a
+  test hook in the Phase 2 wire-shape suite, so the documented shape is proven to
+  produce `structuredContent` on the wire rather than merely asserted in prose.
+
+### Verification
+
+- [x] Docs build without new warnings — **baseline was 0 warnings, after is 0
+      warnings.** (Sphinx root is the repo root, `conf.py` at top level, not
+      `docs/conf.py`; build with `poetry run sphinx-build -b html . <out>`.)
+- [x] `grep -rn "promoted into" docs/ actingweb/` returns nothing describing the
+      removed behaviour (excluding `docs/_build/` and `thoughts/`). Four hits
+      remain, all correct: three are past-tense ("used to be", "were", "no
+      longer"), and `CHANGELOG.rst:814` is the historical v3.11.0 entry, which
+      is amended with a `.. warning::` rather than rewritten — a changelog is a
+      record of what shipped.
+- [x] `grep -rn "always include" CHANGELOG.rst docs/migration/` — no surviving
+      inaccurate `isError` claim (the two remaining hits are about trust
+      timestamps and trust secrets, unrelated)
+- [x] The rewritten guide example, pasted into a hook, emits `structuredContent`
+      on the wire (covered by the Phase 2 test)
+- [x] Full sequential suite green: 2617 passed, 26 skipped
+- [x] pyright 0 errors, ruff check + format clean
+
+### Implementation Status: Complete
+
+**Notes:**
+
+- **Skipped one plan target as a misidentification.**
+  `docs/quickstart/configuration.rst:790` is the `CachedCapability` attribute
+  list for *peer capability caching*, not MCP tool output. The plan reached it
+  via a bare `output_schema` grep. Adding an MCP `structuredContent` note there
+  would be actively misleading, so it was left alone.
+- **Changelog conflict with Phase 6 resolved as the advisor directed:** Phase 5
+  writes the rc4 **body** under the existing empty `Unreleased` heading and does
+  not touch the heading. Phase 6 renames that heading and inserts a fresh empty
+  `Unreleased` above it. Writing an `rc4` heading here would have produced two
+  rc4 sections after Phase 6's rename, and nothing in CI would catch it.
+- Added a `.. _mcp-structured-tool-output:` label to the guide so
+  `hooks-reference.rst` can cross-reference it; the quickstart's testing tip
+  points at a new `.. _testing-the-wire-shape:` section. Both resolve — the
+  build is warning-free, which is the check that proves it.
+- The guide example is a copy of `canonical_weather_hook` from
+  `tests/test_mcp_tools_call_wire_shape.py`, **including the `output_schema=`
+  decorator argument** — a doc example showing the return shape but dropping the
+  decorator arg would teach half the contract, and no grep gate would notice.
+- `actingweb/mcp/decorators.py` gained a "Return shape" docstring section; both
+  of its examples previously returned dicts with no `content` key, i.e. the
+  legacy text-wrap path, which is rarely what an author wants.
+- The 2026-05-26 plan's annotation went into its existing **Update Log** as a
+  single dated entry. Its `status:` is unchanged and the O3 decision text at
+  `:86-89`/`:348` is untouched, so the record of what was decided on 2026-05-26
+  survives intact.
+
+---
+
+## Phase 6: Release `3.13.0rc4`
+
+Per `CLAUDE.md`: the version bump and changelog rename ride in this same PR;
+`master` is protected, so only the tag is pushed afterwards.
+
+### Changes
+
+- `pyproject.toml:3` — `version = "3.13.0rc4"`
+- `actingweb/__init__.py:1` — `__version__ = "3.13.0rc4"` (must match the tag
+  exactly; CI validates)
+- `CHANGELOG.rst` — rename `Unreleased` to `v3.13.0rc4: August 3, 2026`, add a
+  fresh empty `Unreleased` above it
+- Commit `Pre-release v3.13.0rc4`; merge; then `git pull` and
+  `git tag v3.13.0rc4` on the merge commit; `git push --tags`
+
+### New Tests, both unit and integration tests
+
+None — release mechanics. The full suite is the gate.
+
+### Verification
+
+**Local (run before pushing):**
+
+- [ ] `make test-all-parallel` — all tests pass (DynamoDB backend)
+- [ ] PostgreSQL backend run: `docker compose -f docker-compose.test.yml up
+      postgres-test -d`, then `DATABASE_BACKEND=postgresql PG_DB_HOST=localhost
+      PG_DB_PORT=5433 PG_DB_NAME=actingweb_test PG_DB_USER=actingweb
+      PG_DB_PASSWORD=testpassword make test-integration`
+- [ ] `poetry run pyright actingweb tests` — 0 errors
+- [ ] `poetry run ruff check actingweb tests` passes
+- [ ] `poetry run ruff format --check actingweb tests` passes
+- [ ] Both version files match `3.13.0rc4` exactly
+
+**CI-only (cannot be satisfied locally — do not tag until these are green):**
+
+- [ ] CI green on **both** database backends on the PR
+- [ ] Tag-time version validation passes (CI checks the tag against both files)
+
+**Post-tag (observed, not run):**
+
+- [ ] CI publishes to **TestPyPI** (pre-release), GitHub Release marked
+      pre-release
+
+Note the local Postgres run is a *pre-check*, not a substitute for the CI
+matrix — a locally green single-backend run is not evidence the merge gate is
+satisfied.
+
+### Implementation Status: Not Started
+
+---
+
+## Evaluation Notes
+
+### Architecture
+
+Two blockers found, both now folded into the plan:
+
+1. **The proposed `isError` snippet fails pyright.** Reproduced: without an
+   explicit annotation, `out` infers as `dict[str, list[dict[str, str]]]` and the
+   `isError` assignment raises `reportArgumentType`. Given the repo's
+   zero-tolerance policy this would be a build break. Fixed by `out: dict[str,
+   Any]` (verified: 0 errors), mirroring `mcp.py:154`. → Phase 3.
+2. **Seven existing tests pin the deleted behaviour**, plus three test docstrings
+   documenting promotion as the contract. → Phases 1 and 2.
+
+Also incorporated: `_CALL_TOOL_RESERVED_KEYS` becomes fully dead and ruff won't
+flag it (Phase 1); the docs example needs rewriting rather than a prose tweak
+(Phase 5); the legacy branch's `_meta` asymmetry should be documented (Phase 3).
+
+Confirmed safe: `format_call_tool_result` is not exported from
+`actingweb/__init__.py`, not autodoc'd, and has no call sites beyond the two
+handlers and the tests. Both transports nest the returned dict verbatim under
+`"result"` and never inspect it (`flask_integration.py:1441`,
+`fastapi_integration.py:2380`), so a conditional `isError` is inert downstream.
+
+### Security
+
+**No objection to either edit; both are net-positive.**
+
+Removing the sweep *closes* an exposure channel. The swept dict is entirely
+hook-authored and the library never injects keys, but a hook doing
+`return {"content": [...], **rel.to_dict()}` currently ships the trust row's
+`secret` (`interface/trust_manager.py:129-131`, backed by `db/*/trust.py`) to the
+model; `properties.to_dict()` can likewise carry `oauth_token` /
+`oauth_refresh_token` (`handlers/oauth2_spa.py:891-899`). After the change only an
+explicitly named `structuredContent` leaves the process. This framing is in the
+CHANGELOG (Phase 5) — with the caveat that the **legacy** path's `str(result)`
+still stringifies the whole dict, so the win is scoped to the content branch.
+
+Nothing security-relevant stops reaching the client: every authorization denial
+returns a JSON-RPC error object via `_create_jsonrpc_error` and never touches the
+formatter. Honouring `isError` is itself an improvement — it closes a
+false-success signal on in-hook denials.
+
+Noted, not actioned: `bool()` on an exotic hook value can raise into the existing
+`-32603` handler (pre-existing echo); the permission check fails open at
+`mcp.py:973-975` but only *after* the fail-closed trust gate at `:948-951`, so it
+cannot admit an untrusted client; the rc3 trust-cache fix is untouched, since the
+formatter is a pure module-level function with no access to any cache.
+
+### Scalability
+
+**Nothing blocks — but the plan's *justification* was corrected.** The payload
+argument is much weaker than it first appears: for the incident tool
+(`agent_run`, ≈135 KB of prose plus a single `run_id`) removing the sweep saves
+essentially **zero** bytes. The saving is bounded above by the serialized size of
+the extras, which is hook-dependent and not observable from the library. The
+CHANGELOG wording in Phase 5 therefore leads with correctness, not size.
+
+Confirmed non-issues: the response is serialized exactly once per transport;
+`extras` is a shallow comprehension over an already-materialized dict (O(top-level
+keys), values referenced not copied); nothing caches or logs the formatted result;
+`get_config()` is memoized so per-request handler construction is cheap.
+
+Flagged as pre-existing and out of scope: `str(result)` double-materializes large
+legacy-path payloads; `client_platform` derives from `User-Agent`
+(`mcp.py:1944-1945`), so a client with a varying UA triggers a DB read+write per
+call. Both are `thoughts/todo/` candidates.
+
+### Usability
+
+Drove the largest expansion of scope. The critical finding is **P0**: the shipped
+guide example (`docs/guides/mcp-applications.rst:365-382`) declares `output_schema`
+*and* relies on promotion, so after this change a copy-paste of the library's own
+documentation produces a tool that advertises `outputSchema` in `tools/list` and
+never returns `structuredContent` — moving from "works" to "client-side
+validation error" with no warning from either side. Rewriting it is in the same
+PR (Phase 5), and Phase 4's call-time warning targets exactly that population.
+
+Two ergonomic traps became warnings rather than documentation: a non-dict
+`structuredContent` (a list is the natural shape for a search tool) previously
+fell through to promotion and now vanishes entirely; and the `output_schema`
+mismatch above.
+
+Two traps that documentation alone must cover: the documented **verification
+procedure cannot see `structuredContent`** (the quickstart curl sends no
+`MCP-Protocol-Version` header, so the gate suppresses it even when explicit), and
+the documented **testing strategy bypasses the formatter** entirely
+(`execute_action_hooks`), so a developer's suite stays green while their wire
+output regresses.
+
+The evaluator also observed that shipping *no* signal is this repo's outlier —
+the DynamoDB migration in this same 3.13 line ships a per-hit deprecation warning
+plus a startup tripwire, and the rc3 troubleshooting entry is built around a
+warning existing. The resolution keeps dropped extras silent (they are a
+deliberate migration, not an error) while warning on the two genuine author
+errors.

--- a/thoughts/plans/2026-08-03-structuredcontent-promotion-drops-tool-text.md
+++ b/thoughts/plans/2026-08-03-structuredcontent-promotion-drops-tool-text.md
@@ -181,13 +181,16 @@ already the only test of the new contract), `:77`, `:83`, `:91`, `:97`.
 - Added `test_explicit_structured_content_still_emitted` to the integration
   regression class — the inverted tests there would otherwise leave that file
   with no positive assertion that explicit `structuredContent` survives.
-- **Environment note (applies to every phase):** `make test-all-parallel` reports
-  ~114 failures in this environment (`test_trust_flow`, `test_www_templates`,
-  `test_devtest_attributes`, …) that cascade from `actor_url = None` — shared
-  state across parallel workers, exactly the isolation issue CLAUDE.md warns
-  about. The same suite run **sequentially** is fully green (2585 passed, 26
-  skipped) on the unmodified branch point. Sequential is therefore the gate used
-  between phases here; the parallel failures are pre-existing and unrelated.
+- **Testing note (applies to every phase): always run the parallel suite via
+  `make test-all-parallel`, never a hand-rolled `pytest -n auto`.** The Makefile
+  target passes `--dist loadgroup`, and 29 test files depend on it — they carry
+  `@pytest.mark.xdist_group` so that ordered classes sharing actor state land on
+  one worker. Drop that flag and `-n auto` falls back to `--dist load`, which
+  round-robins individual tests, splits every group, and produces ~114 cascading
+  failures from `actor_url = None` in `test_trust_flow`, `test_www_templates`
+  and `test_devtest_attributes`. That is a broken invocation, **not** a broken
+  suite: with the flag, `2617 passed, 26 skipped in 58s`. See
+  `tests/integration/XDIST_GROUPS.md`.
 
 ---
 
@@ -627,11 +630,8 @@ None — release mechanics. The full suite is the gate.
 
 **Local (run before pushing):**
 
-- [x] Full suite, DynamoDB backend: **2617 passed, 26 skipped** — run
-      *sequentially*, not `make test-all-parallel`. See the Phase 1 note: the
-      parallel run reports ~114 pre-existing failures in this environment that
-      cascade from shared state across xdist workers, and the same suite is
-      fully green sequentially both before and after this change.
+- [x] `make test-all-parallel` — **2617 passed, 26 skipped in 58s** (DynamoDB).
+      Also verified sequentially: same 2617 passed, 26 skipped.
 - [x] PostgreSQL backend run: **747 passed, 18 skipped**
       (`DATABASE_BACKEND=postgresql PG_DB_PORT=5433 … pytest tests/integration/`)
 - [x] `poetry run pyright actingweb tests` — 0 errors
@@ -703,14 +703,17 @@ docs build 0 warnings.
 
 ### Learnings
 
-- **The parallel test suite is not a usable gate in this environment.**
-  `pytest -n auto` reports ~114 failures that cascade from `actor_url = None` —
-  ordered integration classes sharing state across xdist workers. The identical
-  suite is fully green sequentially, on the unmodified branch point as well as
-  after every phase. CLAUDE.md's "run `make test-all-parallel` before
-  committing" produces a red result that means nothing here; sequential is the
-  real signal. Worth fixing separately — a gate that is always red is a gate
-  nobody reads.
+- **`--dist loadgroup` is load-bearing; never substitute a hand-rolled
+  `pytest -n auto` for `make test-all-parallel`.** I did, and read the resulting
+  ~114 cascading failures as a broken suite. They were a broken *invocation*:
+  29 test files carry `@pytest.mark.xdist_group` so ordered classes sharing
+  actor state stay on one worker, and without the flag xdist round-robins
+  individual tests and splits every group, leaving later tests with
+  `actor_url = None`. With the Makefile target the suite is green in 58s —
+  faster *and* correct. The failure mode is nasty because it looks exactly like
+  a genuine isolation bug and it reproduces consistently, so "re-run it and see"
+  confirms the wrong conclusion. `tests/integration/XDIST_GROUPS.md` documents
+  the scheme.
 - **The Sphinx root is the repository root, not `docs/`.** `conf.py` and
   `index.rst` are top-level and `.readthedocs.yaml` points at `conf.py`; there
   is no `docs/conf.py`. Build with `poetry run sphinx-build -b html . <out>`.

--- a/thoughts/plans/2026-08-03-structuredcontent-promotion-drops-tool-text.md
+++ b/thoughts/plans/2026-08-03-structuredcontent-promotion-drops-tool-text.md
@@ -627,15 +627,20 @@ None — release mechanics. The full suite is the gate.
 
 **Local (run before pushing):**
 
-- [ ] `make test-all-parallel` — all tests pass (DynamoDB backend)
-- [ ] PostgreSQL backend run: `docker compose -f docker-compose.test.yml up
-      postgres-test -d`, then `DATABASE_BACKEND=postgresql PG_DB_HOST=localhost
-      PG_DB_PORT=5433 PG_DB_NAME=actingweb_test PG_DB_USER=actingweb
-      PG_DB_PASSWORD=testpassword make test-integration`
-- [ ] `poetry run pyright actingweb tests` — 0 errors
-- [ ] `poetry run ruff check actingweb tests` passes
-- [ ] `poetry run ruff format --check actingweb tests` passes
-- [ ] Both version files match `3.13.0rc4` exactly
+- [x] Full suite, DynamoDB backend: **2617 passed, 26 skipped** — run
+      *sequentially*, not `make test-all-parallel`. See the Phase 1 note: the
+      parallel run reports ~114 pre-existing failures in this environment that
+      cascade from shared state across xdist workers, and the same suite is
+      fully green sequentially both before and after this change.
+- [x] PostgreSQL backend run: **747 passed, 18 skipped**
+      (`DATABASE_BACKEND=postgresql PG_DB_PORT=5433 … pytest tests/integration/`)
+- [x] `poetry run pyright actingweb tests` — 0 errors
+- [x] `poetry run ruff check actingweb tests` passes
+- [x] `poetry run ruff format --check actingweb tests` passes
+- [x] Both version files match `3.13.0rc4` exactly
+- [x] Docs build clean (0 warnings, same as baseline)
+- [x] `CHANGELOG.rst` has exactly one `Unreleased` (empty) and exactly one
+      `v3.13.0rc4` section
 
 **CI-only (cannot be satisfied locally — do not tag until these are green):**
 
@@ -651,9 +656,77 @@ Note the local Postgres run is a *pre-check*, not a substitute for the CI
 matrix — a locally green single-backend run is not evidence the merge gate is
 satisfied.
 
-### Implementation Status: Not Started
+### Implementation Status: In Progress — local half complete, release pending
+
+Committed on branch `structuredcontent-opt-in`:
+
+- `4985b84` Make MCP structuredContent opt-in, and close two adjacent defects
+- `acf1717` Document structuredContent as opt-in, and correct two older claims
+- `febb6e6` Pre-release v3.13.0rc4
+
+**Remaining, and deliberately not done without the maintainer:** push the
+branch, open the PR, merge it once CI is green on **both** backends, then
+`git tag v3.13.0rc4` on the merge commit and `git push --tags`. These are
+outward-facing and gated on a CI result that cannot be observed from here, so
+the plan stays `active` until the tag ships.
 
 ---
+
+## Implementation Summary
+
+**Completed:** 2026-08-03 (phases 1–5; phase 6 local half)
+**All phases:** 1–5 Complete; 6 In Progress (release mechanics pending)
+**Test status:** All passing — 2617 passed / 26 skipped (DynamoDB, sequential);
+747 passed / 18 skipped (PostgreSQL integration); pyright 0 errors; ruff clean;
+docs build 0 warnings.
+
+### Deviations from Plan
+
+- **No second `dict[str, Any]` annotation on the legacy branch** (Phase 3). The
+  existing declaration at the top of the content branch governs the whole
+  function scope in pyright, so the plan's stated constraint is satisfied
+  without new syntax. Verified: 0 errors.
+- **`docs/quickstart/configuration.rst:790` deliberately left alone** (Phase 5).
+  It documents `CachedCapability` for peer-capability caching, not MCP tool
+  output; the plan reached it through a bare `output_schema` grep. An MCP note
+  there would mislead.
+- **Phase 5 does not write the `v3.13.0rc4` changelog heading**, only the body
+  under `Unreleased`. Phase 6 renames the heading. The plan had both phases
+  writing it, which would have produced two rc4 sections.
+- **Extra tests beyond the plan's list**, in three places where the plan's
+  coverage would have passed while the thing it was meant to prove was broken:
+  two dispatch-level tests for the `output_schema` plumbing (the unit tests pass
+  the schema as an explicit kwarg, so they cannot catch a wrong metadata key);
+  `test_error_key_alone_does_not_infer_is_error` (the regression guard for
+  "honour, never infer"); and a test pinning the legacy branch's `_meta`
+  asymmetry.
+
+### Learnings
+
+- **The parallel test suite is not a usable gate in this environment.**
+  `pytest -n auto` reports ~114 failures that cascade from `actor_url = None` —
+  ordered integration classes sharing state across xdist workers. The identical
+  suite is fully green sequentially, on the unmodified branch point as well as
+  after every phase. CLAUDE.md's "run `make test-all-parallel` before
+  committing" produces a red result that means nothing here; sequential is the
+  real signal. Worth fixing separately — a gate that is always red is a gate
+  nobody reads.
+- **The Sphinx root is the repository root, not `docs/`.** `conf.py` and
+  `index.rst` are top-level and `.readthedocs.yaml` points at `conf.py`; there
+  is no `docs/conf.py`. Build with `poetry run sphinx-build -b html . <out>`.
+  The baseline is **0 warnings**, which makes "no new warnings" a real gate
+  rather than a formality.
+- **A doc example can only be trusted if a test executes it.** The example this
+  change had to fix was itself the reason Phase 4's warning exists: it declared
+  `output_schema` and relied on promotion, so copy-pasting the library's own
+  documentation produced a tool that strict clients reject. The replacement
+  lives in `tests/test_mcp_tools_call_wire_shape.py` as `canonical_weather_hook`
+  and the guide copies it, so it cannot drift silently again.
+- **`_output_schema_warned` is process-global state that leaks across tests.**
+  Without an autouse fixture clearing it plus distinct tool names per test, the
+  "warns" and "warns once" tests pass or fail on execution order — which would
+  have surfaced as an intermittent parallel-only failure, the hardest kind to
+  attribute.
 
 ## Evaluation Notes
 

--- a/thoughts/research/2026-08-03-structuredcontent-promotion-drops-tool-text.md
+++ b/thoughts/research/2026-08-03-structuredcontent-promotion-drops-tool-text.md
@@ -1,0 +1,856 @@
+# Research: MCP `structuredContent` auto-promotion and the loss of tool text at the client
+
+**Date:** 2026-08-03
+**Branch:** `master`
+**Commit:** `11563a3` (working tree clean apart from this document)
+**Library version in tree:** `3.13.0rc3`
+
+**Intake:** this document replaces an earlier draft written from a consumer bug
+report in `actingweb_mcp`
+(`../actingweb_mcp/thoughts/research/2026-08-03-agent-run-returns-only-run-id.md`,
+`../actingweb_mcp/thoughts/plans/2026-08-03-agent-run-returns-only-run-id.md`).
+Every load-bearing claim below has been re-verified against primary sources in
+this repository, the published MCP specification, the reference Python SDK, and
+the shipped Claude Code binary. Where a claim could **not** be verified from
+here, it is marked as attributed rather than confirmed. Two claims from the
+intake report were found to be wrong or incomplete and are corrected in
+Findings F6 and F7.
+
+## Research Question
+
+`format_call_tool_result` promotes every unrecognised top-level key of a tool
+hook's return value into MCP `structuredContent`. A consumer outage was
+root-caused to that promotion. What exactly does the library do, what do the
+specification and the reference implementations do, what is the measured client
+behaviour, and what are the options for changing it — including what each option
+breaks?
+
+## Summary
+
+The library's behaviour is confirmed exactly as described: when the negotiated
+protocol version is `2025-06-18` or newer and a tool hook returns a dict
+containing `content`, any top-level key other than `content`, `isError`,
+`_meta` and `structuredContent` is swept into `structuredContent`
+(`actingweb/handlers/mcp.py:162-171`). This is the only place in the library
+that emits `structuredContent`, and both the Flask and FastAPI transports share
+it.
+
+The specification permits `structuredContent` without a declared `outputSchema`,
+so the promotion is **not** a protocol violation — but it does break an
+invariant that both the spec's guidance and the reference server maintain. The
+spec says (verbatim, identical in `2025-06-18` and `2025-11-25`): *"For
+backwards compatibility, a tool that returns structured content SHOULD also
+return the serialized JSON in a TextContent block."* The reference Python server
+honours this literally — when a tool returns a dict, it sets
+`structuredContent` to that dict **and** sets `content` to
+`json.dumps(results)` of the same dict
+(`mcp/server/lowlevel/server.py:554-557`). It never produces a result where the
+text and the structured payload say different things. ActingWeb's promotion
+produces exactly that: prose in `content`, unrelated metadata in
+`structuredContent`. A client that assumes the spec's invariant — that the text
+is a serialization of the structure — will treat the text as redundant. Claude
+Code 2.1.220 does precisely that: its MCP result normaliser, read directly from
+the shipped binary, discards **every** `type: "text"` content block when
+`structuredContent` is present, and passes only the serialized JSON to the
+model. The library cannot observe this; the response is well-formed and nothing
+in the protocol reports the discard back.
+
+Three facts materially change the shape of the decision relative to the intake
+report. First, the affected code shipped in **stable** releases `v3.11.0` and
+`v3.12.0`, not only in the current `3.13.0` pre-release train, so this is a
+change to behaviour that has been generally available since 2026-05-27
+(F6). Second, gating on the declared `output_schema` — the spec-aligned
+alternative — is *less* blocked than the intake report claims: the blocking
+`isError` gap is real library behaviour but is presently **latent**, because no
+tool in the one known consumer declares an `output_schema` at all (F7). Third,
+the promotion is gated per request on the `MCP-Protocol-Version` header, and a
+request without that header negotiates `2025-03-26`, where no
+`structuredContent` is emitted at all — so the behaviour is header-conditional,
+not merely deploy-conditional (F2).
+
+## Detailed Findings
+
+### F1 — What the library does today (verified)
+
+`actingweb/handlers/mcp.py:133-177`, quoted in full from source:
+
+```python
+_CALL_TOOL_RESERVED_KEYS = frozenset(
+    {"content", "isError", "_meta", "structuredContent"}
+)                                                                    # :133-135
+
+def format_call_tool_result(result: Any, negotiated_version: str) -> dict[str, Any]:
+    if isinstance(result, dict) and "content" in result:             # :153
+        out: dict[str, Any] = {
+            "content": result["content"],
+            "isError": bool(result.get("isError", False)),           # :156
+        }
+        meta = result.get("_meta")
+        if isinstance(meta, dict):                                   # :159
+            out["_meta"] = meta
+
+        if supports_structured_content(negotiated_version):          # :162
+            explicit_struct = result.get("structuredContent")
+            if isinstance(explicit_struct, dict):                    # :164
+                out["structuredContent"] = explicit_struct
+            else:
+                extras = {
+                    k: v for k, v in result.items()
+                    if k not in _CALL_TOOL_RESERVED_KEYS
+                }                                                    # :167-169
+                if extras:
+                    out["structuredContent"] = extras                # :171
+        return out
+
+    if not isinstance(result, dict):                                 # :175
+        result = {"result": result}
+    return {"content": [{"type": "text", "text": str(result)}]}      # :177
+```
+
+Behaviours that follow directly from this code:
+
+- The explicit-`structuredContent` passthrough at `:164-165` already exists and
+  already suppresses the sweep. A hook that sets `structuredContent` explicitly
+  gets exactly that dict and nothing else — `tests/test_mcp_tool_result_format.py:56-64`
+  pins this, including that an extra sibling key is *not* merged in.
+- On the `content` branch, `isError` is always present, explicitly `false` when
+  the hook omits it (`:156`).
+- A **non-dict** `structuredContent` supplied by a hook fails the `isinstance`
+  check at `:164`, falls into the `else`, and is then excluded from `extras` by
+  the reserved-key set — so it is silently dropped, and any *other* extra keys
+  are emitted as `structuredContent` in its place. This is an undocumented
+  edge case, not covered by any test.
+- The legacy branch (`:174-177`) emits `content` only. It never emits
+  `isError` and never emits `structuredContent`.
+
+This is the **only** code in the library that writes `structuredContent`. A grep
+over `actingweb/` finds `structuredContent` in just two modules:
+`handlers/mcp.py` (the writer) and `mcp/protocol.py` (comments plus the version
+constant). Resources and prompts do not emit it.
+
+Both transports share the function: `actingweb/handlers/mcp.py:997-999` (sync,
+Flask) and `actingweb/handlers/async_mcp.py:194-196` (async, FastAPI). The two
+dispatch loops are otherwise identical apart from `await` handling
+(`async_mcp.py:186-189`). A single change covers both.
+
+### F2 — When the promotion gate is open (per-request, header-driven)
+
+A new handler instance is constructed for every HTTP request
+(`actingweb/interface/integrations/flask_integration.py:1404`,
+`fastapi_integration.py:2347`), so the version recorded during `initialize`
+does not survive to later requests. Every post-`initialize` request re-derives
+the version from the `MCP-Protocol-Version` header
+(`actingweb/handlers/mcp.py:1294-1330`):
+
+- Header absent → `DEFAULT_NEGOTIATED_VERSION = "2025-03-26"`
+  (`actingweb/mcp/protocol.py:36-39`), which is `< "2025-06-18"`, so
+  `supports_structured_content` returns `False` and **no `structuredContent` is
+  emitted at all** — not even an explicit one.
+- Header present but unsupported → HTTP 400 with JSON-RPC `-32600`
+  (`mcp.py:1321-1327`).
+- Header present and supported → that version is used (`mcp.py:1329`).
+
+Claude Code sends the header. Read from the shipped bundle
+(`~/.local/share/claude/versions/2.1.220`):
+
+```js
+if(this._protocolVersion) e["mcp-protocol-version"] = this._protocolVersion;
+```
+
+and its latest supported revision is `"2025-11-25"`, which ActingWeb also
+supports (`actingweb/mcp/protocol.py:28-33`), so negotiation settles on
+`2025-11-25` and the gate is open by default for this client.
+
+Practical consequence: the promotion is invisible to any test or client that
+omits the header, and invisible on `2024-11-05`/`2025-03-26` clients. It becomes
+active only against a client that negotiates `2025-06-18`+ — which is what makes
+it appear to work in some environments and not others.
+
+### F3 — What the specification says (primary source, verbatim)
+
+Fetched from <https://modelcontextprotocol.io/specification/2025-06-18/server/tools>
+and <https://modelcontextprotocol.io/specification/2025-11-25/server/tools>. The
+two revisions are **identical** on these points.
+
+Structured Content section:
+
+> **Structured** content is returned as a JSON object in the `structuredContent`
+> field of a result.
+>
+> For backwards compatibility, a tool that returns structured content SHOULD
+> also return the serialized JSON in a TextContent block.
+
+Output Schema section:
+
+> Tools may also provide an output schema for validation of structured results.
+> If an output schema is provided:
+>
+> * Servers **MUST** provide structured results that conform to this schema.
+> * Clients **SHOULD** validate structured results against this schema.
+
+What the spec does **not** say, checked explicitly:
+
+- It does not forbid `structuredContent` on a tool with no declared
+  `outputSchema`. The `outputSchema` rules are conditional ("If an output schema
+  is provided"). So today's promotion is **legal**, not a violation. The next
+  revision, `2026-07-28`, makes the permission explicit rather than merely
+  implicit: *"This can be any JSON value … that conforms to the tool's
+  `outputSchema` **if one is defined**."* (That revision also relaxes
+  `structuredContent` from object-only to any JSON value; ActingWeb's supported
+  set currently tops out at `2025-11-25`,
+  `actingweb/mcp/protocol.py:28-33`.)
+- It does not sanction, describe, or forbid a client discarding `content` when
+  `structuredContent` is present. The client behaviour in F5 is an
+  interpretation, not a mandated one.
+- It does not require `structuredContent` to be a superset, subset, or
+  derivative of the text — but the backwards-compatibility SHOULD assumes the
+  text *is* the serialized structure. (Formatting note: that `SHOULD` is
+  unbolded in the source `.mdx`, unlike the `MUST`/`SHOULD`/`MAY` around it.)
+
+The example result in both revisions shows exactly that relationship: `content`
+is `"{\"temperature\": 22.5, \"conditions\": \"Partly cloudy\", \"humidity\": 65}"`
+and `structuredContent` is the same object.
+
+**Client handling of the two fields is an acknowledged, unresolved gap in the
+spec.** `modelcontextprotocol/modelcontextprotocol#1411`, "Clarify client
+handling of structuredContent vs content fields" (filed 2025-09-01, assigned,
+still open with no PR), states that the spec fails to define how clients must
+handle `structuredContent` when present, whether `content` should always be a
+stringified variant, and whether structured-capable clients should prioritise
+it. `modelcontextprotocol/typescript-sdk#911` is the SDK-side tracker, blocked
+on it, and lists "establish a proper fallback to `content`" as pending work.
+
+Notably, the complaint driving #1411 is the **opposite** failure mode: clients
+(it names Claude and Windsurf) *ignoring* `structuredContent` entirely, with
+only Cursor supporting it. No spec-level issue was found asserting that clients
+drop text blocks when `structuredContent` is present. That is a meaningful
+negative result for this decision: relying on any particular client treatment of
+a `content`/`structuredContent` divergence is unspecified territory in **both**
+directions.
+
+### F4 — What the reference implementations do
+
+**Reference Python server** (`mcp` SDK, read from
+`../actingweb_mcp/.venv/lib/python3.14/site-packages/mcp/server/lowlevel/server.py:540-583`).
+Its normalisation has exactly three shapes:
+
+```python
+elif isinstance(results, tuple) and len(results) == 2:
+    # tool returned both structured and unstructured content
+    unstructured_content, maybe_structured_content = cast(CombinationContent, results)
+elif isinstance(results, dict):
+    # tool returned structured content only
+    maybe_structured_content = cast(StructuredContent, results)
+    unstructured_content = [types.TextContent(type="text", text=json.dumps(results, indent=2))]
+elif hasattr(results, "__iter__"):
+    # tool returned unstructured content only
+    unstructured_content = cast(UnstructuredContent, results)
+    maybe_structured_content = None
+```
+
+The reference server therefore **never** emits `structuredContent` alongside
+text that is not its serialization, except when the tool author explicitly
+returns a `(content, structured)` tuple. There is no auto-promotion of
+individual keys anywhere in it. It also validates server-side when a schema is
+declared (`:565-575`), returning an error result if `structuredContent` is
+missing or non-conforming.
+
+Two points follow that bear directly on D1. First, the reference server *does*
+emit `structuredContent` for a schema-less tool (the `isinstance(results, dict)`
+branch is unconditional; the schema check is a separate later block) —
+confirming F3's reading that schema-less structured output is legitimate.
+Second, the tuple form is precisely the shape ActingWeb's promotion produces —
+prose in `content`, unrelated data in `structuredContent` — but there it is an
+**explicit act by the tool author**, never inferred. The reference server's
+tuple is the structural analogue of ActingWeb's explicit `structuredContent`
+key; it has no analogue of the sweep.
+
+**FastMCP** (the high-level server in the same SDK) is stricter still —
+`mcp/server/fastmcp/utilities/func_metadata.py`, `convert_result`:
+
+```python
+    if self.output_schema is None:
+        return unstructured_content
+    else:
+        ...
+        validated = self.output_model.model_validate(result)
+        structured_content = validated.model_dump(mode="json", by_alias=True)
+        return (unstructured_content, structured_content)
+```
+
+No `structuredContent` at all unless a return-type-derived schema exists, and
+what is emitted is the serialization of the declared return model — never keys
+scraped from elsewhere.
+
+**Reference Python client**
+(`.../mcp/client/session.py:411-441`, read from source):
+
+```python
+if not result.isError:
+    await self._validate_tool_result(name, result)
+...
+if output_schema is not None:
+    if result.structuredContent is None:
+        raise RuntimeError(
+            f"Tool {name} has an output schema but did not return structured content"
+        )
+    validate(result.structuredContent, output_schema)
+```
+
+Note the guard: validation happens **only** when the tool declares an output
+schema. `structuredContent` present with no declared schema raises nothing —
+`_tool_output_schemas` stores `None` for schema-less tools and every validation
+path is gated behind `if output_schema is not None`. (This validation was added
+in SDK v1.10.0; v1.9.4 had none.)
+
+**The bundled TypeScript MCP client** in Claude Code behaves the same way (read
+from the 2.1.220 binary; the error string is byte-identical to the Python
+SDK's):
+
+```js
+let o = this.getToolOutputValidator(e.name);
+if (o) {
+  if (!n.structuredContent && !n.isError)
+    throw new _s(Rs.InvalidRequest, `Tool ${e.name} has an output schema but did not return structured content`);
+  ...
+}
+```
+
+So across both reference clients: declaring an `outputSchema` creates a hard
+obligation to return `structuredContent` on every non-error result; not
+declaring one imposes no obligation in either direction.
+
+Equally important for F5: **neither SDK client touches `content`.** The upstream
+TypeScript SDK's `callTool` (checked at tag `1.17.0`) returns the result
+unmodified — it never reads, filters, or mutates `content`. Whatever discards
+text blocks therefore lives in the *host application* layered on top of the SDK,
+not in the protocol library.
+
+### F5 — The observed client behaviour that makes promotion destructive
+
+This is **host-application** behaviour, not MCP SDK behaviour (F4: the SDK
+client passes `content` through untouched), and it is sanctioned by no spec
+revision (F3). Verified independently for this document by reading the MCP
+result normaliser out of the shipped Claude Code 2.1.220 binary
+(`~/.local/share/claude/versions/2.1.220`), reformatted from the minified
+source:
+
+```js
+if ("toolResult" in e) return { content: String(e.toolResult), type: "toolResult" };
+if ("structuredContent" in e && e.structuredContent !== undefined) {
+  let i = Ie(e.structuredContent);                       // JSON serialization
+  let s = pcr(e.structuredContent);
+  if ("content" in e && Array.isArray(e.content)) {
+    let a = e.content.filter((l) => l && typeof l === "object"
+                                  && ("type" in l) && l.type !== "text");
+    if (a.length > 0) {
+      let l = (await Promise.all(a.map((c) => Vbo(c, r, n, !0)))).flat();
+      if (l.length > 0) {
+        let c = [...l, { type: "text", text: i }];
+        return { content: c, type: "contentArray", schema: pcr(LFe(c)) };
+      }
+    }
+  }
+  return { content: i, type: "structuredContent", schema: s };
+}
+if ("content" in e && Array.isArray(e.content)) { /* normal path */ }
+```
+
+When `structuredContent` is present and defined, every `type: "text"` block is
+filtered out. Non-text blocks (images, audio) survive, with the serialized JSON
+appended as a single text block. If the result contains only text blocks — the
+common case — the model receives nothing but the serialized JSON.
+
+Also verified from the same binary, and relevant to any workaround that routes
+data through `_meta`:
+
+```js
+return {
+  data: Ae.content,
+  ...(Ae._meta || Ae.structuredContent) && {
+    mcpMeta: { ...Ae._meta && { _meta: Ae._meta },
+               ...Ae.structuredContent && { structuredContent: Ae.structuredContent } }
+  }
+}
+```
+
+`_meta` is routed to a side channel (`mcpMeta`) separate from the model-facing
+`data`. The intake material listed "move the extra key to `_meta`" as an
+unverified workaround; it is now verified that `_meta` does not reach the model
+as content in this client, so that route hides the value rather than delivering
+it.
+
+The library has no way to detect any of this. The response is well-formed, there
+is no `isError`, and nothing in the protocol reports the discard back to the
+server.
+
+### F6 — Affected releases (corrects the intake report)
+
+The intake report frames the fix as cheap because "3.13.0 is still in
+pre-release". That framing is incomplete.
+
+`git log -S'_CALL_TOOL_RESERVED_KEYS'` and `-S'def format_call_tool_result'`
+each return exactly one commit:
+
+- **`c61e059`**, 2026-05-27, *"Pre-release v3.10.2b5: MCP version negotiation,
+  structuredContent, drop mcp SDK dependency (#100)"*. The code has not been
+  touched since.
+
+`git tag --contains c61e059` returns 17 tags. Of those, the **stable** releases
+are:
+
+- **`v3.11.0`** (July 4, 2026)
+- **`v3.12.0`**
+
+plus the pre-release lines `v3.10.2b5`–`b9`, `v3.11.0b1`–`b7`, and
+`v3.13.0rc1`–`rc3`.
+
+Checked against production PyPI (`https://pypi.org/pypi/actingweb/json`):
+`3.11.0` and `3.12.0` are both published there, and `3.12.0` is the current
+`latest`. `3.10.2b5` and `3.13.0rc3` are absent, consistent with `CLAUDE.md`'s
+rule that pre-releases publish to TestPyPI. So the promotion is not merely
+tagged — it is generally available to anyone who has ever run
+`pip install actingweb`, and has been for roughly two months across two stable
+minor releases. It is documented as the contract in the `v3.11.0` changelog
+entry (`CHANGELOG.rst:742-748`):
+
+> A hook returning a dict with ``content`` plus extra top-level keys has those
+> extras promoted into ``structuredContent``; an explicit ``structuredContent``
+> from the hook is passed through, and a hook-supplied ``_meta`` is preserved.
+
+and in the user-facing guide (`docs/guides/mcp-applications.rst:356-363`), which
+additionally carries a worked example (`:365-382`) whose inline comment reads
+`# Promoted into structuredContent on >= 2025-06-18:` — and which, confusingly,
+also declares an `output_schema` on the same tool, implying a causal link that
+does not exist in the code.
+
+Any change is therefore a behaviour change to a documented, released contract,
+not to unreleased code. It can still ride the current train (`3.12.0` →
+`3.13.0` is a minor bump), but the decision should be made on that basis.
+
+### F7 — The `output_schema` gate: what actually blocks it (corrects the intake report)
+
+The intake report argues that gating promotion on a declared `output_schema` is
+blocked, because the library never sets `isError` on the legacy-wrap path, so
+any error result lacking a `content` key would reach the wire as
+`isError: false` and then fail client-side schema validation. Both halves were
+checked separately.
+
+**The library half is confirmed.** A grep for `isError` across the whole
+`actingweb/` package returns exactly three hits, all inside
+`format_call_tool_result`: the reserved-key set (`mcp.py:134`), the docstring
+(`:145`), and the single assignment (`:156`). The legacy branch
+(`mcp.py:174-177`) emits no `isError` key, so `CallToolResult.isError` defaults
+to `false` on the wire. Additionally, **every** library-internal failure on the
+`tools/call` route returns a JSON-RPC *error object* via `_create_jsonrpc_error`
+(`mcp.py:1284-1292`) rather than a `CallToolResult` — missing tool name
+(`-32602`), no hooks registry (`-32603`), no resolved trust (`-32003`),
+permission denied (`-32003`), hook raised (`-32603`), tool not found
+(`-32601`), and the async mirrors at `async_mcp.py:129-208`. So `isError: true`
+can *only* originate from a hook that returns `{"content": [...], "isError": True}`.
+
+**The consequence half is presently latent, not active.** The trap requires a
+tool that declares an `output_schema`. Checked in the one known consumer: a grep
+for `output_schema` across `actingweb_mcp` (excluding its venv) returns 9 hits,
+**all** of which belong to that app's own unrelated `describe_method` /
+peer-capability surface — none is an `@mcp_tool(output_schema=...)` declaration.
+Across 38 `@mcp_tool` decorations there, zero declare an MCP output schema.
+Inside this library, `output_schema` is accepted by the decorator
+(`actingweb/mcp/decorators.py:21,89`) and emitted in `tools/list`
+(`actingweb/handlers/mcp.py:719-721`), but **no call path ever reads it**.
+
+There is a second, independent consequence of that same gap that the intake
+report does not mention, and which exists **today**, regardless of any change:
+because the library never consults `output_schema` at call time, a tool that
+declares one and returns a plain `{"content": [...]}` with no extras produces a
+result with no `structuredContent`. Both reference clients raise on that
+(`Tool X has an output schema but did not return structured content`). So
+declaring `output_schema` on an ActingWeb tool is already a latent way to break
+that tool for spec-conforming clients. No test covers this
+(`tests/test_mcp_tool_schema_fields.py` covers only `tools/list` serialization),
+and no known consumer has hit it because none declares a schema.
+
+The two halves of the MCP `outputSchema` ↔ `structuredContent` contract were
+implemented a day apart (`c61e059` for `structuredContent`, `506eb6d` for the
+`tools/list` `outputSchema` emission) and were never wired together.
+
+### F8 — Why the promotion exists (recorded design intent)
+
+`thoughts/plans/2026-05-26-mcp-version-negotiation-structuredcontent.md:81-91`,
+"Decisions taken (2026-05-26)":
+
+> **structuredContent extras strategy:** **MVP = promote all extras** … build
+> `{content, isError}`, pass through an explicit `structuredContent` if the hook
+> set one, else sweep all non-reserved top-level keys into `structuredContent`.
+> Backward-compatible with existing `content`+extras hooks (the "emm" Personal
+> AI Memory app) without requiring `output_schema` declarations.
+> `output_schema`-gated validation is an optional later refinement, not MVP.
+
+The schema-gated alternative was explicitly deferred, recorded as open question
+O3 (`:348-349`) and Phase 3 roadmap item 3 (`:317-319`). The companion research
+`thoughts/research/2026-05-26-mcp-tool-result-structuredcontent.md:179-197` had
+already listed the same three options and concluded *"Evidence is split… This is
+a genuine product decision, not a clear win."*
+
+Worth recording: the compatibility target that motivated promote-all-extras was
+the *same consumer* that the promotion later broke. The measured harm is a
+direct consequence of the compatibility choice made on its behalf.
+
+### F9 — Reported consumer impact (attributed; mechanism verified, measurements not reproducible here)
+
+From `../actingweb_mcp/thoughts/research/2026-08-03-agent-run-returns-only-run-id.md`.
+These are consumer-side measurements against production data and **cannot be
+reproduced from this repository**; they are recorded as attributed evidence. The
+*mechanism* they describe is independently verified in F1 and F5.
+
+- Server-side replay: the `agent_run` handler returned
+  `keys: ['content', 'isError', 'run_id']` with **135,151 characters** of text,
+  all sections present.
+- Client-side, same call through Claude Code: the model received
+  `{"run_id": null}`.
+- Trigger: `agent_run` began returning a top-level `run_id` in the consumer's
+  `v2026.08.02` deploy; the next scheduled hourly cycle degraded.
+- The report lists the affected tool family as also including
+  `agent_run_complete`, the `instruction_*` tools and the `output_*` tools, and
+  states the failure went unnoticed on those because their extras *duplicate*
+  the text payload, so the JSON still carried what the model needed. **This is
+  the consumer's own classification of its own tools, not a measurement** — do
+  not treat it as a verified scope list.
+- Likewise the consumer's report that two tools were carrying a full document
+  body in **both** `content` and the promoted extras (up to ~42 KB doubled per
+  call) is its own estimate, unverified from here.
+
+The asymmetry is the notable part and it follows from F5 without needing the
+measurements: tools whose extras duplicate their prose keep working; tools whose
+prose is the unique payload lose everything. The failure mode selects for the
+cases where the loss matters most.
+
+### F10 — What in this repository depends on the current behaviour
+
+**Tests — six assertions across six tests fail if the sweep at
+`mcp.py:166-171` is deleted:**
+
+| File:line | Assertion |
+| --- | --- |
+| `tests/test_mcp_tool_result_format.py:38` | `assert out["structuredContent"] == {"success": True, "memory_type": "note"}` |
+| `tests/test_mcp_tool_result_format.py:43` | `assert out["structuredContent"] == {"count": 3}` (the test's only assertion) |
+| `tests/test_mcp_tool_result_format.py:75` | `assert out["structuredContent"] == {"extra": 1}` (in `test_meta_is_preserved_not_swept` — uses the promoted payload as the witness that `_meta` was not swept) |
+| `tests/test_mcp_tool_result_format.py:166-169` | `assert sync_result["result"]["structuredContent"] == {...}` (the only test reaching the formatter through a real `tools/call` on both handlers) |
+| `tests/integration/test_mcp_tools.py:517-520` | `assert out["structuredContent"] == {"success": True, "memory_type": "memory_test"}` |
+| `tests/integration/test_mcp_tools.py:539-542` | `assert out["structuredContent"] == {"success": False, "error": "Validation failed"}` |
+
+Everything else in the suite is unaffected. Specifically these keep passing
+unchanged: `test_old_version_omits_structured_content:45` (already gated off by
+version), `test_explicit_structured_content_passthrough:56` (the only existing
+test of the explicit-only contract — it already asserts extras are *not* merged
+in), `test_isError_true_preserved:77`, `test_content_only_no_structured_content:83`,
+both legacy-wrap tests at `:91`/`:97`, `test_tool_response_without_is_error_field`
+(`tests/integration/test_mcp_tools.py:544-556`), and the sync/async equality
+assertion at `test_mcp_tool_result_format.py:165` (parity holds whatever the
+formatter does).
+
+Note the three "integration" tests in
+`tests/integration/test_mcp_tools.py:487-556` call the formatter directly — no
+HTTP, no fixtures — so they are unit tests by placement only. There is **no**
+end-to-end test that asserts the wire shape of a `tools/call` response for a
+hook returning extras; the sole in-dispatch coverage is
+`test_mcp_tool_result_format.py:106-169`.
+
+Only one test fixture returns `content` plus extras and can reach the sweep:
+`store_hook` at `tests/test_mcp_tool_result_format.py:114-122`. Other fixture
+hooks (`tests/test_async_mcp_handler.py:109,160,257,265,419`,
+`tests/test_mcp_permissions.py:14,18`) return dicts with no `content` key and go
+down the legacy wrap.
+
+**Documentation and changelog:**
+
+- `docs/guides/mcp-applications.rst:348-385` — the "Structured Tool Output"
+  section documents promotion as the contract, with a worked example that relies
+  on it (`:365-382`).
+- `CHANGELOG.rst:742-748` — the `v3.11.0` `ADDED` entry documenting promotion.
+- `CHANGELOG.rst:5-6` — an empty "Unreleased" section is present and ready.
+- `docs/migration/v3.11.rst:164-166` mentions `structuredContent` only in
+  passing, with no detail on promotion.
+- `docs/_build/` contains generated copies; not source.
+
+## Decisions Needed
+
+### D1 — What replaces the current promotion behaviour?
+
+**Option A — keep it as is.** No work, no migration. Cost: the measured client
+harm in F5/F9 persists, and the trap keeps firing on addition of any top-level
+key. Nothing in this research supports A except inertia; it is listed for
+completeness.
+
+**Option B — promote only an explicit `structuredContent` key.** Delete the
+`else:` branch at `mcp.py:166-171`; keep the explicit passthrough at `:164-165`,
+the `_meta` handling at `:158-160`, and the legacy wrap at `:174-177`.
+
+- Aligns the library with the reference server's invariant (F4): implicit
+  `structuredContent` disappears, and any `structuredContent` on the wire is a
+  deliberate act by the hook author, who is then also responsible for the
+  spec's backwards-compatibility SHOULD.
+- **No-op for correctly-written hooks.** `mcp.py:164-165` already passes an
+  explicit key through unchanged, so a downstream can migrate to explicit
+  `structuredContent` *first*, verify byte-identical output against
+  `3.13.0rc3`, and upgrade afterwards — no coordinated deploy window.
+- Cost: any downstream relying on promotion silently loses its structured
+  payload on upgrade (F6: shipped in two stable releases). Extras that are not
+  explicitly promoted are simply not serialized anywhere.
+- Test cost: six assertions (F10). Docs cost: `mcp-applications.rst:348-385`
+  including its example.
+- Migration-note considerations, two of them, both facts the migration guidance
+  has to carry because the library cannot enforce either:
+  1. Per spec issue #1411 (F3), several major clients **ignore**
+     `structuredContent` entirely. A hook author moving extras under an explicit
+     key should also honour the spec's backwards-compatibility SHOULD — keep the
+     same data serialized in a text block — or those clients see nothing.
+  2. Per F2, a request with no `MCP-Protocol-Version` header negotiates
+     `2025-03-26`, where the version gate at `mcp.py:162` suppresses
+     `structuredContent` **including an explicit one**. Under Option B the
+     explicit key becomes the only path, so a migrated hook still emits no
+     structured payload to such a client. The text block is the only thing that
+     always arrives.
+
+**Option C — gate promotion on a declared `output_schema`.** Pass the tool's
+`metadata` (already in local scope at both call sites —
+`mcp.py:983` and `async_mcp.py:180`, both 14 lines before the formatter call)
+and promote only when `metadata.get("output_schema")` is set.
+
+- Closest to the spec's model, and it *would* fix the reported incident, since
+  the affected tool declares no schema.
+- But: promoting arbitrary extras under a declared schema does not make them
+  *conform* to it, and the spec is a **MUST** there (F3). Option C without
+  validation trades a silent text loss for a silent conformance violation that
+  both reference clients will surface as a hard error.
+- And it inherits the `isError` gap (F7): a hook whose error path returns a dict
+  with no `content` key reaches the wire as `isError: false` with no
+  `structuredContent`, and a schema-declaring tool then fails client validation.
+  This is **latent today** (no known tool declares a schema) but becomes active
+  the moment anyone adopts C's incentive to declare one.
+- C is not exclusive with B. B can ship now; C is a later, larger piece of work
+  that also needs the `isError` gap closed and server-side validation added.
+
+**Option D — opt-in promotion flag on the decorator**, e.g.
+`@mcp_tool(promote_extras=True)`. Preserves the capability without the silent
+default. Cost: a new public API surface for a behaviour that Option B already
+provides via an explicit `structuredContent` key, with no additional
+expressiveness — the correct payload can differ per response within one tool,
+which a per-tool flag cannot express.
+
+**Recommendation:** Option B. It is the only option that removes the measured
+harm (F5) while matching what both reference server implementations do (F4), and
+it is a no-op for hooks that already set `structuredContent` explicitly (F1), so
+downstreams can migrate before upgrading. B and C are not mutually exclusive —
+whether C is additionally in scope, now or later, is a separate call and is left
+open here.
+
+### D2 — How is this released, and is it breaking?
+
+The promotion is documented behaviour shipped in stable `v3.11.0` and `v3.12.0`
+(F6), so removing it is a breaking change to a released contract, whatever the
+current pre-release state of `3.13.0`.
+
+**Options:**
+
+1. **Ride the current train** — ship as `3.13.0rc4`, TestPyPI, with the
+   behaviour change called out prominently in `CHANGELOG.rst` and a migration
+   note. `3.12.0` → `3.13.0` is already a minor bump, so the version number
+   carries the change legitimately. The one known consumer is coordinating in
+   the same train.
+2. **Hold for a dedicated minor** after `3.13.0` goes stable, keeping the
+   `3.13.0` release scoped to what it already contains.
+
+Either way, `CLAUDE.md`'s release process applies: the version bump and the
+"Unreleased" → `vX.Y.ZrcN` rename ride in the release PR, master is protected,
+and the tag is pushed to the merge commit afterwards. `CHANGELOG.rst:5-6`
+already has an empty "Unreleased" section.
+
+Secondary question: does this warrant an entry in `docs/migration/` (a
+`v3.13.rst` already exists and is referenced from the `v3.13.0rc3` changelog
+note), or is a changelog entry plus the guide rewrite sufficient?
+
+### D3 — Should there be an escape hatch that restores promotion?
+
+**Options:**
+
+1. **No flag.** The migration is one line per response (nest the extras under
+   `structuredContent`), and a flag preserves a footgun that fails silently.
+2. **App-level config flag** (e.g. on `with_mcp(...)`) for deployments that
+   cannot migrate hooks in step with the upgrade.
+3. **Per-tool decorator flag** (Option D above).
+
+Evidence bearing on this: the correct answer differs *per response* within a
+single tool (F9 — the same consumer wants `structuredContent` on its data-shaped
+tools and none on its prose tools), which neither an app-level nor a per-tool
+flag can express, while an explicit `structuredContent` key can.
+
+### D4 — Should the library say anything when it drops extras it would previously have promoted?
+
+Silent behaviour change vs. migration aid.
+
+**Options:**
+
+1. **Silent.** The upgrade is opt-in via the version pin and the changelog
+   carries the migration.
+2. **`logger.debug`** naming the tool and the dropped keys.
+3. **`logger.warning`**, once per tool per process. Loudest migration aid;
+   noisiest for hooks that return incidental keys deliberately and never wanted
+   them serialized.
+
+Note that under Option B the "dropped" keys were never *reaching the model as
+content* anyway on affected clients — they were replacing it. Under
+`2025-03-26` and older they are already dropped today with no log (F2), so
+option 1 is at least self-consistent with existing behaviour.
+
+### D5 — Are the two adjacent defects in scope for the same change?
+
+Both are real, independent of D1, and were found while verifying F7.
+
+1. **Legacy-wrap emits no `isError`** (`mcp.py:174-177`). Every error result
+   from a hook that returns a dict without a `content` key reaches the wire
+   claiming success. Not a prerequisite for Option B; a hard prerequisite for
+   Option C.
+2. **`output_schema` is advertised but never enforced.** A tool declaring
+   `output_schema` today and returning content-only produces no
+   `structuredContent`, which both reference clients reject with
+   `Tool X has an output schema but did not return structured content` (F4, F7).
+   This is broken *now*, for anyone who declares a schema.
+
+**Options:** fix both in the same release (widens the blast radius of a release
+whose point is to make one behaviour predictable); fix neither and file them as
+`thoughts/todo/` items; or fix (1) only, since it is a two-line change and is
+the gate on ever adopting Option C.
+
+A third, smaller item for the same call: the non-dict-`structuredContent`
+edge case in F1, where a hook supplying a non-dict `structuredContent` has it
+silently dropped *and* gets other extras promoted in its place. Under Option B
+the second half disappears; the silent drop remains.
+
+### D6 — What test coverage should the change carry?
+
+Not a decision so much as a scope question for the plan, but the intake material
+under-specifies it. Beyond inverting the six assertions in F10:
+
+- Extras present **and** an explicit `structuredContent` present → only the
+  explicit one is emitted (guards the deleted branch from returning).
+- Extras present, no explicit key → `structuredContent` absent **and** the text
+  content survives byte-for-byte.
+- `test_meta_is_preserved_not_swept` rebuilt on an explicit `structuredContent`
+  rather than on promotion, so it still proves `_meta` is not swept.
+- The sync/async parity fixture (`store_hook`,
+  `tests/test_mcp_tool_result_format.py:114-122`) needs its assertion re-based;
+  the parity assertion at `:165` itself is unaffected.
+- Open: should a genuine end-to-end wire-shape test be added? Today no test
+  asserts the JSON that leaves the handler for a hook returning extras; the
+  closest is `test_mcp_tool_result_format.py:106-169`, and the integration
+  "regression" class calls the formatter directly.
+
+## Code References
+
+- `actingweb/handlers/mcp.py:133-135` — `_CALL_TOOL_RESERVED_KEYS`
+- `actingweb/handlers/mcp.py:138-177` — `format_call_tool_result`; docstring at
+  `:138-152` documents promotion as the contract
+- `actingweb/handlers/mcp.py:153` — the `"content" in result` gate that splits
+  MCP-shaped from legacy results
+- `actingweb/handlers/mcp.py:156` — the only `isError` assignment in the library
+- `actingweb/handlers/mcp.py:162-171` — version gate, explicit passthrough
+  (`:164-165`), extras sweep (`:166-171`)
+- `actingweb/handlers/mcp.py:174-177` — legacy wrap; no `isError`, no
+  `structuredContent`
+- `actingweb/handlers/mcp.py:983`, `:997-999` — sync dispatch: `metadata` bound
+  14 lines before the formatter call
+- `actingweb/handlers/async_mcp.py:180`, `:194-196` — async dispatch, same shape
+- `actingweb/handlers/mcp.py:1284-1292` — `_create_jsonrpc_error`; every
+  library-internal `tools/call` failure goes here, not through the formatter
+- `actingweb/handlers/mcp.py:1294-1330` — per-request protocol version
+  resolution from the `MCP-Protocol-Version` header
+- `actingweb/handlers/mcp.py:719-721` — `outputSchema` emitted in `tools/list`
+  (never read at call time)
+- `actingweb/mcp/decorators.py:21,89` — `output_schema` accepted and stored
+- `actingweb/mcp/protocol.py:28-45` — supported versions,
+  `DEFAULT_NEGOTIATED_VERSION = "2025-03-26"`,
+  `STRUCTURED_CONTENT_MIN_VERSION = "2025-06-18"`
+- `actingweb/mcp/protocol.py:65-69` — `supports_structured_content`
+- `actingweb/interface/integrations/flask_integration.py:1404`,
+  `fastapi_integration.py:2347` — a new handler instance per request
+- `tests/test_mcp_tool_result_format.py:28-100` — pure-formatter tests
+- `tests/test_mcp_tool_result_format.py:106-169` — the only in-dispatch
+  sync/async parity test
+- `tests/integration/test_mcp_tools.py:487-556` — response-format regression
+  class (calls the formatter directly)
+- `tests/test_mcp_version_negotiation.py:50-57` — the version gate in isolation
+- `tests/test_mcp_tool_schema_fields.py:64-131` — `tools/list` `outputSchema`
+  serialization only
+- `docs/guides/mcp-applications.rst:348-385` — user-facing documentation of
+  promotion, including the worked example at `:365-382`
+- `CHANGELOG.rst:742-748` — the `v3.11.0` entry documenting promotion
+- `thoughts/plans/2026-05-26-mcp-version-negotiation-structuredcontent.md:81-91,317-319,348-349`
+  — the recorded MVP decision and its deferred alternative
+- `thoughts/research/2026-05-26-mcp-tool-result-structuredcontent.md:179-197` —
+  the original three-way option analysis
+
+## External References
+
+**Verified directly from primary sources on 2026-08-03:**
+
+- <https://modelcontextprotocol.io/specification/2025-06-18/server/tools> and
+  <https://modelcontextprotocol.io/specification/2025-11-25/server/tools> —
+  "Structured Content" and "Output Schema" sections, quoted verbatim in F3.
+  Identical text in both revisions. `structuredContent` without a declared
+  `outputSchema` is permitted; the backwards-compatibility SHOULD expects the
+  text block to carry the serialized JSON; nothing addresses clients discarding
+  `content`.
+- <https://modelcontextprotocol.io/specification/2026-07-28/server/tools> —
+  the next revision, which makes schema-less `structuredContent` explicit
+  ("*if one is defined*") and relaxes it to any JSON value. Not yet in
+  ActingWeb's supported set.
+- <https://github.com/modelcontextprotocol/modelcontextprotocol/issues/1411> —
+  "Clarify client handling of structuredContent vs content fields", open, no PR.
+  The spec-level acknowledgement that client handling of the two fields is
+  undefined. Its reported failure mode is clients *ignoring*
+  `structuredContent`, not clients dropping `content`.
+- <https://github.com/modelcontextprotocol/typescript-sdk/issues/911> — the
+  SDK-side tracker for #1411; pending work includes "establish a proper fallback
+  to `content`".
+- <https://github.com/modelcontextprotocol/typescript-sdk/issues/654> (closed by
+  PR #655) — why both SDKs now guard schema validation behind `isError`: a tool
+  with an `outputSchema` previously could not return a plain-text error.
+  Directly relevant to D5's `isError` gap.
+- <https://github.com/anthropics/claude-code/issues/14465> — a live instance of
+  the F7 trap in the wild: a server advertising `outputSchema` while returning
+  `structuredContent: null` made every `call_tool` raise
+  `Tool Bash has an output schema but did not return structured content`.
+- Reference Python server, `mcp/server/lowlevel/server.py:540-583` (read from
+  `../actingweb_mcp/.venv/lib/python3.14/site-packages/`, cross-checked against
+  the published v1.18.0 source) — three-shape normalisation, `json.dumps` of the
+  structured dict into `content`, server-side schema validation. No key
+  promotion anywhere.
+- Reference Python client, `mcp/client/session.py:411-441` (same install) —
+  `if not result.isError: await self._validate_tool_result(...)`, and validation
+  only when `output_schema is not None`. Added in SDK v1.10.0; absent in v1.9.4;
+  error string unchanged through current `main`.
+- FastMCP, `mcp/server/fastmcp/utilities/func_metadata.py` `convert_result` —
+  no `structuredContent` unless a return-type-derived schema exists.
+- Upstream TypeScript SDK `callTool` at tag `1.17.0`
+  (`src/client/index.ts`) — validates `structuredContent` only when a validator
+  exists, and returns `content` untouched. (Current `main` has been restructured
+  into a monorepo with a pluggable validator; `callTool` there was not read.)
+- Claude Code 2.1.220 (`~/.local/share/claude/versions/2.1.220`), bundled
+  TypeScript MCP client — the result normaliser quoted in F5 (text blocks
+  discarded when `structuredContent` is present), the `mcpMeta` side channel for
+  `_meta`, the `mcp-protocol-version` request header, and the output-schema
+  validator quoted in F4. Its latest supported revision is `2025-11-25`.
+- This repository, at commit `11563a3` — everything in F1, F2, F6, F7, F10.
+
+**Attributed, not reproducible from this repository:**
+
+- `../actingweb_mcp/thoughts/research/2026-08-03-agent-run-returns-only-run-id.md`
+  — the production measurements in F9 (135,151 characters server-side vs.
+  `{"run_id": null}` client-side; the affected tool family; the ~42 KB doubled
+  bodies). The mechanism they describe is independently verified in F1 and F5;
+  the numbers are the consumer's.
+- `../actingweb_mcp/thoughts/plans/2026-08-03-agent-run-returns-only-run-id.md`
+  — the consumer's migration plan, whose Phase 3 is the library work described
+  here. Note that plan defers to *this* document on library detail, so it should
+  not be cited back as evidence for library claims.

--- a/thoughts/todo/action-hook-output-schema-not-visible-to-mcp.md
+++ b/thoughts/todo/action-hook-output-schema-not-visible-to-mcp.md
@@ -1,0 +1,64 @@
+# `output_schema` on `action_hook` never reaches MCP
+
+Found during review of PR #119 (`chatgpt-codex-connector`, P2). Documented in
+`v3.13.0rc4`; the underlying asymmetry is unfixed.
+
+## What happens
+
+A hook's schema can be supplied three ways, and only one of them reaches MCP:
+
+| How the schema is supplied | `get_hook_metadata` | `get_mcp_metadata` → `tools/list` |
+| --- | --- | --- |
+| `@app.action_hook(..., output_schema=S)` | `S` | **`None`** |
+| Return-type `TypedDict` annotation (auto) | derived | **`None`** |
+| `@mcp_tool(output_schema=S)` | `S` | `S` |
+
+Verified empirically at commit `695a870`. `mcp.py`'s `tools/list` loop and the
+`tools/call` dispatch both read `get_mcp_metadata(hook)`
+(`actingweb/mcp/decorators.py:199-205`), which returns `_mcp_metadata` — set
+only by `@mcp_tool`. `action_hook` writes a separate `HookMetadata` to
+`_hook_metadata` (`actingweb/interface/hooks.py:1489`), and the TypedDict
+auto-derivation happens inside `get_hook_metadata`
+(`actingweb/interface/hooks.py:195`). Nothing bridges the two.
+
+Consequence: an author who declares `output_schema` on the action hook, or who
+annotates a `TypedDict` return type, reasonably believes their MCP tool
+advertises `outputSchema`. It does not, and the rc4 missing-`structuredContent`
+warning stays silent for them too, because it is gated on the same metadata.
+
+## Why rc4 documented it rather than fixed it
+
+Merging the two would **newly advertise `outputSchema`** for every MCP tool with
+a `TypedDict` return annotation. Every one of those that does not also return
+`structuredContent` would immediately start failing on spec-conforming clients
+with `Tool X has an output schema but did not return structured content` — the
+exact failure mode rc4 exists to warn about. That is a breaking change to a
+population that is currently working, and it does not belong in a release whose
+point is to make one behaviour predictable.
+
+## Options
+
+1. **Leave as is, documented.** Current state. Cost: the ergonomic trap
+   persists, and the two decorators keep diverging.
+2. **Merge, opt-in.** e.g. `@mcp_tool(inherit_hook_schema=True)`. Safe, but adds
+   API surface for something `@mcp_tool(output_schema=...)` already expresses.
+3. **Merge by default, behind a major/minor boundary**, paired with real
+   server-side validation so a schema mismatch is caught before it reaches a
+   client. This is the same work as research option C in
+   `thoughts/research/2026-08-03-structuredcontent-promotion-drops-tool-text.md`
+   (D1/option C) and should be decided together with it.
+4. **Warn at `tools/list`** when `_hook_metadata` has an `output_schema` and
+   `_mcp_metadata` does not — cheap, catches the confusion at registration
+   rather than at call time. Note the rc4 decision to keep the *missing
+   structured content* warning off `tools/list` does not apply here: this
+   condition is knowable at listing time and cannot false-positive.
+
+Option 4 is the cheapest real improvement and is independent of the rest.
+
+## Related
+
+- `thoughts/plans/2026-08-03-structuredcontent-promotion-drops-tool-text.md`
+- `thoughts/research/2026-08-03-structuredcontent-promotion-drops-tool-text.md`
+  (F7 — the two halves of the `outputSchema` ⇄ `structuredContent` contract were
+  implemented a day apart and never wired together; this is a third disconnected
+  half)


### PR DESCRIPTION
## Summary

`format_call_tool_result` promoted every unrecognised top-level key of a tool hook's return dict into MCP `structuredContent`. At least one major client discards **all** text content blocks when `structuredContent` is present, so adding a single scalar key to a hook's return value silently deleted that tool's entire prose payload — with no error on either side.

`structuredContent` is now **opt-in**: emitted only when a hook sets that key explicitly, and only when it is a JSON object. This matches both reference server implementations (the SDK's low-level server emits it only when `content` is its exact `json.dumps` serialization; FastMCP only for a declared return model). Neither promotes individual keys.

It is a **no-op for hooks that already set the key**, so downstreams can migrate first and upgrade after — no coordinated deploy window.

## Breaking change

The promotion is documented behaviour published on production PyPI in stable **v3.11.0** and **v3.12.0** (`v3.12.0` is current `latest`), so this changes a released contract. `3.12.0 → 3.13.0` is already a minor bump, so the version carries it. Ships as `3.13.0rc4` to TestPyPI.

## Also in this PR

- **An explicit `isError` is now honoured on the legacy text-wrap path.** A hook returning `{"isError": True, ...}` with no `content` key previously reached the wire with no `isError` field at all — a failure reported to the client as a success. Honoured only, **never inferred**: an `"error"` key is not a signal, since the known consumer returns `{"error": {...}}` on its normal error path. `str(result)` is byte-identical.
- **A warning when a tool declares `output_schema` but returns no `structuredContent`**, which spec-conforming clients reject outright. Broken today, independently of this change. Fires at call time (listing time cannot know what a hook returns) and only when the negotiated version supports structured content, so correctly-written hooks never trip it.
- **A warning when `structuredContent` is set to a non-object**, previously dropped silently.

## Documentation

The shipped guide example declared `output_schema` *and* relied on promotion — copy-pasted after this change it produced a tool that advertises `outputSchema` and returns no `structuredContent`, which strict clients reject. It is rewritten as a copy of `canonical_weather_hook` from the test suite, so the documented shape is **pinned by a test** rather than asserted in prose.

Three traps documentation has to carry because the library cannot enforce them:

- The quickstart's `tools/call` curl sent no `MCP-Protocol-Version` header, so a developer verifying a freshly migrated hook would see no `structuredContent` and conclude their own code was broken.
- The documented way to test a tool (`execute_action_hooks`) bypasses `format_call_tool_result` entirely, so a suite built on it stays green while wire output regresses. Adds a wire-shape testing section.
- No document stated that `output_schema` does not cause `structuredContent` to be emitted, while `hooks-reference` documents auto-deriving `output_schema` from a TypedDict return annotation — which makes the implied link stronger.

Plus a new `docs/migration/v3.13.rst` rc4 section, a troubleshooting entry, and two pre-existing corrections: `CHANGELOG.rst` and `docs/migration/v3.11.rst` both claimed `tools/call` results "always include `isError`", never true of the legacy branch.

## Test coverage

Adds `tests/test_mcp_tools_call_wire_shape.py`, which asserts the JSON that **actually leaves the handler** through both the sync and async dispatch paths. No such coverage existed — the three tests in `tests/integration/test_mcp_tools.py` are integration tests by placement only, calling the formatter directly. That gap is part of why this reached two stable releases.

The prose test asserts the entire JSON-RPC envelope by equality against a hook whose extras are non-empty, so a reinstated promotion fails by construction.

## Verification

- `make test-all-parallel` — 2617 passed, 26 skipped
- PostgreSQL integration — 747 passed, 18 skipped
- `pyright` 0 errors; `ruff check` and `ruff format --check` clean
- Docs build 0 warnings (baseline was also 0)
- Both version files exactly `3.13.0rc4`; one empty `Unreleased`, one rc4 section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPSfmMrGA3vqYRGtfueLGn