### PR TITLE
Pre-release v3.13.0rc6: migration refuses damaged lists

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,44 @@ CHANGELOG
 Unreleased
 ----------
 
+v3.13.0rc6: August 9, 2026
+--------------------------
+
+.. note::
+
+   Refines the ``rc5`` property-list work: bulk migration now refuses lists
+   with holes or orphans instead of silently closing them. Only affects
+   deployments that run ``actingweb-migrate-property-lists``.
+
+CHANGED
+~~~~~~~
+
+- **Migration now refuses a damaged list.**
+  ``actingweb-migrate-property-lists --migrate`` and
+  ``ListProperty.migrate_to_v2()`` refuse a list whose ``verify()`` reports
+  missing or orphaned indices, and the dry run reports those lists as
+  needing repair rather than counting them as "would migrate" — it exits
+  ``1`` when any exist, so ``0`` means the migration has nothing to trip
+  over. Migrating damaged data is not merely lossy but *unreportably*
+  lossy: migration renumbers the survivors, so afterwards the hole is
+  gone, the list verifies healthy, and nothing is left to say an item was
+  destroyed. In ``rc5`` the dry run warned about duplicate residue and said
+  nothing whatsoever about holes, so a sweep over a fleet containing one
+  could report "0 refused, 0 errors" and an operator would proceed past the
+  last moment the damage was visible. Lazy migration already refused
+  damaged lists on exactly these grounds; this applies the same rule to the
+  deliberate path. Repair first
+  (``actingweb-verify-property-lists --repair``), or pass
+  ``--migrate-damaged`` / ``migrate_to_v2(allow_damaged=True)`` to migrate
+  anyway — which logs what it is giving up.
+
+  Duplicate residue is unaffected and still migrates: it stays visible
+  after conversion, since a v2 list's ``verify()`` reports duplicates the
+  same way a v1 list's does, so migrating it destroys no evidence. Only
+  holes and orphans gate.
+- A successful migration that closed holes (only reachable via
+  ``--migrate-damaged``) now logs at WARNING rather than INFO.
+
 DOCUMENTATION
 ~~~~~~~~~~~~~
 
@@ -22,6 +60,12 @@ DOCUMENTATION
   migration guide's repair step (where operators are told to run it), the
   property-lists guide, and ``compact()``'s docstring, with a regression
   test pinning the measured interruption states. No behaviour change.
+- Corrected two stale statements about lazy migration, left behind when its
+  default changed to off in 3.13.0rc5: the downgrade-ordering warning
+  described a 50-item list as "by definition a lazy-migration candidate"
+  (true only where an operator has raised the limit), and the bulk script's
+  own docstring still opened by describing lazy migration as the normal
+  path.
 
 v3.13.0rc5: August 9, 2026
 --------------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,24 @@ CHANGELOG
 Unreleased
 ----------
 
+DOCUMENTATION
+~~~~~~~~~~~~~
+
+- **Documented that ``compact()`` is not crash-safe in either storage
+  format, and that an interrupted repair leaves damage repair will not
+  itself fix.** Only the v2 rank-rebalance window was documented in
+  3.13.0rc5; the v1 path -- the one every upgrading operator runs via
+  ``actingweb-verify-property-lists --repair`` -- has the same shape.
+  Survivors are written to their new positions before the tail rows are
+  deleted, so an interruption leaves a copy at both, with the stored length
+  unchanged: the list reads back with **no error**. ``verify()`` catches it
+  through the adjacent-duplicate heuristic, but re-running ``--repair``
+  will not remove the copy, because duplicates are preserved by design --
+  including the one the interrupted repair created. Now covered in the
+  migration guide's repair step (where operators are told to run it), the
+  property-lists guide, and ``compact()``'s docstring, with a regression
+  test pinning the measured interruption states. No behaviour change.
+
 v3.13.0rc5: August 9, 2026
 --------------------------
 

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.0rc5"
+__version__ = "3.13.0rc6"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/interface/property_store.py
+++ b/actingweb/interface/property_store.py
@@ -390,11 +390,12 @@ class NotifyingListProperty:
         self._register_diff("metadata")
         return report
 
