### PR TITLE
Skip heavy CI jobs for documentation-only PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,12 +3,17 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # Don't spend review tokens on internal planning docs. `paths-ignore` is
+    # safe HERE — unlike tests.yml, this workflow is not a required status
+    # check, so a PR that never triggers it is still mergeable.
+    #
+    # Deliberately narrow: user-facing docs (docs/**, *.rst) still get a review.
+    # Widen this list if reviewing prose isn't worth the tokens.
+    paths-ignore:
+      - 'thoughts/**'
+      - 'AGENTS.md'
+      - 'CLAUDE.md'
+      - 'TODO.md'
 
 jobs:
   claude-review:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,112 @@ on:
     branches: [ master, main, develop ]
 
 jobs:
+  # Classify the PR's changed files so a docs-only PR doesn't pay for the full
+  # matrix. Every heavy job below is gated on this job's outputs.
+  #
+  # Why a filter job and NOT `on.pull_request.paths-ignore`: master requires
+  # "Tests (Python 3.11, dynamodb)", "Tests (Python 3.11, postgresql)",
+  # "Documentation Build" and "type-check". A workflow skipped by a path filter
+  # never creates those check runs at all, so a docs PR would wait forever on
+  # statuses that can never report. A job skipped by an `if:` condition DOES
+  # create its check run (conclusion: skipped), which satisfies the requirement.
+  # Keep it that way — moving these filters up to the `on:` block will silently
+  # make every docs PR unmergeable.
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    name: Detect changes
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+      docs: ${{ steps.filter.outputs.docs }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Classify changed files
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Deliberately NOT `set -e`. A skipped job satisfies a required check,
+          # so any failure to classify must fall back to running EVERYTHING —
+          # otherwise a broken filter would wave an untested PR through green.
+          set -uo pipefail
+
+          run_everything() {
+            echo "::warning::$1 — running the full suite."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "docs=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          if [ -z "${BASE_SHA:-}" ] || [ -z "${HEAD_SHA:-}" ]; then
+            run_everything "Base or head SHA missing"
+          fi
+
+          # Three-dot: everything on the PR branch since it diverged from base.
+          if ! FILES=$(git diff --name-only "$BASE_SHA...$HEAD_SHA"); then
+            run_everything "Could not diff $BASE_SHA...$HEAD_SHA"
+          fi
+
+          if [ -z "$FILES" ]; then
+            run_everything "Empty changed-file list"
+          fi
+
+          echo "Changed files:"
+          echo "$FILES" | sed 's/^/  /'
+
+          code=false
+          docs=false
+
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              # Neither built by Sphinx nor read by any CI step. Note this list
+              # is deliberately short: `tests/integration/XDIST_GROUPS.md` must
+              # NOT be here, because verify_groups.py parses it during the test
+              # job — a Markdown file that is genuinely part of CI.
+              thoughts/*|AGENTS.md|CLAUDE.md|TODO.md)
+                ;;
+              # Sphinx sources. source_suffix is .rst only, so .md under docs/
+              # isn't built — but it's still a docs change, and treating it as
+              # one costs a docs build, not a 30-minute matrix.
+              docs/*|*.rst|conf.py)
+                docs=true
+                ;;
+              # Everything else: code, CI config, packaging, test fixtures.
+              # docs=true as well because sphinx.ext.autodoc pulls docstrings
+              # out of actingweb/**, so code can break the docs build.
+              *)
+                code=true
+                docs=true
+                ;;
+            esac
+          done <<< "$FILES"
+
+          echo "code=$code" >> "$GITHUB_OUTPUT"
+          echo "docs=$docs" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### CI scope for this PR"
+            echo ""
+            echo "| Job group | Will run |"
+            echo "| --- | --- |"
+            echo "| Tests (both backends) + type-check | \`$code\` |"
+            echo "| Documentation Build | \`$docs\` |"
+            if [ "$code" = "false" ] && [ "$docs" = "false" ]; then
+              echo ""
+              echo "Docs-only change with no Sphinx sources touched — all heavy jobs skipped."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
   tests:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -189,8 +294,10 @@ jobs:
 
   test-summary:
     runs-on: ubuntu-latest
-    needs: tests
-    if: always() && github.event_name == 'pull_request'
+    needs: [changes, tests]
+    # always() so the summary still posts when a backend fails, but not when the
+    # tests job was skipped — there would be no artifacts to download.
+    if: always() && needs.changes.outputs.code == 'true' && github.event_name == 'pull_request'
 
     steps:
       - name: Download test results
@@ -299,6 +406,8 @@ jobs:
             });
 
   type-check:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
@@ -336,6 +445,8 @@ jobs:
         run: poetry run ruff check actingweb tests
 
   docs:
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     name: Documentation Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,10 +12,15 @@ jobs:
   # "Tests (Python 3.11, dynamodb)", "Tests (Python 3.11, postgresql)",
   # "Documentation Build" and "type-check". A workflow skipped by a path filter
   # never creates those check runs at all, so a docs PR would wait forever on
-  # statuses that can never report. A job skipped by an `if:` condition DOES
-  # create its check run (conclusion: skipped), which satisfies the requirement.
-  # Keep it that way — moving these filters up to the `on:` block will silently
-  # make every docs PR unmergeable.
+  # statuses that can never report. Moving these filters up to the `on:` block
+  # will silently make every docs PR unmergeable.
+  #
+  # A job skipped by an `if:` condition DOES create its check run (conclusion
+  # skipped, which satisfies the requirement) — but ONLY for a job without a
+  # matrix. See the long comment on `tests` below: a skipped MATRIX job is not
+  # expanded, so it reports under the unexpanded name and the two required
+  # per-backend contexts are never created. That is why `type-check` and `docs`
+  # are gated at job level and `tests` is gated per step.
   changes:
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -120,7 +125,20 @@ jobs:
 
   tests:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    # NO job-level `if:` here, unlike type-check and docs below. GitHub
+    # evaluates a job-level `if:` BEFORE expanding `strategy.matrix`, so a
+    # skipped matrix job is never instantiated and its check run is reported
+    # under the LITERAL, unexpanded name
+    # "Tests (Python ${{ matrix.python-version }}, ${{ matrix.backend }})".
+    # The required contexts "Tests (Python 3.11, dynamodb)" and
+    # "Tests (Python 3.11, postgresql)" would then never be created at all and
+    # would sit pending forever, making every docs-only PR unmergeable.
+    # Measured on PR #125, not assumed.
+    #
+    # So the job always runs and every step is gated instead. The job reports
+    # success under the correct expanded name, at the cost of starting the
+    # runner and its service containers (~30s) on a docs-only PR.
+    # If you add a step here, GATE IT — an unguarded step runs on docs PRs.
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -153,14 +171,17 @@ jobs:
 
     steps:
       - name: Checkout code
+        if: needs.changes.outputs.code == 'true'
         uses: actions/checkout@v5
 
       - name: Set up Python
+        if: needs.changes.outputs.code == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install Poetry
+        if: needs.changes.outputs.code == 'true'
         uses: snok/install-poetry@v1
         with:
           version: 1.7.0
@@ -168,6 +189,7 @@ jobs:
           virtualenvs-in-project: true
 
       - name: Load cached venv
+        if: needs.changes.outputs.code == 'true'
         id: cached-poetry-dependencies
         uses: actions/cache@v5
         with:
@@ -175,11 +197,11 @@ jobs:
           key: venv-${{ runner.os }}-${{ matrix.backend }}-${{ hashFiles('**/poetry.lock') }}
 
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true' && needs.changes.outputs.code == 'true'
         run: poetry install --no-interaction --with dev --extras "all"
 
       - name: Run PostgreSQL migrations
-        if: matrix.backend == 'postgresql'
+        if: matrix.backend == 'postgresql' && needs.changes.outputs.code == 'true'
         run: |
           cd actingweb/db/postgresql
           poetry run alembic upgrade head
@@ -191,7 +213,7 @@ jobs:
           PG_DB_PASSWORD: testpassword
 
       - name: Wait for DynamoDB to be ready
-        if: matrix.backend == 'dynamodb'
+        if: matrix.backend == 'dynamodb' && needs.changes.outputs.code == 'true'
         run: |
           echo "Waiting for DynamoDB to be ready..."
           for i in {1..30}; do
@@ -206,11 +228,13 @@ jobs:
           exit 1
 
       - name: Verify xdist groups
+        if: needs.changes.outputs.code == 'true'
         run: |
           echo "Verifying xdist group documentation..."
           poetry run python tests/integration/verify_groups.py
 
       - name: Run all tests in parallel
+        if: needs.changes.outputs.code == 'true'
         run: |
           echo "Collecting tests..."
           poetry run pytest tests/ --collect-only -q
@@ -266,7 +290,7 @@ jobs:
           PG_DB_PASSWORD: testpassword
 
       - name: Report test flakiness
-        if: always()
+        if: always() && needs.changes.outputs.code == 'true'
         run: |
           echo "Analyzing test results for flakiness..."
           if [ -f test-results/tests-${{ matrix.backend }}.xml ]; then
@@ -279,20 +303,21 @@ jobs:
           fi
 
       - name: Upload test results
-        if: always()
+        if: always() && needs.changes.outputs.code == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: test-results-${{ matrix.backend }}
           path: test-results/
 
       - name: Upload coverage
-        if: always()
+        if: always() && needs.changes.outputs.code == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report-${{ matrix.backend }}
           path: htmlcov-${{ matrix.backend }}/
 
       - name: Upload coverage to Codecov
+        if: needs.changes.outputs.code == 'true'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,6 +76,16 @@ jobs:
               # job — a Markdown file that is genuinely part of CI.
               thoughts/*|AGENTS.md|CLAUDE.md|TODO.md)
                 ;;
+              # CHANGELOG.rst is a Sphinx source AND a test input — the same
+              # trap as XDIST_GROUPS.md above. tests/test_version_consistency.py
+              # asserts its version matches pyproject.toml/__init__.py and that
+              # the "Unreleased" section is present, and CLAUDE.md asks every PR
+              # to add an entry here. Must come before the *.rst branch: bash
+              # `case` takes the first match.
+              CHANGELOG.rst)
+                code=true
+                docs=true
+                ;;
               # Sphinx sources. source_suffix is .rst only, so .md under docs/
               # isn't built — but it's still a docs change, and treating it as
               # one costs a docs build, not a 30-minute matrix.


### PR DESCRIPTION
## Problem

A PR touching only `thoughts/` currently runs both test matrix legs, `type-check`, `Documentation Build`, `test-summary`, **and** a Claude review. None of it can be affected by the change.

## Approach

A cheap `changes` job (~15s) classifies the PR's files; the heavy jobs are gated on its outputs.

| Change set | tests + type-check | Documentation Build |
| --- | --- | --- |
| `thoughts/**`, `CLAUDE.md`, `AGENTS.md`, `TODO.md` | skipped | skipped |
| `docs/**`, `*.rst`, `conf.py` | skipped | runs |
| anything else | runs | runs |

Code implies docs as well, because `sphinx.ext.autodoc` pulls docstrings out of `actingweb/**`.

## Two things this deliberately does not do

**It does not use `on.pull_request.paths-ignore`.** `master` requires four checks (`Tests (Python 3.11, dynamodb)`, `Tests (Python 3.11, postgresql)`, `Documentation Build`, `type-check`). A workflow skipped by a path filter never *creates* those check runs, so a docs PR would wait forever on statuses that can never report. A job skipped by an `if:` condition does create its check run. There is a comment in the file warning against "simplifying" this back.

**It does not skip on `**/*.md`.** `tests/integration/XDIST_GROUPS.md` is parsed by `verify_groups.py:30` during the test job — a Markdown file that genuinely is part of CI, so it must keep triggering the tests that validate it.

## Fail-open

A skipped job satisfies a required check, so a broken classifier would wave an untested PR through green. A missing SHA, a failed diff, or an empty file list therefore runs the full suite and emits a `::warning::`.

## Verification

- Classifier exercised against 10 change sets (including `XDIST_GROUPS.md`, `docs/*.md`, and mixed docs+code) — all classify as intended.
- All three fail-open branches confirmed to emit `code=true docs=true`.
- Expression wiring checked character-by-character: job id `changes`, outputs `code`/`docs`, step id `filter`. A typo there would parse fine and silently skip everything.

**This PR itself touches `.github/`, so it classifies as `code=true` and runs the full suite** — the filter cannot skip validation of its own change. The behaviour under a docs-only change is proven by the follow-up `thoughts/`-only PR, not by this one.

## Follow-up for a maintainer

A `changes` **job** failure (runner loss, checkout failure) still skips everything downstream and merges green; the fail-open above covers step errors, not job death. Closing that means adding **"Detect changes"** to the required status checks — worth doing deliberately, since it also means a flaky filter job blocks all PRs. If taken, it must be applied **after** this merges, or every open PR blocks on a check that does not exist yet.

No CHANGELOG entry: no consumer-visible change, and there is no precedent for CI-only entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)