### PR TITLE
[probe] docs-only — do not merge

### DIFF
--- a/thoughts/todo/.ci-probe.md
+++ b/thoughts/todo/.ci-probe.md
@@ -1,0 +1,3 @@
+# CI probe
+
+Temporary.


### PR DESCRIPTION
Diff is one `thoughts/` file, so the filter returns code=false/docs=false. Observing whether the matrix jobs instantiate their per-matrix check runs when skipped. Temporary.