-    def migrate_to_v2(self) -> dict[str, Any]:
+    def migrate_to_v2(self, allow_damaged: bool = False) -> dict[str, Any]:
         """Migrate this list from v1 to v2 storage -- see
-        ListProperty.migrate_to_v2(). Registers a "metadata" diff (same
-        rationale as compact()) only when a migration actually happened."""
-        report = self._list_prop.migrate_to_v2()
+        ListProperty.migrate_to_v2(), including what ``allow_damaged``
+        gives up. Registers a "metadata" diff (same rationale as
+        compact()) only when a migration actually happened."""
+        report = self._list_prop.migrate_to_v2(allow_damaged=allow_damaged)
         if report.get("migrated"):
             self._register_diff("metadata")
         return report

--- a/actingweb/maintenance/migrate_property_lists.py
+++ b/actingweb/maintenance/migrate_property_lists.py
@@ -230,17 +230,29 @@ def migrate_actor(
             # operator gets a clean-looking report over damaged data and
             # migrates it away without ever seeing it.
             if report["missing_indices"] or report["orphan_indices"]:
-                refused.append((f"{actor_id}/{name}", "repair required"))
+                if not allow_damaged:
+                    refused.append((f"{actor_id}/{name}", "repair required"))
+                    logger.warning(
+                        f"actor={actor_id} list={name}: WOULD REFUSE -- "
+                        f"missing_indices={report['missing_indices']} "
+                        f"orphan_indices={report['orphan_indices']}. "
+                        f"Migration closes holes in flight and the damage "
+                        f"stops being reportable; repair first with "
+                        f"actingweb-verify-property-lists --repair, or pass "
+                        f"--migrate-damaged to migrate and accept the loss"
+                    )
+                    continue
+                # --migrate-damaged was passed, so predict what the real
+                # run will do rather than refusing: a dry run that reports
+                # a refusal the actual migration would not perform is
+                # useless as the gate the docs tell operators to use.
                 logger.warning(
-                    f"actor={actor_id} list={name}: WOULD REFUSE -- "
+                    f"actor={actor_id} list={name}: would migrate and CLOSE "
                     f"missing_indices={report['missing_indices']} "
-                    f"orphan_indices={report['orphan_indices']}. Migration "
-                    f"closes holes in flight and the damage stops being "
-                    f"reportable; repair first with "
-                    f"actingweb-verify-property-lists --repair, or pass "
-                    f"--migrate-damaged to migrate and accept the loss"
+                    f"orphan_indices={report['orphan_indices']} "
+                    f"(--migrate-damaged) -- the damage stops being "
+                    f"reportable once this runs"
                 )
-                continue
             if report["adjacent_duplicates"]:
                 logger.warning(
                     f"actor={actor_id} list={name}: would migrate "

--- a/actingweb/maintenance/migrate_property_lists.py
+++ b/actingweb/maintenance/migrate_property_lists.py
@@ -4,22 +4,27 @@ Bulk-migrate v1 (dense-integer) property lists to v2 (fractional rank key)
 storage -- see thoughts/plans/2026-08-08-property-list-index-integrity.md,
 Phase 5.
 
-Small lists (<= 50 items by default) already migrate lazily on their next
-mutation (append/insert/__setitem__/__delitem__) -- this script is for
-lists too large or too idle to reach that trigger on their own, and for a
-one-time upgrade sweep across an existing deployment.
+Lazy migration is OFF by default (ACTINGWEB_LAZY_MIGRATION_MAX_LENGTH=0),
+so out of the box this script is the only thing that converts an existing
+list. Where an operator has turned it on, it still only covers lists at or
+under that item count that get mutated -- this script is for the rest, and
+for a one-time upgrade sweep across an existing deployment at a rate and a
+time of the operator's choosing (migration is inline and synchronous, so
+one append() to a 40-item v1 list would otherwise do the whole migration
+inside a user's request).
 
-Two things this script is the ONLY route for:
+**Damaged lists are refused, by this script and by migrate_to_v2()
+itself.** Migration renumbers the surviving rows, so a hole does not
+survive it -- and neither does the evidence: the migrated list verifies
+healthy afterwards with no record of what went missing. Repair first
+(actingweb-verify-property-lists --repair, or ListProperty.compact()),
+then migrate. --migrate-damaged overrides this for an operator who has
+looked at the damage and decided to move on; the dry run names the lists
+that need it either way.
 
-- **Damaged lists.** Lazy migration refuses a list that verify() reports as
-  unhealthy, because migrating closes holes in flight and would make the
-  damage unreportable. Repair first (compact(), or
-  scripts/verify_property_lists.py --repair), then migrate.
-- **Deployments with lazy migration turned off.** Migration is inline and
-  synchronous -- one append() to a 40-item v1 list does the whole migration
-  inside that request. Set ACTINGWEB_LAZY_MIGRATION_MAX_LENGTH=0 to keep it
-  out of user traffic entirely and rely on this script's rate limiter
-  instead.
+Duplicate residue does NOT block migration: it stays visible afterwards
+(v2's verify() reports duplicates just as v1's does), so migrating it
+destroys no evidence. It is reported, not refused.
 
 Run with the SAME environment as the application (DATABASE_BACKEND and its
 backend-specific connection settings), e.g.::
@@ -30,10 +35,12 @@ backend-specific connection settings), e.g.::
         --checkpoint-file .migrate.checkpoint.json
     poetry run python scripts/migrate_property_lists.py --downgrade ACTOR_ID/list_name
 
-Dry-run (report only) by default -- reports what WOULD be migrated,
-including refused names (containing '#') and duplicate residue, without
-writing anything. --migrate performs the migration via
-ListProperty.migrate_to_v2() (idempotent, safe to interrupt and re-run).
+Dry-run (report only) by default -- reports what WOULD be migrated, what
+would be refused (names containing '#', and lists with holes or orphans),
+and duplicate residue, without writing anything. It exits 1 when anything
+would be refused, so "exit 0" means the migration has nothing to trip
+over. --migrate performs the migration via ListProperty.migrate_to_v2()
+(idempotent, safe to interrupt and re-run).
 
 Unlike scripts/backfill_property_lookup.py, this uses a single
 per-actor-at-a-time model (matching scripts/verify_property_lists.py)
@@ -49,11 +56,13 @@ locking is taken), and only as a last resort -- there is no forward path
 back to v2 other than a fresh migration.
 
 ORDER MATTERS: roll the application back to the pre-v2 release FIRST, then
-run --downgrade against the database. A list with <= 50 items is a lazy-
-migration candidate again the instant it's v1 -- if the current (v2-aware)
+run --downgrade against the database. Where lazy migration has been turned
+on, a downgraded list at or under its item limit is a lazy-migration
+candidate again the instant it's v1 -- if the current (v2-aware)
 application is still running against it, its very next append/insert/
 setitem/delitem migrates it straight back to v2, silently undoing the
-downgrade.
+downgrade. Rolling the application back first also removes that race,
+which is the other reason to do it in that order.
 
 Exit code 0 if every eligible list was migrated (or already was) by the
 end of the run, 1 if any list was refused or errored.
@@ -167,11 +176,14 @@ def migrate_actor(
     migrate: bool,
     limiter: RateLimiter,
     identity_key: str | None = None,
-) -> tuple[int, int, int, list[str]]:
+    allow_damaged: bool = False,
+) -> tuple[int, int, int, list[tuple[str, str]]]:
     """Migrate (or dry-run report on) every v1 list belonging to one actor.
 
     Returns (lists_checked, lists_migrated_or_would_migrate, lists_errored,
-    refused_names).
+    refusals), where each refusal is a ``(actor_id/list_name, reason)``
+    pair -- ``"rename required"`` for a '#'-named list, ``"repair
+    required"`` for one with holes or orphans.
     """
     from actingweb.property import PropertyListStore
     from actingweb.property_list import ListProperty
@@ -182,7 +194,7 @@ def migrate_actor(
     checked = 0
     migrated = 0
     errored = 0
-    refused: list[str] = []
+    refused: list[tuple[str, str]] = []
 
     for name in list_names:
         limiter.wait()
@@ -203,7 +215,7 @@ def migrate_actor(
         checked += 1
 
         if "#" in name:
-            refused.append(f"{actor_id}/{name}")
+            refused.append((f"{actor_id}/{name}", "rename required"))
             logger.warning(
                 f"actor={actor_id} list={name}: REFUSED -- name contains "
                 f"'#', rename before migrating; keeps working as v1"
@@ -212,6 +224,23 @@ def migrate_actor(
 
         if not migrate:
             report = list_prop.verify(identity_key=identity_key)
+            # Holes and orphans first: migration closes them, and unlike
+            # duplicates they leave nothing behind for a later verify() to
+            # find. A dry run that mentions only duplicates is how an
+            # operator gets a clean-looking report over damaged data and
+            # migrates it away without ever seeing it.
+            if report["missing_indices"] or report["orphan_indices"]:
+                refused.append((f"{actor_id}/{name}", "repair required"))
+                logger.warning(
+                    f"actor={actor_id} list={name}: WOULD REFUSE -- "
+                    f"missing_indices={report['missing_indices']} "
+                    f"orphan_indices={report['orphan_indices']}. Migration "
+                    f"closes holes in flight and the damage stops being "
+                    f"reportable; repair first with "
+                    f"actingweb-verify-property-lists --repair, or pass "
+                    f"--migrate-damaged to migrate and accept the loss"
+                )
+                continue
             if report["adjacent_duplicates"]:
                 logger.warning(
                     f"actor={actor_id} list={name}: would migrate "
@@ -232,7 +261,7 @@ def migrate_actor(
             continue
 
         try:
-            result = list_prop.migrate_to_v2()
+            result = list_prop.migrate_to_v2(allow_damaged=allow_damaged)
         except Exception as e:
             logger.error(f"actor={actor_id} list={name}: migrate_to_v2() failed: {e}")
             errored += 1
@@ -240,12 +269,19 @@ def migrate_actor(
 
         if result["migrated"]:
             migrated += 1
-            logger.info(
+            level = logger.warning if result["had_holes"] else logger.info
+            level(
                 f"actor={actor_id} list={name}: migrated "
                 f"({result['item_count']} items, "
                 f"had_holes={result['had_holes']}, "
                 f"duplicates={result['duplicate_count']})"
             )
+        elif result.get("reason") == "damaged":
+            # Only reachable without --migrate-damaged. migrate_to_v2()
+            # has already logged the detail; record it as a refusal so the
+            # run exits non-zero and the actor stays out of the
+            # checkpoint, exactly like a '#'-named list.
+            refused.append((f"{actor_id}/{name}", "repair required"))
         elif result.get("reason") == "already_v2":
             # Not a refusal: migrate_to_v2() re-reads the stored format
             # itself, so a list that another request lazily migrated between
@@ -257,7 +293,7 @@ def migrate_actor(
         else:
             # "name_contains_hash" -- needs an operator rename before this
             # list can ever migrate.
-            refused.append(f"{actor_id}/{name}")
+            refused.append((f"{actor_id}/{name}", "rename required"))
 
     return checked, migrated, errored, refused
 
@@ -340,6 +376,15 @@ def main() -> int:
         ),
     )
     parser.add_argument(
+        "--migrate-damaged",
+        action="store_true",
+        help=(
+            "also migrate lists with holes or orphans, CLOSING them: the "
+            "lost items stay lost and stop being reported (default: refuse "
+            "them and report a repair is needed)"
+        ),
+    )
+    parser.add_argument(
         "--checkpoint-file",
         default=".migrate_property_lists.checkpoint.json",
         help="resume state file (default .migrate_property_lists.checkpoint.json)",
@@ -373,6 +418,14 @@ def main() -> int:
 
     _log_target(config, "MIGRATE" if args.migrate else "dry-run", args.rps)
 
+    if args.migrate_damaged:
+        logger.warning(
+            "--migrate-damaged: lists with holes or orphans WILL be "
+            "migrated. Migration renumbers the survivors, so the damage is "
+            "closed and stops being reportable -- the migrated lists verify "
+            "healthy afterwards with no record of what went missing."
+        )
+
     actors = get_actor_list(config).fetch()
     if not actors:
         logger.info("No actors found")
@@ -385,7 +438,7 @@ def main() -> int:
     total_checked = 0
     total_migrated = 0
     total_errored = 0
-    total_refused: list[str] = []
+    total_refused: list[tuple[str, str]] = []
     actors_swept = 0
 
     for actor in actors:
@@ -393,7 +446,12 @@ def main() -> int:
         if not actor_id or checkpoint.is_done(actor_id):
             continue
         checked, migrated, errored, refused = migrate_actor(
-            actor_id, config, args.migrate, limiter, args.identity_key
+            actor_id,
+            config,
+            args.migrate,
+            limiter,
+            args.identity_key,
+            args.migrate_damaged,
         )
         total_checked += checked
         total_migrated += migrated
@@ -414,8 +472,10 @@ def main() -> int:
         f"{'migrated' if args.migrate else 'would_migrate'}={total_migrated} "
         f"refused={len(total_refused)} errors={total_errored}"
     )
-    for name in total_refused:
-        logger.warning(f"REFUSED (rename required): {name}")
+    for name, reason in total_refused:
+        logger.warning(
+            f"{'REFUSED' if args.migrate else 'WOULD REFUSE'} ({reason}): {name}"
+        )
     if not args.migrate and total_checked:
         logger.info("Re-run with --migrate to perform the migration.")
     if args.migrate and not total_refused and not total_errored:

--- a/actingweb/property_list.py
+++ b/actingweb/property_list.py
@@ -1775,7 +1775,7 @@ class ListProperty:
 
         return report
 
-    def migrate_to_v2(self) -> dict[str, Any]:
+    def migrate_to_v2(self, allow_damaged: bool = False) -> dict[str, Any]:
         """Migrate this list from v1 (dense integers) to v2 (fractional
         rank keys) storage, in place.
 
