### PR TITLE
[probe] docs-only CI behaviour — do not merge

### DIFF
--- a/thoughts/todo/.ci-probe.md
+++ b/thoughts/todo/.ci-probe.md
@@ -1,0 +1,4 @@
+# CI probe
+
+Temporary. Verifies whether a matrix job skipped by a job-level `if:`
+still instantiates its per-matrix check runs. Deleted after the answer.


### PR DESCRIPTION
Temporary probe. Diff is one `thoughts/` file, so the filter returns `code=false`/`docs=false`.

Question: do `Tests (Python 3.11, dynamodb)` and `Tests (Python 3.11, postgresql)` appear as **skipped** check runs, or not appear at all? Codex flagged (P1 on #123) that a job-level `if:` is evaluated before `strategy.matrix` expands, which would leave those required contexts permanently pending on master.

Closed and deleted once observed.