@@ -1786,8 +1786,8 @@ class ListProperty:
            v1) if the name contains ``#``, or if metadata is unparsable
            (``verify()`` -> ``_load_metadata()`` raises ``ValueError``,
            which propagates -- Phase 2's existing fail-fast behavior).
-        2. ``verify()`` the v1 list. Holes are closed in-flight (only
-           surviving rows migrate, in their existing order); duplicate
+        2. ``verify()`` the v1 list, and refuse a list with holes or
+           orphans unless ``allow_damaged=True`` (see below). Duplicate
            residue migrates as both copies, as-is, and is reported.
         3. Clear any v2-range rows a PREVIOUS interrupted attempt left
            behind. This is what makes re-running safe even if the v1 list
@@ -1814,10 +1814,34 @@ class ListProperty:
         idempotent, so a re-run (or the bulk migration script) finishes
         the cleanup safely.
 
+        Args:
+            allow_damaged: migrate a list that ``verify()`` reports holes
+                or orphans in, accepting that migration CLOSES them --
+                the surviving rows are renumbered and the missing ones
+                stop being missing. The lost item stays lost, but nothing
+                reports it any more: the migrated list verifies healthy
+                and there is no record left of what index went absent.
+                That is the right trade for an operator who has looked at
+                the damage and decided to move on, and the wrong one as a
+                default, so it is off by default and this method refuses
+                instead. Repair first (``compact()``, or
+                ``actingweb-verify-property-lists --repair``) and the
+                question does not arise.
+
+                Only holes and orphans gate on this. Duplicate residue
+                migrates freely, because it stays visible afterwards --
+                ``_v2_verify()`` reports duplicates the same way
+                ``verify()`` does, so migrating it destroys no evidence.
+                ``_maybe_lazy_migrate()`` is deliberately stricter and
+                skips any unhealthy list, duplicates included: it runs
+                inside a user's write with nobody reading its output, so
+                it declines anything it cannot handle silently.
+
         Returns:
             Dict with ``migrated`` (bool) and either ``reason`` (str, only
             when not migrated) or ``item_count``/``had_holes``/
-            ``duplicate_count`` (when migrated).
+            ``duplicate_count`` (when migrated). A ``"damaged"`` reason
+            also carries ``missing_indices`` and ``orphan_indices``.
         """
         if _V2_RANK_MARKER in self.name:
             logger.error(
@@ -1840,6 +1864,32 @@ class ListProperty:
             return {"migrated": False, "reason": "already_v2"}
 
         report = self.verify()
+
+        # Refuse a damaged list. Migration renumbers survivors, so a hole
+        # does not survive it -- and neither does the evidence: the
+        # migrated list verifies healthy, and the report naming what was
+        # closed is this method's return value, which a bulk sweep over
+        # hundreds of lists reduces to one line in a log. An operator who
+        # repairs first gets to see the damage; one who migrates first
+        # never finds out it was there.
+        missing = report["missing_indices"]
+        orphans = report["orphan_indices"]
+        if (missing or orphans) and not allow_damaged:
+            logger.error(
+                f"List '{self.name}' not migrated to v2: verify() reports "
+                f"missing_indices={missing} orphan_indices={orphans}. "
+                f"Migration closes holes in flight, so the damage would "
+                f"stop being reportable -- repair it first (compact(), or "
+                f"actingweb-verify-property-lists --repair), or pass "
+                f"allow_damaged=True to migrate and accept the loss. The "
+                f"list keeps working as v1 in the meantime"
+            )
+            return {
+                "migrated": False,
+                "reason": "damaged",
+                "missing_indices": missing,
+                "orphan_indices": orphans,
+            }
 
         if not self._db:
             raise RuntimeError("No database connection available")

--- a/actingweb/property_list.py
+++ b/actingweb/property_list.py
@@ -1705,6 +1705,27 @@ class ListProperty:
         item, and silently collapsing one copy would bless the data loss
         as intentional rather than surface it.
 
+        NOT CRASH-SAFE (v1, same shape as ``_v2_compact()``). Survivors are
+        rewritten at their new positions BEFORE the tail rows are deleted,
+        so an interruption between the two leaves a copy at both the old
+        and the new position. Measured on a 4-slot list with one hole,
+        interrupting at successive writes:
+
+        - after the first move: rows ``[a, c, c, d]``, length still 4
+        - after the second:     rows ``[a, c, d, d]``, length still 4
+
+        Both are readable with **no error** -- length matches the rows
+        present, so nothing looks wrong to a caller. ``verify()`` does
+        catch them, via the adjacent byte-identical heuristic, so a
+        follow-up sweep reports the list unhealthy.
+
+        The sharp part: re-running ``compact()`` does NOT clean this up.
+        Duplicates are preserved by design (above), so the repair tool
+        will not remove the copy its own interruption created, and the
+        list stays one item too long until someone resolves it by hand.
+        Prefer running repair when the actor is not taking writes, and
+        re-run ``verify()`` afterwards rather than assuming success.
+
         Returns:
             The ``verify()`` report this call acted on (taken before any
             write).

--- a/docs/guides/property-lists.rst
+++ b/docs/guides/property-lists.rst
@@ -196,12 +196,33 @@ gradual, never required for a list to keep functioning:
     actingweb-migrate-property-lists              # dry run
     actingweb-migrate-property-lists --migrate
 
-  The script reports lists it refuses to migrate (names containing
-  ``#`` -- rename first) and any duplicate-value residue it preserves
-  as-is.
+  The script reports lists it refuses to migrate -- names containing ``#``
+  (rename first) and lists with holes or orphans (repair first) -- and any
+  duplicate-value residue it preserves as-is. The dry run exits ``1`` if
+  anything would be refused, so ``0`` means the migration has nothing to
+  trip over; treat that as the gate rather than reading the log.
 - **Programmatic**: ``actor.property_lists.<name>._list_prop.migrate_to_v2()``
   migrates one list directly. Idempotent -- safe to call again (a no-op
   once the list is already v2) and safe to re-run after an interruption.
+
+.. warning::
+
+   **Migration refuses a damaged list, and this is worth understanding
+   rather than working around.** Migrating a list with a hole in it is not
+   merely lossy -- it is *unreportably* lossy. The surviving rows are
+   renumbered, so afterwards the hole is gone, the list verifies healthy,
+   and nothing is left to say an item was ever destroyed. Repair first
+   (``actingweb-verify-property-lists --repair``, or ``compact()``), which
+   closes the hole while leaving the duplicate evidence intact, and the
+   question does not arise.
+
+   ``--migrate-damaged`` (or ``migrate_to_v2(allow_damaged=True)``) exists
+   for the operator who has looked at the damage and decided to move on. It
+   logs what it is giving up.
+
+   Duplicate residue does **not** block migration, because it survives the
+   conversion visibly -- a v2 list's ``verify()`` reports duplicates the
+   same way a v1 list's does. Only holes and orphans gate.
 
 .. danger::
 
@@ -246,12 +267,16 @@ gradual, never required for a list to keep functioning:
    takes no lock against concurrent writes and is not part of the normal
    operational flow -- do not script it into routine tooling.
 
-   **Order matters.** A downgraded list with <= 50 items is, by
+   **Order matters.** Where lazy migration has been enabled, a downgraded
+   list at or under ``ACTINGWEB_LAZY_MIGRATION_MAX_LENGTH`` is, by
    definition, a lazy-migration candidate again -- if the *current*
    application (the one with v2 support) is still running against it, its
    very next mutation (``append``/``insert``/item ``__setitem__``/
    ``__delitem__``) migrates it straight back to v2, silently undoing the
-   downgrade. Roll the application back to the pre-v2 release **first**,
+   downgrade. At the default of 0 that particular race is off, but the
+   ordering rule is the same either way, because a v2-aware application
+   still writes v2 to any list it creates or converts.
+   Roll the application back to the pre-v2 release **first**,
    then run ``--downgrade`` against the database from a checkout that
    still has v2 support (the tool itself needs the v2 code to read the
    list it's converting) -- never the other way around.

--- a/docs/guides/property-lists.rst
+++ b/docs/guides/property-lists.rst
@@ -369,16 +369,28 @@ cap.
 
 .. warning::
 
-   ``compact()`` on a v2 list is not crash-safe end to end. It writes every
-   item under its new rank before retiring any old row, so an interruption
-   partway leaves both copies of the already-rewritten items readable, and
-   re-running ``compact()`` does not undo that -- it treats all of them as
-   genuine items. This is the deliberate trade: the alternative, retiring
-   each old row as its replacement is written, would leave interrupted
-   states silently *reordered* instead, which nothing detects. Recovery is
-   manual; the stale copies are the ones whose rank keys are not part of the
-   evenly spaced sequence a fresh rebalance produces. Prefer running it when
-   the actor is not taking writes.
+   ``compact()`` is not crash-safe end to end, in **either** storage format.
+   It writes every item to its new location before retiring any old row, so
+   an interruption partway leaves a copy at both. Re-running ``compact()``
+   does not undo that -- it treats every copy as a genuine item, and under
+   v1 it explicitly declines to touch duplicate residue at all. Prefer
+   running it when the actor is not taking writes, and re-run ``verify()``
+   afterwards rather than assuming success.
+
+   **v1** (dense integers): interrupting the rewrite of a 4-slot list with
+   one hole leaves ``[a, c, c, d]`` or ``[a, c, d, d]`` with the length
+   still reading 4 -- readable with no error, because nothing is
+   structurally inconsistent. ``verify()`` catches it through the adjacent
+   byte-identical heuristic, but repair will not remove it: duplicates are
+   preserved by design, including the one repair itself created. Resolving
+   it is manual.
+
+   **v2** (rank keys): the same window, as a rank rebalance. The deliberate
+   trade here is that the alternative -- retiring each old row as its
+   replacement is written -- would leave interrupted states silently
+   *reordered* instead, which nothing detects at all. Recovery is manual;
+   the stale copies are the ones whose rank keys are not part of the evenly
+   spaced sequence a fresh rebalance produces.
 
 See the ActingWeb specification and Properties handler documentation for complete API details.
 

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -25,11 +25,12 @@ Version Migrations
 **v3.13 Migration**
    Guide for upgrading to ActingWeb 3.13, covering the DynamoDB scalability
    work (``rc1``/``rc2``), the MCP trust-cache authorization fix (``rc3``),
-   the MCP ``structuredContent`` behaviour change in ``rc4``, and the
-   property-list changes in ``rc5``. **If you use list properties, read the
-   ``rc5`` section before upgrading** — list reads now fail loudly on
-   pre-existing data damage that earlier releases silently skipped past, so
-   sweeping and repairing comes first.
+   the MCP ``structuredContent`` behaviour change in ``rc4``, the
+   property-list changes in ``rc5``, and migration's refusal to convert
+   damaged lists in ``rc6``. **If you use list properties, read the ``rc5``
+   section before upgrading** — list reads now fail loudly on pre-existing
+   data damage that earlier releases silently skipped past, so sweeping and
+   repairing comes first.
 
 **v3.11 Migration**
    Guide for upgrading to ActingWeb 3.11, covering the one new PostgreSQL

--- a/docs/migration/v3.13.rst
+++ b/docs/migration/v3.13.rst
@@ -2,6 +2,42 @@
 Migrating to ActingWeb 3.13
 ===========================
 
+Behaviour change in rc6: migration refuses damaged lists
+========================================================
+
+.. note::
+
+   This is a refinement of the ``rc5`` property-list work below, and only
+   affects you if you run ``actingweb-migrate-property-lists`` (step 4). If
+   you are upgrading from a release older than ``rc5``, read the ``rc5``
+   section first — it is the one with the pre-upgrade steps.
+
+``actingweb-migrate-property-lists --migrate`` and
+``ListProperty.migrate_to_v2()`` now **refuse a list with holes or orphans**,
+and the dry run reports those lists as needing repair instead of counting
+them as "would migrate". A dry run that finds any exits ``1``.
+
+The reason is that migrating damaged data is not just lossy, it is
+*unreportably* lossy. Migration renumbers the surviving rows, so the hole is
+gone afterwards — and so is the evidence. The migrated list verifies healthy,
+and nothing remains to say an item ever went missing. In ``rc5`` the dry run
+said nothing about holes at all, so a sweep over a fleet containing one could
+report "0 refused, 0 errors" and an operator would proceed in good faith,
+past the last moment at which the damage was still visible.
+
+Lazy migration already refused damaged lists in ``rc5``, for exactly this
+reason. ``rc6`` applies the same rule to the deliberate path.
+
+What to do: **repair first** (step 2), then migrate. If you have looked at
+the damage and decided to migrate anyway, ``--migrate-damaged`` (or
+``migrate_to_v2(allow_damaged=True)``) does it, and says clearly in the log
+what it is giving up.
+
+Duplicate residue is **not** affected — it never blocked migration and still
+does not. A duplicate stays visible after conversion, because v2's
+``verify()`` reports duplicates just as v1's does, so migrating it destroys
+no evidence. Only holes and orphans gate.
+
 Behaviour change in rc5: property-list storage, repair, and fail-fast reads
 ===========================================================================
 
@@ -190,6 +226,13 @@ as a deliberate operator action::
     actingweb-migrate-property-lists              # dry run
     actingweb-migrate-property-lists --migrate
 
+**Repair (step 2) before you migrate, and treat the dry run's exit code as
+the gate.** Migration refuses a list with holes or orphans, and the dry run
+names them and exits ``1``; a dry run that exits ``0`` is telling you the
+migration has nothing to trip over. This matters more than it sounds:
+migration renumbers survivors, so a hole that goes through it stops existing
+*and* stops being reportable. See the rc6 section at the top.
+
 Step 5: understand the new storage format
 -----------------------------------------
 
@@ -226,9 +269,10 @@ whole-list rewrite migrates a list of any original size, because the first
 "nothing migrates without me" true.
 
 **Bulk migration** (step 4 above) is for lists too large or too idle to
-migrate lazily, and is the only route for damaged lists once you have
-repaired them. ``migrate_to_v2()`` is idempotent and safe to interrupt and
-re-run.
+migrate lazily, and — with lazy migration off by default — for everything
+else too. It refuses damaged lists on the same grounds lazy migration does;
+repair them first. ``migrate_to_v2()`` is idempotent and safe to interrupt
+and re-run.
 
 **List names containing ``#`` are refused.** ``#`` is reserved for internal
 v2 storage keys. New lists cannot be created with it; existing lists that
@@ -246,7 +290,9 @@ your latency numbers.
 
 **Downgrade is unsupported.** ``migrate_property_lists.py --downgrade`` exists
 as an emergency converter only. If you use it, roll the application back to a
-pre-v2 release *first*: a downgraded list of 50 items or fewer is a
+pre-v2 release *first*. With lazy migration at its default of 0 this is
+"only" the ordinary rule that the reader must precede the data; if you have
+raised the limit, it is sharper — a downgraded list at or under it is a
 lazy-migration candidate again, so a still-running v2-aware application
 migrates it straight back on its next write.
 

--- a/docs/migration/v3.13.rst
+++ b/docs/migration/v3.13.rst
@@ -83,6 +83,28 @@ rather than surface it. Duplicates are reported and left for you to decide
 about. Repair does not recover a destroyed item — nothing can; the row is
 gone.
 
+.. warning::
+
+   **Repair is not crash-safe, and an interrupted repair leaves damage it
+   will not itself fix.** ``compact()`` rewrites surviving rows at their new
+   positions before deleting the tail, so an interruption between the two
+   leaves a copy at both the old and the new position. Measured on a 4-slot
+   list with one hole: interrupting after the first move leaves
+   ``[a, c, c, d]``, after the second ``[a, c, d, d]`` — both with the
+   length still reading 4, so **the list reads back with no error at all**.
+
+   ``verify()`` does catch it (the duplicate is adjacent and byte-identical,
+   which is exactly what its heuristic looks for), so a follow-up sweep
+   reports the list unhealthy. But re-running ``--repair`` will not remove
+   the copy: duplicates are preserved by design, so the tool declines to
+   touch the residue its own interruption created, and the list stays one
+   item too long until you resolve it by hand.
+
+   In practice: run repair when the actor is not taking writes, and **run
+   the sweep again afterwards** rather than assuming it worked. The same
+   shape applies to ``compact()`` on a v2 list, where it is a rank rebalance
+   — see the guide's warning box.
+
 Step 3: expect these breaking changes after upgrading
 -----------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.13.0rc5"
+version = "3.13.0rc6"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@actingweb.io>"]
 maintainers = ["Greger Wedel <support@actingweb.io>"]

--- a/tests/integration/test_migrate_property_lists_script.py
+++ b/tests/integration/test_migrate_property_lists_script.py
@@ -234,6 +234,44 @@ class TestMigrateActor:
         assert fresh.verify()["format"] == 2
         assert fresh.to_list() == ["a", "c"]
 
+    def test_dry_run_with_migrate_damaged_predicts_the_migration(self, test_actor):
+        """A dry run must predict the run it is a dry run OF.
+
+        With --migrate-damaged, the real run migrates the holed list -- so
+        the dry run has to say "would migrate" and come back clean. Having
+        it refuse instead would report a refusal that will not happen,
+        tell the operator to pass the flag they already passed, and make
+        the exit code the docs nominate as the gate unreachable for anyone
+        who has looked at their damage and decided to proceed.
+        """
+        import migrate_property_lists as script  # type: ignore[import-not-found]
+
+        _seed_v1_list(
+            test_actor.config, test_actor.id, "dry_run_damaged_ok", ["a", "b", "c"]
+        )
+        db = get_property(test_actor.config)
+        assert db.set(
+            actor_id=test_actor.id, name="list:dry_run_damaged_ok-1", value=None
+        )
+
+        checked, migrated, errored, refused = script.migrate_actor(
+            test_actor.id,
+            test_actor.config,
+            migrate=False,
+            limiter=script.RateLimiter(0),
+            allow_damaged=True,
+        )
+
+        assert checked == 1
+        assert migrated == 1
+        assert errored == 0
+        assert refused == []
+
+        # Still a dry run -- nothing was written.
+        fresh = ListProperty(test_actor.id, "dry_run_damaged_ok", test_actor.config)
+        assert fresh.verify().get("format") != 2
+        assert fresh.verify()["missing_indices"] == [1]
+
     def test_already_v2_lists_are_skipped(self, test_actor):
         import migrate_property_lists as script  # type: ignore[import-not-found]
 

--- a/tests/integration/test_migrate_property_lists_script.py
+++ b/tests/integration/test_migrate_property_lists_script.py
@@ -139,11 +139,100 @@ class TestMigrateActor:
         assert checked == 1
         assert migrated == 0
         assert errored == 0
-        assert refused == [f"{test_actor.id}/bad-#name"]
+        assert refused == [(f"{test_actor.id}/bad-#name", "rename required")]
 
         fresh = getattr(test_actor.property_lists, "bad-#name")
         assert fresh.verify().get("format") != 2
         assert fresh.to_list() == ["a"]
+
+    def test_dry_run_names_a_holed_list_instead_of_saying_would_migrate(
+        self, test_actor
+    ):
+        """The dry run's whole job is to tell an operator what --migrate
+        will do. A holed list must come back as a refusal, not as a bare
+        "would migrate".
+
+        This is the defect this test exists for: the dry run warned about
+        duplicate residue and said nothing whatsoever about holes, so a
+        sweep over a fleet containing one reported "0 refused, 0 errors"
+        and the operator went ahead. Migration then closed the hole, and
+        because a migrated list verifies healthy, that was the last moment
+        anyone could have found out.
+        """
+        import migrate_property_lists as script  # type: ignore[import-not-found]
+
+        _seed_v1_list(
+            test_actor.config, test_actor.id, "dry_run_holed", ["a", "b", "c"]
+        )
+        db = get_property(test_actor.config)
+        assert db.set(actor_id=test_actor.id, name="list:dry_run_holed-1", value=None)
+
+        checked, migrated, errored, refused = script.migrate_actor(
+            test_actor.id,
+            test_actor.config,
+            migrate=False,
+            limiter=script.RateLimiter(0),
+        )
+
+        assert checked == 1
+        assert migrated == 0, "a list that would be refused is not 'would migrate'"
+        assert errored == 0
+        assert refused == [(f"{test_actor.id}/dry_run_holed", "repair required")]
+
+    def test_migrate_refuses_a_holed_list_and_leaves_it_v1(self, test_actor):
+        import migrate_property_lists as script  # type: ignore[import-not-found]
+
+        _seed_v1_list(
+            test_actor.config, test_actor.id, "migrate_holed_script", ["a", "b", "c"]
+        )
+        db = get_property(test_actor.config)
+        assert db.set(
+            actor_id=test_actor.id, name="list:migrate_holed_script-1", value=None
+        )
+
+        checked, migrated, errored, refused = script.migrate_actor(
+            test_actor.id,
+            test_actor.config,
+            migrate=True,
+            limiter=script.RateLimiter(0),
+        )
+
+        assert checked == 1
+        assert migrated == 0
+        assert errored == 0
+        assert refused == [(f"{test_actor.id}/migrate_holed_script", "repair required")]
+
+        fresh = ListProperty(test_actor.id, "migrate_holed_script", test_actor.config)
+        assert fresh.verify().get("format") != 2
+        assert fresh.verify()["missing_indices"] == [1]
+
+    def test_migrate_damaged_flag_migrates_the_holed_list(self, test_actor):
+        import migrate_property_lists as script  # type: ignore[import-not-found]
+
+        _seed_v1_list(
+            test_actor.config, test_actor.id, "migrate_damaged_ok", ["a", "b", "c"]
+        )
+        db = get_property(test_actor.config)
+        assert db.set(
+            actor_id=test_actor.id, name="list:migrate_damaged_ok-1", value=None
+        )
+
+        checked, migrated, errored, refused = script.migrate_actor(
+            test_actor.id,
+            test_actor.config,
+            migrate=True,
+            limiter=script.RateLimiter(0),
+            allow_damaged=True,
+        )
+
+        assert checked == 1
+        assert migrated == 1
+        assert errored == 0
+        assert refused == []
+
+        fresh = ListProperty(test_actor.id, "migrate_damaged_ok", test_actor.config)
+        assert fresh.verify()["format"] == 2
+        assert fresh.to_list() == ["a", "c"]
 
     def test_already_v2_lists_are_skipped(self, test_actor):
         import migrate_property_lists as script  # type: ignore[import-not-found]
@@ -235,6 +324,31 @@ class TestMainCommandLineWorkflow:
         assert migrated.verify()["format"] == 2
         assert migrated.to_list() == ["a", "b"]
 
+    def test_dry_run_exits_nonzero_when_a_list_needs_repair(
+        self, test_actor, monkeypatch, tmp_path
+    ):
+        """ "Dry run came back 0" is what an operator checks before
+        committing to the migration, so a fleet with a damaged list in it
+        must not produce one."""
+        import migrate_property_lists as script  # type: ignore[import-not-found]
+
+        _only_this_actor(monkeypatch, test_actor.id)
+
+        _seed_v1_list(test_actor.config, test_actor.id, "dry_exit_holed", ["a", "b"])
+        db = get_property(test_actor.config)
+        assert db.set(actor_id=test_actor.id, name="list:dry_exit_holed-0", value=None)
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "migrate_property_lists.py",
+                "--checkpoint-file",
+                str(tmp_path / "checkpoint.json"),
+            ],
+        )
+        assert script.main() == 1
+
     def test_concurrently_migrated_list_is_not_reported_as_refused(self, test_actor):
         """A list that another writer migrates between the sweep's verify()
         and migrate_to_v2()'s own fresh format re-read comes back as
@@ -253,14 +367,14 @@ class TestMainCommandLineWorkflow:
 
         real_migrate = ListProperty.migrate_to_v2
 
-        def _migrate_after_someone_else_did(self):
+        def _migrate_after_someone_else_did(self, allow_damaged=False):
             # Stand in for a concurrent lazy migration landing in the gap.
             if self.name == "raced_list":
                 other = ListProperty(
                     actor_id=self.actor_id, name=self.name, config=self.config
                 )
                 real_migrate(other)
-            return real_migrate(self)
+            return real_migrate(self, allow_damaged=allow_damaged)
 
         with mock.patch.object(
             ListProperty, "migrate_to_v2", _migrate_after_someone_else_did

--- a/tests/integration/test_property_list_migration.py
+++ b/tests/integration/test_property_list_migration.py
@@ -137,7 +137,14 @@ class TestMigrateToV2Direct:
         assert fresh.to_list() == before_items
         assert fresh.to_indexed_list() == before_indexed
 
-    def test_holed_list_migrates_with_hole_closed(self, test_actor):
+    def test_holed_list_is_refused_and_keeps_serving_v1(self, test_actor):
+        """A hole must block migration by default.
+
+        Migrating a holed list is not merely lossy -- it is UNREPORTABLY
+        lossy. The survivors are renumbered, the hole is gone, and the
+        migrated list verifies healthy, so nothing afterwards can tell
+        that an item went missing. Refusing keeps the damage on the books
+        until an operator decides what to do about it."""
         _seed_v1_list(
             test_actor.config, test_actor.id, "migrate_holed", ["a", "b", "c", "d"]
         )
@@ -146,14 +153,59 @@ class TestMigrateToV2Direct:
         prop_list = ListProperty(test_actor.id, "migrate_holed", test_actor.config)
         result = prop_list.migrate_to_v2()
 
+        assert result["migrated"] is False
+        assert result["reason"] == "damaged"
+        assert result["missing_indices"] == [1]
+
+        fresh = ListProperty(test_actor.id, "migrate_holed", test_actor.config)
+        assert fresh.verify().get("format") != 2
+        # Still v1, still damaged, still saying so.
+        assert fresh.verify()["missing_indices"] == [1]
+
+    def test_holed_list_migrates_with_hole_closed_when_allowed(self, test_actor):
+        """--migrate-damaged's library equivalent: the operator asked, so
+        the hole is closed -- and note what the assertions below pin, which
+        is exactly why the default is a refusal. After this call there is
+        no way left to discover that ``b`` was ever there."""
+        _seed_v1_list(
+            test_actor.config, test_actor.id, "migrate_holed_ok", ["a", "b", "c", "d"]
+        )
+        _punch_hole(test_actor.config, test_actor.id, "migrate_holed_ok", 1)
+
+        prop_list = ListProperty(test_actor.id, "migrate_holed_ok", test_actor.config)
+        result = prop_list.migrate_to_v2(allow_damaged=True)
+
         assert result["had_holes"] is True
         assert result["item_count"] == 3
 
-        fresh = ListProperty(test_actor.id, "migrate_holed", test_actor.config)
+        fresh = ListProperty(test_actor.id, "migrate_holed_ok", test_actor.config)
         assert fresh.to_list() == ["a", "c", "d"]
         assert fresh.verify()["healthy"] is True
 
+    def test_orphan_row_is_refused_too(self, test_actor):
+        """Orphans (rows past the recorded length) gate the same way holes
+        do -- migration drops them silently, since it only reads
+        ``[0, stored_length)``."""
+        _seed_v1_list(test_actor.config, test_actor.id, "migrate_orphan", ["a", "b"])
+        db = get_property(test_actor.config)
+        assert db.set(
+            actor_id=test_actor.id,
+            name="list:migrate_orphan-2",
+            value=json.dumps("stranded"),
+        )
+
+        prop_list = ListProperty(test_actor.id, "migrate_orphan", test_actor.config)
+        result = prop_list.migrate_to_v2()
+
+        assert result["migrated"] is False
+        assert result["reason"] == "damaged"
+        assert result["orphan_indices"] == [2]
+
     def test_duplicate_residue_migrates_preserved_and_reported(self, test_actor):
+        """Duplicates migrate freely, unlike holes, and this test says why:
+        the last assertion shows the duplicate is STILL reported after the
+        migration. Nothing is hidden by converting it, so there is nothing
+        for a refusal to protect."""
         _seed_v1_list(test_actor.config, test_actor.id, "migrate_dup", ["a", "b", "c"])
         db = get_property(test_actor.config)
         # Duplicate residue: index 2 holds the same value as index 1.
@@ -166,9 +218,11 @@ class TestMigrateToV2Direct:
         prop_list = ListProperty(test_actor.id, "migrate_dup", test_actor.config)
         result = prop_list.migrate_to_v2()
 
+        assert result["migrated"] is True
         assert result["duplicate_count"] == 1
         fresh = ListProperty(test_actor.id, "migrate_dup", test_actor.config)
         assert fresh.to_list() == ["a", "b", "b"]
+        assert fresh.verify()["adjacent_duplicates"]
 
     def test_refuses_name_with_hash_and_keeps_serving_v1(self, test_actor):
         _seed_v1_list(test_actor.config, test_actor.id, "a-#x", ["a", "b"])

--- a/tests/test_property_list_integrity.py
+++ b/tests/test_property_list_integrity.py
@@ -1485,3 +1485,83 @@ class TestDuplicateDetectionAfterAnEdit:
         assert report["duplicate_identities"] == {}
         assert report["identity_checked_count"] == 2
         assert report["healthy"] is True
+
+
+class TestCompactIsNotCrashSafe:
+    """Pins the documented interruption states of v1 ``compact()``.
+
+    Repair writes survivors to their new positions before deleting the tail,
+    so an interruption leaves a copy at both -- with the stored length
+    unchanged, which means the list reads back with NO error. Documented in
+    compact()'s docstring, the property-lists guide and the migration
+    guide's repair step; this test is what keeps those honest.
+
+    The sharp part is the last assertion: re-running compact() does not
+    clean it up, because duplicates are preserved by design -- including the
+    one the interrupted repair itself created.
+    """
+
+    @staticmethod
+    def _seed_holed(store, actor_id, name):
+        # [a, <hole>, c, d] with the length still claiming 4.
+        for i, v in [(0, "a"), (2, "c"), (3, "d")]:
+            store[(actor_id, f"list:{name}-{i}")] = json.dumps(v)
+        store[(actor_id, f"list:{name}-meta")] = json.dumps(
+            {
+                "length": 4,
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+                "item_type": "json",
+                "chunk_size": 1,
+                "version": "1.0",
+                "description": "",
+                "explanation": "",
+            }
+        )
+
+    @pytest.mark.parametrize(
+        ("calls_before_crash", "expected_rows"),
+        [(2, ["a", "c", "c", "d"]), (3, ["a", "c", "d", "d"])],
+    )
+    def test_interrupted_repair_leaves_a_readable_duplicate(
+        self, monkeypatch, fake_store, calls_before_crash, expected_rows
+    ):
+        actor_id = f"actor-compact-crash-{calls_before_crash}"
+        name = "damaged"
+        self._seed_holed(fake_store, actor_id, name)
+        monkeypatch.setattr(
+            "actingweb.property_list.get_property_list",
+            lambda config: _FakePropertyList(fake_store),
+        )
+        counter = [0]
+        _patch_get_property(
+            monkeypatch,
+            lambda config: CrashInjectingPropertyDb(
+                fake_store, calls_before_crash=calls_before_crash, call_counter=counter
+            ),
+        )
+
+        prop_list = ListProperty(actor_id=actor_id, name=name, config=object())
+        with pytest.raises(DbError):
+            prop_list.compact()
+
+        # No error on read: the length still matches the rows present, so
+        # nothing is structurally inconsistent -- it is just wrong.
+        _patch_get_property(monkeypatch, lambda config: FakePropertyDb(fake_store))
+        fresh = ListProperty(actor_id=actor_id, name=name, config=object())
+        assert fresh.to_list() == expected_rows
+        assert _meta_length(fake_store, actor_id, name) == 4
+
+        # verify() does catch it -- the copy is adjacent and byte-identical.
+        report = fresh.verify()
+        assert report["adjacent_duplicates"]
+        assert report["healthy"] is False
+
+        # But repair will not remove it: duplicates are preserved by design,
+        # including the one the interrupted repair created.
+        fresh.compact()
+        after = ListProperty(actor_id=actor_id, name=name, config=object())
+        assert after.to_list() == expected_rows, (
+            "re-running repair must not silently collapse the duplicate -- "
+            "and equally must not be mistaken for cleaning it up"
+        )

--- a/thoughts/todo/v2-compact-staged-commit.md
+++ b/thoughts/todo/v2-compact-staged-commit.md
@@ -1,4 +1,4 @@
-# `_v2_compact()` needs a recoverable commit protocol
+# `compact()` needs a recoverable commit protocol (BOTH formats)
 
 `ListProperty._v2_compact()` rebalances a v2 list's fractional rank keys by
 writing every item under a fresh, evenly-spaced rank and then deleting the old
@@ -10,6 +10,22 @@ all of them as genuine items, and rebalances the doubled list.
 Raised as a P1 on PR #121 (Codex review, `actingweb/property_list.py:1186`) and
 accepted as real. Not fixed there: the fix is a protocol change, not a patch,
 and the current behaviour is the safer of the two obvious options.
+
+## v1 has the same window, and it was missed until after rc5 shipped
+
+This todo was written about `_v2_compact()`. The v1 path has the identical
+shape and is the one every upgrading operator runs, via
+`actingweb-verify-property-lists --repair`: survivors are written to their
+new positions before the tail is deleted, so an interruption leaves a copy
+at both. Measured on a 4-slot list with one hole — interrupting after the
+first move gives `[a, c, c, d]`, after the second `[a, c, d, d]`, with the
+stored length still 4, so the list reads back with **no error**.
+
+`verify()` catches it via the adjacent byte-identical heuristic, which is
+better than v2 manages. But re-running `--repair` will not remove it:
+duplicates are preserved by design, so the tool declines to touch the
+residue its own interruption created. Documented in rc5+1; a fix must cover
+both formats.
 
 ## Why the obvious fix is worse
 


### PR DESCRIPTION
## What

Two things, one release.

**1. Migration refuses a damaged list** (the behaviour change).

`actingweb-migrate-property-lists --migrate` and `ListProperty.migrate_to_v2()` now refuse a list whose `verify()` reports missing or orphaned indices. The dry run reports those lists as needing repair rather than counting them as "would migrate", and exits `1` — so a dry run exiting `0` means the migration has nothing to trip over.

Migrating damaged data is not merely lossy but **unreportably** lossy. Migration renumbers the surviving rows, so afterwards the hole is gone, the list verifies healthy, and nothing is left to say an item was ever destroyed.

In rc5 the dry run warned about duplicate residue and said nothing whatsoever about holes. A sweep over a fleet containing a known hole could therefore report "0 refused, 0 errors" — that is not hypothetical, it is what a downstream consumer's recorded baseline says — and an operator would proceed in good faith, past the last moment the damage was visible.

Lazy migration already refused damaged lists on exactly these grounds. This applies the same rule to the deliberate path.

- `--migrate-damaged` / `migrate_to_v2(allow_damaged=True)` for an operator who has looked at the damage and decided to move on; it logs what it is giving up
- refusals keep the actor out of the checkpoint and fail the run, the same as a `#`-named list
- a migration that closed holes now logs at WARNING, not INFO

**Duplicates deliberately still migrate.** A duplicate stays visible after conversion — a v2 list's `verify()` reports duplicates the same way a v1 list's does — so migrating it destroys no evidence. Only holes and orphans gate. The existing duplicate test now asserts this explicitly.

**2. `compact()` is not crash-safe in EITHER format** (documentation, originally this PR).

Only the v2 rank-rebalance window was documented in rc5. The v1 path — the one every upgrading operator runs via `--repair` — has the same shape: survivors are written to their new positions before the tail rows are deleted, so an interruption leaves a copy at both, with the stored length unchanged. Measured on a 4-slot list with one hole: `[a, c, c, d]` after the first move, `[a, c, d, d]` after the second, **both reading back with no error**. `verify()` catches it, but re-running `--repair` will not remove the copy, because duplicates are preserved by design — including the one the interrupted repair created.

## Testing

- Five new regression tests, all confirmed to fail with the guards reverted (dry-run reporting, `--migrate` refusal, `--migrate-damaged`, orphan rows, `main()`'s exit code)
- `TestCompactIsNotCrashSafe` pins the measured v1 interruption states, including that a second `compact()` does **not** clean them up — that assertion fails if someone later makes repair collapse duplicates, which would silently bless real data loss
- 2761 passed, 26 skipped; ruff, pyright, and `sphinx-build -W` clean

## Docs

Migration guide gains an rc6 section and a repair-before-migrate gate on step 4; the property-lists guide gains a warning box on the refusal. Also corrects two statements left stale when lazy migration's default went to 0 in rc5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)