### PR TITLE
Add todo/INDEX.md; audit plan statuses and research coverage

### DIFF
--- a/thoughts/plans/2025-10-03-actingweb-mcp-protection-tests.md
+++ b/thoughts/plans/2025-10-03-actingweb-mcp-protection-tests.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: done
 ---
 
 # ActingWeb Library Protection Tests for actingweb_mcp Implementation Plan

--- a/thoughts/plans/2025-12-14-remaining-handlers-analysis.md
+++ b/thoughts/plans/2025-12-14-remaining-handlers-analysis.md
@@ -1,5 +1,6 @@
 ---
 status: done
+verified: thoughts/verifications/2025-12-14-handler-refactoring-initiative-complete.md
 ---
 
 # Remaining Handlers Analysis

--- a/thoughts/plans/2025-12-18-test-coverage-improvements.md
+++ b/thoughts/plans/2025-12-18-test-coverage-improvements.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: done
 ---
 
 # Test Coverage Improvements Implementation Plan

--- a/thoughts/plans/2026-01-20-auto-subscription-handling.md
+++ b/thoughts/plans/2026-01-20-auto-subscription-handling.md
@@ -1,5 +1,5 @@
 ---
-status: active
+status: done
 ---
 
 # Automatic Subscription Handling Implementation Plan

--- a/thoughts/plans/2026-01-25-fastapi-async-handler-optimization.md
+++ b/thoughts/plans/2026-01-25-fastapi-async-handler-optimization.md
@@ -1,5 +1,5 @@
 ---
-status: proposed
+status: done
 ---
 
 # FastAPI Async Handler Optimization

--- a/thoughts/plans/2026-02-01-subscription-sync-redundancy-fix.md
+++ b/thoughts/plans/2026-02-01-subscription-sync-redundancy-fix.md
@@ -1,11 +1,24 @@
 ---
-status: active
+status: done
 ---
 
 # Subscription Sync Redundancy Fix
 
 **Date**: 2026-02-01 (Updated: 2026-02-02)
-**Status**: Phase 0 & 0.5 Complete - Critical Bugs Fixed, New Critical Bug Found (Permission Diff), Performance Optimizations Pending
+**Status**: ~~Phase 0 & 0.5 Complete - Critical Bugs Fixed, New Critical Bug Found (Permission Diff), Performance Optimizations Pending~~
+
+> **Corrected 2026-08-14 — this status line was stale; the plan is `done`.** The
+> permission-diff asymmetry was fixed via **Option A** as recommended:
+> `_build_callback_data()` now sends the full effective permission set through
+> `_get_effective_permissions()` (`actingweb/trust_permissions.py:392`), so the
+> prerequisite this plan put on incremental sync was met before that landed.
+> Phase 1 (incremental sync) is in `actingweb/handlers/callbacks.py:804`; Phase 2
+> (capability staleness) is in `subscription_manager.py`. **Phase 3 is
+> superseded** — the permission callback no longer calls full `sync_peer()`, so
+> there is no redundant permission fetch left to skip. **Phase 4 is moot** — its
+> premise was the profile-extraction bug Phase 0 fixed
+> (`tests/integration/test_peer_profile_extraction.py`). No remainder was
+> carried to `todo/`.
 **Priority**: HIGH - Correctness + Performance Impact
 
 ## Overview

--- a/thoughts/plans/2026-07-30-mcp-trust-cache-crosses-clients.md
+++ b/thoughts/plans/2026-07-30-mcp-trust-cache-crosses-clients.md
@@ -1,5 +1,6 @@
 ---
 status: done
+verified: thoughts/verifications/2026-07-31-mcp-trust-cache-crosses-clients.md
 ---
 
 # Implementation Plan: MCP trust cache client crossing (authorization bypass)

--- a/thoughts/research/2026-08-13-mcp-2026-07-28-stateless-revision.md
+++ b/thoughts/research/2026-08-13-mcp-2026-07-28-stateless-revision.md
@@ -1,0 +1,413 @@
+# Research: MCP 2026-07-28 stateless revision — what it means for the library's hand-rolled MCP handler
+
+**Date:** 2026-08-13
+**Branch:** master
+**Commit:** 3c497a3 (v3.13.0rc6)
+
+## Research Question
+
+The MCP specification revision published 2026-07-28 (SEP-2567, SEP-2575)
+removes the `initialize` handshake and protocol-level sessions, making MCP a
+stateless request/response protocol. ActingWeb implements MCP by hand and
+advertises support up to `2025-11-25`.
+
+What does the revision change, what breaks, and what would the library have to
+do to serve modern clients?
+
+## Summary
+
+**This is a breaking protocol change with no automatic fall-forward, and the
+library owns all of it.** `actingweb/mcp/protocol.py:4-6` states the position
+plainly: the library implements MCP by hand and does not depend on the official
+`mcp` SDK. Nothing arrives for free on an SDK bump — but equally, no SDK bump
+can break us. The whole 2026-07-28 surface is ours to implement or decline.
+
+**Nothing is broken today, and the reason is a happy accident worth
+protecting.** The spec's compatibility model has three client eras, not two.
+*Modern → legacy* fails, but ***dual-era* → legacy explicitly "Works"**, via a
+client-side fallback triggered by a `4xx` whose body is **not** a recognised
+modern error. Traced through our code: a 2026-07-28 request carries
+`MCP-Protocol-Version: 2026-07-28`, hits `_resolve_request_protocol_version`
+(`actingweb/handlers/mcp.py:1390-1426`), and returns HTTP 400 + JSON-RPC
+`-32600` — a *standard* code, outside the MCP-reserved `-32020`–`-32099` range.
+The spec: *"Anything else identifies a legacy server."* The client then falls
+back to `initialize`, which we serve and which we deliberately exempt from
+version validation (`actingweb/handlers/mcp.py:377-382`).
+
+**The most important finding is a negative one: do not "improve" that error.**
+Returning a spec-shaped `-32022` with a `data.supported` array would *break*
+dual-era clients — `-32022` identifies a **modern** server, so the client would
+stop falling back and instead retry a modern-shaped request declaring
+`2025-11-25`, which is incoherent because that version requires `initialize`.
+The current `-32600`-without-`data.supported` is the correct legacy-only
+signal. It was written as ordinary spec compliance, not as a deliberate era
+signal, and **no test asserts it in that role**.
+
+**Two mechanisms in the library become permanently dead rather than broken.**
+`Mcp-Session-Id` is read but never issued or validated
+(`actingweb/handlers/mcp.py:1428-1458`, `:2135-2168`); the downstream consumer
+records it as null on 100 % of production rows. And `_mcp_client_info_cache`
+(`:21`, `:2114-2133`) is a module-global keyed on that header with an
+`ip+hash(UA)` fallback — already unreliable in any multi-process deployment,
+which the existing `todo/mcp-cache-lifecycle-and-revocation.md` item 4 already
+tracks from a different angle.
+
+**Urgency is set entirely by a fact we could not verify:** when, or whether,
+any client ships *modern-only*. Anthropic's announcement says "rolling out
+across Claude products soon" with no per-surface dates; the Claude Code
+changelog has zero matches for the revision. Legacy clients are unaffected
+indefinitely; dual-era clients degrade to us successfully; modern-only clients
+fail by design.
+
+## Detailed Findings
+
+### 1. What the revision removes and adds
+
+Prior revision was `2025-11-25`. From the
+[changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog),
+verbatim:
+
+> Remove protocol-level sessions and the `Mcp-Session-Id` header from the
+> Streamable HTTP transport. … Servers that need cross-call state use explicit,
+> server-minted handles passed as ordinary tool arguments (SEP-2567).
+
+> Make MCP stateless: remove the `initialize`/`notifications/initialized`
+> handshake. Every request now carries its protocol version and client
+> capabilities in `_meta` … (SEP-2575).
+
+**Removed outright, not deprecated** — none appear in the
+[deprecated registry](https://modelcontextprotocol.io/specification/2026-07-28/deprecated):
+`initialize`, `notifications/initialized`, `Mcp-Session-Id` + DELETE teardown,
+`ping`, `logging/setLevel`, the standalone GET SSE stream,
+`resources/subscribe`/`unsubscribe`, SSE resumability (`Last-Event-ID`).
+
+Every one of those except the SSE machinery is something this library
+implements today.
+
+**Added, mandatory for a modern server:**
+
+| Surface | Requirement |
+| --- | --- |
+| `_meta` `io.modelcontextprotocol/protocolVersion` | **Required** on every request |
+| `_meta` `io.modelcontextprotocol/clientCapabilities` | **Required**; missing capability → `-32021` |
+| `_meta` `io.modelcontextprotocol/clientInfo` | **Optional** (SHOULD) — identity is no longer guaranteed |
+| `server/discover` | Servers **MUST** implement |
+| `MCP-Protocol-Version` header | **MUST** mirror the `_meta` field; mismatch → `-32020` |
+| `Mcp-Method`, `Mcp-Name`, `Mcp-Param-{Name}` | **REQUIRED** request headers |
+| `ttlMs` + `cacheScope` on list/read results | **MUST** include (SEP-2549) |
+| Unknown modern method | **MUST** return HTTP `404` + `-32601` |
+
+Elicitation moves to Multi Round-Trip Requests (MRTR, SEP-2322): a server
+returns `resultType: "input_required"` with an opaque `requestState` blob the
+client echoes back on a *new* request id. The spec requires servers to treat it
+as attacker-controlled — integrity protection (HMAC/AEAD), principal binding,
+TTL — and to enforce single-use server-side where that matters. **Roots,
+Sampling and Logging are newly deprecated** (SEP-2577) under a new twelve-month
+window; Dynamic Client Registration is deprecated too (still functional this
+revision). Elicitation is the surviving client feature.
+
+### 2. Where the library sits today
+
+- **Versions:** `["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"]`,
+  `LATEST` = `2025-11-25`, default-when-header-absent `2025-03-26`
+  (`actingweb/mcp/protocol.py:28-39`).
+- **Transport:** JSON-RPC over plain HTTP POST. `GET /mcp` returns a static
+  discovery dict (`actingweb/handlers/mcp.py:331-363`); no SSE, no
+  `StreamingResponse`, no DELETE route — non-GET/POST is 405
+  (`actingweb/interface/integrations/fastapi_integration.py:2365-2366`).
+- **Handler size:** `actingweb/handlers/mcp.py` 2313 lines,
+  `actingweb/handlers/async_mcp.py` 457, dispatching by hand. The value in
+  those lines is the ActingWeb-specific wiring — `_require_mcp_peer_id`
+  (`:564-594`), the permission evaluator (`:1056-1059`), trust-row writes
+  (`:2088-2096`) — not the JSON-RPC plumbing.
+- **Methods implemented:** `initialize`, `notifications/initialized`, `ping`,
+  `tools/list`, `tools/call`, `resources/list`, `resources/read`,
+  `prompts/list`, `prompts/get`. Anything else → `-32601` (`:434-436`).
+- **Not implemented:** `resources/templates/list`, `resources/subscribe`,
+  `completion/complete`, `logging/setLevel`, sampling, roots. `elicit` appears
+  nowhere in the codebase.
+- **Client capabilities are never parsed.** `_handle_initialize`
+  (`:492-562`) reads only `protocolVersion` and `clientInfo`. A modern server
+  MUST enforce declared capabilities and return `-32021` when one is missing —
+  we have no machinery for that at all.
+
+### 3. The fallback path, traced
+
+First contact from a 2026-07-28 client against the library as it stands:
+
+1. Any method other than `initialize` carries `MCP-Protocol-Version: 2026-07-28`.
+2. `_resolve_request_protocol_version` (`actingweb/handlers/mcp.py:1409-1423`)
+   reads the header (both casings), finds it unsupported, sets HTTP 400 and
+   returns JSON-RPC `-32600` with message
+   `"Unsupported MCP-Protocol-Version: 2026-07-28"`.
+3. `-32600` is a standard JSON-RPC code. The MCP-reserved range is
+   `-32020`–`-32099`, holding exactly `HeaderMismatch` (`-32020`),
+   `MissingRequiredClientCapability` (`-32021`) and
+   `UnsupportedProtocolVersion` (`-32022`).
+4. Per the spec's HTTP detection procedure, a body that is *not* a recognised
+   modern error means "legacy server" → the client falls back to `initialize`.
+5. We serve `initialize` and deliberately skip header validation on it
+   (`:377-382`), so the fallback lands on a working path.
+6. Era determination is cached per origin, so the cost is **one** rejected
+   request per client, not per call.
+
+The relevant matrix rows, verbatim from
+[Versioning and Compatibility](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning):
+
+> | Modern | Legacy | **Fails.** The server may reject the request with an
+> implementation-defined error, stay silent, or even process an era-ambiguous
+> method under legacy semantics. …
+
+> | Dual-era | Legacy | **Works.** … HTTP: the modern request returns a `4xx`
+> without a recognized modern error body, and the client falls back to
+> `initialize` …
+
+**Residual risk.** The probe is `MAY`, body inspection is `SHOULD`, and the
+fallback instruction itself carries **no RFC-2119 keyword**. "Recognized modern
+JSON-RPC error" is never defined as a closed set — only via "such as". The
+spec's summary sentence (*"Anything else identifies a legacy server"*) is the
+strongest protection available. Low risk, non-zero, per-client
+implementation-dependent.
+
+**This makes the `-32600` shape load-bearing and untested-as-such.**
+`tests/test_mcp_wire_shape.py` covers version gating for `structuredContent`,
+not this. A future cleanup that "upgrades" the error to a spec-shaped `-32022`
+would read as an improvement in review and would silently break dual-era
+fallback.
+
+### 4. What becomes dead rather than broken
+
+**`Mcp-Session-Id`.** Read at `_resolve_transport_session_id`
+(`actingweb/handlers/mcp.py:1428-1458`) and `_get_session_key` (`:2135-2168`),
+surfaced to hooks as `MCPContext.transport_session_id`
+(`actingweb/runtime_context.py:134-139`). Never generated, never validated, no
+response header anywhere. The fallback key is
+`f"{client_ip}:{hash(user_agent[:50])}"`, degenerating to the placeholder
+`"unknown:0"` when IP and UA are both absent (`:1439-1441`).
+
+Downstream evidence from the consumer repo (`actingweb_mcp`): the field is
+persisted as `RunRecord.started_by_transport_session_id` and used for
+run-ownership fencing, and that repo's own code records it as **null on 100 %
+of production run records** — the header never arrives in practice. Removing it
+from the spec makes an already-inert guard permanently inert. The ownership
+check that actually runs keys on `peer_id` and is untouched.
+
+**`_mcp_client_info_cache`.** Module-global dict (`:21`), 600 s TTL
+(`:2125-2133`), keyed by the same session key. It stores `clientInfo` at
+`initialize` and reads it on later requests. With `initialize` gone and
+`clientInfo` optional-per-request, its write path disappears. Note the library
+already reads `clientInfo` opportunistically on non-`initialize` requests
+(`:414-416`, *"MCP clients send clientInfo with many requests, not just
+initialize"*) — which is directionally what the new revision formalises.
+
+Durable client identity survives regardless: `_update_trust_with_client_info`
+(`:2088-2096`) writes `client_name`/`client_version`/`client_platform` onto the
+trust row, and `get_client_info_from_context`
+(`actingweb/runtime_context.py:430-479`) falls back to it.
+
+**`_handle_notifications_initialized`** (`actingweb/handlers/mcp.py:392-393`,
+`:1361-1370`) loses its caller entirely — the notification it answers no longer
+exists in the modern revision. It currently responds even to a true
+notification (returning `"id": null`) because, per its own comment, some
+clients send it as a request.
+
+Existing related item: `todo/mcp-cache-lifecycle-and-revocation.md` §4 already
+flags `_mcp_client_info_cache` as keyed by a client-supplied header, and §2 the
+absence of cross-process invalidation.
+
+### 5. What a dual-era server would have to do
+
+The spec permits one endpoint to serve both eras:
+
+> A dual-era **server** selects its behavior from how the client opens:
+> * A request carrying modern per-request `_meta` is served statelessly …
+> * An `initialize` request selects legacy semantics …
+
+**The discipline is: branch on the presence of modern `_meta`, never on method
+name.** `ping` is the documented trap — it takes no parameters, so nothing in
+its shape distinguishes eras. A `ping` carrying modern `_meta` is a modern
+request for a method that no longer exists, and must get `404` + `-32601`; a
+`ping` without it is legacy and answered normally. Answering every `ping`
+unconditionally lets a half-modern client conclude we support a removed method.
+
+`notifications/initialized` has the identical shape and needs the identical
+treatment: no meaningful params, unauthenticated, and removed in 2026-07-28
+alongside `initialize`. Together with `ping` these are the library's only two
+unauthenticated methods (`actingweb/handlers/mcp.py:392-395`), and both are
+era-ambiguous by construction.
+
+Gap list against the current handler:
+
+| Needed | Status today |
+| --- | --- |
+| Modern `_meta` parsing + era branch | absent |
+| `server/discover` | absent |
+| Capability enforcement → `-32021` | capabilities never parsed (`:492-562`) |
+| Header mirroring validation → `-32020` | absent |
+| `404` + `-32601` for unknown modern methods | currently `-32601` with 200 |
+| `ttlMs` + `cacheScope` on list/read results | absent |
+| MRTR + signed `requestState` | no elicitation at all |
+| `subscriptions/listen` | needs SSE; see §6 |
+
+**A caching trap specific to this library.** `tools/list` output is
+permission-filtered per peer (`:753-759`), so it varies by caller. That forces
+`cacheScope: "private"` — `"public"` would authorise shared gateways to serve
+one actor's tool list to another. The spec permits per-credential variation but
+**forbids** per-connection variation:
+
+> The set **MAY** vary by the authorization presented on the request … since
+> credentials are per-request input, not connection state.
+
+Our filtering keys on the resolved `peer_id` from the bearer token, which is
+per-request input — compatible, but it must be `private`.
+
+### 6. Deployment shapes that constrain the answer
+
+The library is transport-agnostic, but its primary consumer runs FastAPI under
+Mangum on AWS Lambda behind API Gateway **HTTP API v2**, which buffers the full
+response. SSE is architecturally unavailable there, so `subscriptions/listen`
+(a long-lived pinned POST stream) cannot be served on that deployment
+regardless of what the library implements. It is opt-in, so this is a
+limitation rather than a compliance failure.
+
+Also relevant for any implementation that adds required request headers: the
+new `Mcp-Param-{Name}` headers are **dynamically named**, so a CORS
+`allowedHeaders` allow-list cannot enumerate them — and `'*'` is not usable
+where `Authorization` is in play. Only affects browser-based MCP clients;
+server-side clients never preflight.
+
+The module-global caches are per-process and per-warm-container; the
+statelessness the revision assumes is something this deployment already
+violates quietly rather than loudly.
+
+### 7. Documentation mismatches found while reading
+
+Recorded, not fixed:
+
+1. `actingweb/handlers/mcp.py:281` says the handler "Delegates the request to
+   the FastMCP server"; it dispatches JSON-RPC by hand and
+   `actingweb/mcp/protocol.py:4-6` says there is no SDK dependency.
+2. `actingweb/handlers/oauth2_endpoints.py:795` advertises
+   `capabilities.resources: False` in the published
+   `/.well-known/oauth-protected-resource/mcp` document, while consumers
+   register resources and `_handle_initialize` computes the capability
+   dynamically (`actingweb/handlers/mcp.py:531-536`).
+3. `actingweb/handlers/oauth2_endpoints.py:744` cites **RFC 8705** for the
+   document served at the RFC 9728 path.
+4. `actingweb/pyproject.toml:56-60` declares extras `postgresql`, `flask`,
+   `fastapi`, `all` — but consumers request `mcp` and `dynamodb`, neither of
+   which exists.
+5. Sync/async `resources/read` formatting divergence — already recorded as
+   `todo/mcp-cache-lifecycle-and-revocation.md` §8.
+
+## Decisions Needed
+
+### Decision 1: Does the library go dual-era, and when?
+
+Deferred by design — see `todo/mcp-2026-07-28-dual-era-support.md` for the
+trigger criteria this research produced.
+
+**Options:**
+
+1. **Wait for a trigger.** Zero cost. Legacy clients are unaffected and
+   dual-era clients fall back successfully. Risk: we learn a client went
+   modern-only from user reports, since the rejection currently logs at debug
+   level only.
+2. **Implement dual-era pre-emptively.** Removes timeline risk for a revision
+   no client we serve is confirmed to speak, at the cost of the §5 gap list
+   across a 2313-line handler.
+3. **Minimum modern read path only** — `server/discover`, `_meta` parsing,
+   `tools/list` + `tools/call`, caching hints — deferring MRTR and
+   `subscriptions/listen` (the latter unusable on the primary deployment).
+
+### Decision 2: Adopt the official Python SDK, or keep hand-rolling?
+
+The revision is the first change large enough to make this worth re-asking.
+`mcp` Python SDK v2.0.0 shipped 2026-07-28 with dual-era support,
+`server/discover`, `subscriptions/listen` and MRTR; v1.x is maintenance-only.
+
+**Options:**
+
+1. **Adopt the SDK.** Gets the whole modern surface for free and permanently.
+   Cost: the library's MCP layer is not JSON-RPC plumbing but ActingWeb trust
+   and permission wiring threaded through every method — `_require_mcp_peer_id`,
+   the permission evaluator, trust-row writes, the actor cache. Those would
+   have to be re-expressed against `MCPServer` and the new resolver
+   dependency-injection model. Also introduces a hard dependency the library
+   has deliberately avoided (`actingweb/mcp/protocol.py:4-6`), affecting every
+   consumer's dependency tree.
+2. **Keep hand-rolling.** Consistent with the current design and keeps the
+   trust wiring untouched; every item in §5 is then ours to write and test.
+3. **Hybrid** — SDK for wire-format/era handling, ActingWeb hooks for
+   authorization. Needs a spike to establish whether the SDK's extension points
+   can carry per-peer permission filtering on `tools/list`.
+
+### Decision 3: Protect the `-32600` era signal now?
+
+Independent of Decisions 1 and 2, and cheap.
+
+**Options:**
+
+1. **Add a regression test** asserting HTTP 400 + `-32600` **without**
+   `data.supported` for an unsupported future version, with a comment naming it
+   as the dual-era fallback trigger. Prevents a well-intentioned future
+   "upgrade" to `-32022`.
+2. **Enrich the error message string** to name supported versions. The spec
+   applies exactly this reasoning to the mirror-image case: a server SHOULD
+   name its versions because for a client with no fall-forward *"this message
+   may be the only diagnostic they can surface to users."* Must go in the
+   free-text `message`, **not** `data.supported`.
+3. **Raise the log level** on unsupported-version rejections so a client-era
+   shift is visible in telemetry rather than in user reports.
+
+These compose; they are not mutually exclusive.
+
+## Code References
+
+- `actingweb/mcp/protocol.py:4-6` — no MCP SDK dependency, by design
+- `actingweb/mcp/protocol.py:8-13` — "supported" means negotiable, not fully implemented
+- `actingweb/mcp/protocol.py:28-39` — supported versions, default `2025-03-26`
+- `actingweb/handlers/mcp.py:377-382` — `initialize` exempted from version validation
+- `actingweb/handlers/mcp.py:1390-1426` — 400 + `-32600` (the dual-era fallback trigger)
+- `actingweb/handlers/mcp.py:414-416` — `clientInfo` already read per-request
+- `actingweb/handlers/mcp.py:492-562` — `initialize`; client capabilities never parsed
+- `actingweb/handlers/mcp.py:1428-1458`, `:2135-2168` — `Mcp-Session-Id` read, never issued
+- `actingweb/handlers/mcp.py:21`, `:2114-2133` — `_mcp_client_info_cache`
+- `actingweb/handlers/mcp.py:564-594`, `:753-759`, `:1056-1059` — trust/permission wiring
+- `actingweb/handlers/mcp.py:2088-2096` — durable client identity on the trust row
+- `actingweb/handlers/mcp.py:331-363` — `GET /mcp` static discovery dict
+- `actingweb/runtime_context.py:121-146`, `:430-479` — `MCPContext`, client-info fallback
+- `actingweb/interface/integrations/fastapi_integration.py:2365-2366`, `:2380` — 405 on other methods; `JSONResponse` only
+- `actingweb/handlers/oauth2_endpoints.py:742-798` — RFC 9728 protected-resource document
+
+## External References
+
+- [MCP 2026-07-28 specification](https://modelcontextprotocol.io/specification/2026-07-28)
+- [Key Changes / changelog](https://modelcontextprotocol.io/specification/2026-07-28/changelog)
+- [Versioning and Compatibility](https://modelcontextprotocol.io/specification/2026-07-28/basic/versioning) — three-era model, compatibility matrix
+- [Streamable HTTP transport](https://modelcontextprotocol.io/specification/2026-07-28/basic/transports/streamable-http) — fallback procedure, required headers
+- [Base Protocol / `_meta` and error codes](https://modelcontextprotocol.io/specification/2026-07-28/basic/index) — reserved `-32020`–`-32099`
+- [Multi Round-Trip Requests](https://modelcontextprotocol.io/specification/2026-07-28/basic/patterns/mrtr) — `requestState`
+- [Server Utilities § Caching](https://modelcontextprotocol.io/specification/2026-07-28/server/utilities/caching) — `ttlMs`, `cacheScope`
+- [Deprecated Features registry](https://modelcontextprotocol.io/specification/2026-07-28/deprecated)
+- [Anthropic: bringing MCP 2026-07-28 to Claude](https://claude.com/blog/bringing-mcp-2026-07-28-to-claude) — "soon", no per-surface dates
+- [Python SDK v2.0.0](https://github.com/modelcontextprotocol/python-sdk/releases/tag/v2.0.0) · [v1→v2 migration](https://py.sdk.modelcontextprotocol.io/migration/)
+
+## Unverified
+
+- **Per-surface Claude rollout dates.** No published statement that 2026-07-28
+  is live in Claude.ai, Claude Desktop or Claude Code; the Claude Code
+  changelog has zero protocol-version entries. This single fact sets urgency.
+- **ChatGPT connectors' current revision** — OpenAI's docs declare none.
+- Whether any client we serve will ship **modern-only** rather than dual-era.
+- Whether the SDK's extension points could carry ActingWeb's per-peer
+  permission filtering (Decision 2 option 3) — not spiked.
+
+## Related
+
+- `todo/mcp-2026-07-28-dual-era-support.md` — trigger criteria for picking this up
+- `todo/mcp-cache-lifecycle-and-revocation.md` — §2 cross-process invalidation,
+  §4 `_mcp_client_info_cache` keyed by client-supplied header
+- `thoughts/plans/2026-05-26-mcp-version-negotiation-structuredcontent.md` — the
+  Phase 3 roadmap that `actingweb/mcp/protocol.py:8-13` defers transport
+  compliance to

--- a/thoughts/todo/2026-06-15-postgres-parallel-delete-not-persisting.md
+++ b/thoughts/todo/2026-06-15-postgres-parallel-delete-not-persisting.md
@@ -103,6 +103,11 @@ Delete those three things to re-enable; CI on the branch will then verify the fi
 
 ## Suggested investigation steps
 
+**Decided 2026-08-14** (owner walkthrough): do the first step now, on one branch
+shared with `thoughts/todo/ci-postgres-parallel-flakiness.md`. Same CI matrix,
+same conditions, and that todo's process-global psycopg pool is hypothesis 1
+here — one instrumentation pass should collect evidence for both.
+
 - [ ] Reproduce in CI deterministically: add temporary debug to `delete_attr`
       (`db/postgresql/attribute.py`) logging `cur.rowcount` after the `DELETE` and
       `current_schema()` / `search_path` for the connection. Confirm whether the

--- a/thoughts/todo/INDEX.md
+++ b/thoughts/todo/INDEX.md
@@ -1,0 +1,113 @@
+# todo/ — prioritised index
+
+Every file in this directory, ordered by what to do next. **Built 2026-08-13**
+from a full read of every file. **Last reviewed 2026-08-14** — an audit of all
+27 plans and 17 research docs for uncovered work (6 plan statuses corrected, 4
+todos added), followed by an item-by-item walkthrough with the owner (1 todo
+dropped, every row given a direction).
+
+Each row's **Decided 2026-08-14** clause is the outcome of that walkthrough. It
+records the direction taken and, where it matters, the option *not* taken.
+Rows 12 and 13 carry no such clause by design — a blocked item's trigger *is*
+its decision, and both triggers were reconfirmed unfired.
+
+**This file is a table of contents, not a source of truth.** Each row says what
+implementing it buys and why it's worth doing — one line each, deliberately.
+Everything else lives in the linked file. If a row and its file disagree, the
+file wins.
+
+**Maintaining it:** add a row when you add a todo, delete the row when you delete
+the todo. Re-rank when something lands or a trigger fires. Don't copy detail up
+here — a duplicated fact is a fact that will drift.
+
+Ordering is by *impact ÷ effort*, not by severity alone: a cheap fix to a
+moderate problem outranks an expensive fix to a slightly worse one.
+
+---
+
+## 1. Do next
+
+Real problems, in production or under it, with a known shape.
+
+| # | Item | Impact of doing it | Why now |
+| --- | --- | --- | --- |
+| 1 | [`migrate_to_v2()` needs a claim](migrate-to-v2-needs-a-claim.md) | Closes the last path where an ordinary concurrent request can **destroy committed list data** — the migration clears the v2 range and writes its own older snapshot over a list another instance already migrated *and* appended to | The trigger is **lazy**: any two mutating requests for the same actor race for it, so this is live on every 3.13 deployment's normal traffic today, and a consumer's bulk migration at GA only multiplies the attempts. Accepted as real on PR #121. A claim row via the existing `create_if_not_exists()` primitive is the cheapest close. **Decided 2026-08-14: one plan covering rows 1 and 2** — they share a storage layer, and designing the claim row and the compaction journal together avoids two divergent primitives |
+| 2 | [`compact()` needs a recoverable commit protocol](v2-compact-staged-commit.md) | An interrupted compaction stops leaving an unrecoverable double of the list — today re-running `--repair` **declines to touch the residue its own interruption created** | The v1 half is the path every upgrading operator runs (`actingweb-verify-property-lists --repair`), and the damaged list reads back with **no error**. **Trap:** deleting each old row right after writing its replacement is the obvious fix and is *worse* — it silently permutes the list, and `verify()` has no signal for that at all. Journal row is the cheap option. **Decided 2026-08-14: planned jointly with row 1** |
+| 3 | [Postgres parallel DELETE not persisting](2026-06-15-postgres-parallel-delete-not-persisting.md) | Answers whether the PG backend can silently drop a committed `DELETE` under concurrency, and lifts the quarantine on two assertions currently dark on postgresql | Open since June with no root cause — but the **decisive step is cheap and nobody has run it**: log `cur.rowcount` and `search_path` from `delete_attr` in CI, and the leading hypothesis (a pooled connection contaminated by the `property_lookup_pkey` error) either falls or stands. **Decided 2026-08-14: one instrumentation branch covering this and row 10** — same matrix, and row 10's process-global psycopg pool is this row's leading hypothesis |
+
+## 2. High leverage
+
+Bigger, designed, and each buys more than it costs.
+
+| # | Item | Impact of doing it | Why now |
+| --- | --- | --- | --- |
+| 4 | [`ListAttribute` shift-loop design](attribute-list-shift-design.md) | Removes the **last instance** of the design that caused the production list corruption — `ListAttribute` still has, verbatim, what `ListProperty` had before the 3.13 fix | Materially cheaper than when filed: the fractional-rank v2 format, its `verify()`/`compact()` primitives and its migration shape now exist and are proven, so option 3 — the only option that closes the corruption class rather than mitigating it — is mostly a port. It waited on **lower blast radius**, not on being safe. **Decided 2026-08-14: option 3, the full v2 port** — the only one that closes the class rather than mitigating it |
+| 5 | [Property fetch reads the whole partition](property-fetch-reads-whole-partition.md) (I0) | Cuts the dominant remaining read cost for list-heavy actors: one measured production actor paid **1,027 RCU to return 5 properties**, because ~1,009 `list:*` rows share its partition and are discarded client-side | Called *"the most valuable thing in this document"* by the consumer feedback that drove 3.13, and deferred **to 3.14** only because it is a hot-path rewrite on an already-validated release — that window opens at GA. 3.13 removed the *cross-actor* superlinearity, which was the important half; this is the *within-actor* half. **Invisible without per-call capacity instrumentation**, so it will not resurface on its own. **Decided 2026-08-14: re-measure against GA before designing** — the deferral rationale rests on rc1 numbers, and which fix shape is right depends on how dominant the `list:` rows still are |
+| 6 | **Revocation doesn't evict the MCP caches** — §1 of [cache-lifecycle register](mcp-cache-lifecycle-and-revocation.md) | A revoked token, deleted trust or downgraded permission actually stops working, instead of being honoured for up to the 5-minute cache TTL in every warm process | `clear_token_from_cache()` has exactly **one** caller (logout) — `revoke_token`, `revoke_all_tokens`, `/oauth/revoke`, trust deletion and permission downgrade all miss it. The tuple-keyed `_trust_cache` the trust-cache plan added already supports the eviction, so §1 is wiring, not design. Don't let §2 (cross-process invalidation, genuinely large) block it. **Decided 2026-08-14: both paths** — token-keyed eviction on the three revocation endpoints, plus direct `_trust_cache` eviction on trust deletion and permission downgrade |
+
+## 3. Real, not urgent
+
+| # | Item | Impact of doing it | Why now |
+| --- | --- | --- | --- |
+| 7 | [`subs_list` cache asymmetry](subs-list-cache-asymmetry.md) | Drops one **strongly-consistent Query per property write** for every actor with no subscribers | **The ordering is the whole item.** The one-line guard fix (`is None`) is unsafe until the cross-request `Actor` cache is dealt with: the falsy guard is exactly what stops a long-lived MCP-cached actor going permanently blind to subscriptions created in another container. The correctness half landed in rc2; landing the cost half first trades a bounded cost bug for an unbounded correctness one. **Decided 2026-08-14: take the cache-lifetime question (item 4) rather than the guard** — does `_actor_cache` hold identity/auth only, or do instance caches need a request-boundary reset? That unblocks the guard and de-risks every future memo. **Pair with row 6**, same cache module |
+| 8 | [`output_schema` on `action_hook` never reaches MCP](action-hook-output-schema-not-visible-to-mcp.md) | Closes an ergonomic trap: an author who declares `output_schema=` or annotates a `TypedDict` return reasonably believes their MCP tool advertises `outputSchema`, and it does not | Documented in rc4, unfixed, and the two decorators keep diverging. Merging **by default** would newly advertise `outputSchema` for every TypedDict-annotated tool and break the ones that return no `structuredContent` — so that decision belongs with the structuredContent research, not on its own. **Decided 2026-08-14: option 4 now** — warn at `tools/list` when `_hook_metadata` carries an `output_schema` and `_mcp_metadata` does not. Cheap, cannot false-positive, catches the confusion at registration rather than call time, and forecloses nothing |
+| 9 | [Orphan detection in the offline verifier](orphan-detection-in-verifier.md) (DEL5) | Ships the sweep every consumer writes for themselves after a deletion incident — and ships it with the four edge cases that make it safe | Purely additive; `verify_tables` already exists to host it. The reason to do it in the library is that the classification is **not obvious**: an empty actor set must yield *zero* orphans, not "everything", and system actors like `_actingweb_websocket` hold live data under ids deliberately absent from the actors table. All four cases are already written into `docs/reference/actor-deletion.rst` — start there. **Decided 2026-08-14: ship it in `verify_tables`** rather than leaving each consumer to write their own |
+| 10 | [Postgres parallel CI flakiness](ci-postgres-parallel-flakiness.md) | Removes the remaining instability the hang watchdog only bounds — a fixed-`creator` test racing two process-global singletons, a full alembic chain per xdist worker, and an unexamined `--dist loadgroup` requirement | Not the same defect as row 3 (that one is correctness, this is test infra), but same matrix and same conditions, and follow-up 1's process-global psycopg pool is row 3's leading hypothesis. **Decided 2026-08-14: one instrumentation branch shared with row 3**, which promotes this off "not urgent" as a passenger |
+
+## 4. Cheap cleanups
+
+Small, mechanical, each removes something actively misleading.
+
+| # | Item | Impact of doing it | Why now |
+| --- | --- | --- | --- |
+| 11 | **Harden the `-32600` dual-era signal** — "Cheap hardening" in [dual-era support](mcp-2026-07-28-dual-era-support.md) | Pins the behaviour that lets dual-era MCP clients fall back to us, names our supported versions where a client can surface them, and makes modern-only clients visible in telemetry rather than via user reports | **Read the trap before touching the error path.** The HTTP 400 + `-32600` we answer an unknown protocol version with **is** the legacy-server signal a dual-era client falls back on. Replacing it with a spec-shaped `-32022` + `data.supported` looks more correct and converts every dual-era client's working fallback into a retry loop — and **no test asserts it as the fallback signal**. **Decided 2026-08-14: all three items** — regression test, versions named in the `message` string (never `data.supported`), and the log level raised so row 13's trigger is observable. Needs none of the deferred work in row 13 |
+
+## 5. Blocked or waiting on someone else
+
+Nothing to do until the named thing happens. Listed so they aren't mistaken for
+neglected work.
+
+| # | Item | Waiting on |
+| --- | --- | --- |
+| 12 | [Remove the legacy property GSI machinery](legacy-property-gsi-removal.md) | The **next major version bump**. Five removals, enumerated. Note the sequencing constraint: release notes telling legacy-GSI holdouts to migrate must ship in a release that **still contains the backfill script** — so the note is written before the removal, not alongside it. Also absorbs I3 (the `use_lookup_table` three-sources-of-truth wart), which was deferred to be paired with exactly this |
+| 13 | [Dual-era MCP support](mcp-2026-07-28-dual-era-support.md) | A client we serve going **modern-only**. A dual-era client needs nothing from us, so "supports 2026-07-28" is not the signal — a *sustained* stream of 400/`-32600` from one origin is (a single one is the healthy handshake). Also blocked-adjacent: `actingweb_mcp`'s `require_mcp_auth_for_init` middleware silently becomes a no-op under the modern revision, since both of its inputs are removed |
+
+## 6. Registers — records, not schedulable work
+
+Each holds deliberately-deferred items with the rationale they were cut and the
+trigger that would justify pulling one forward. **A trigger that hasn't fired
+means the register is working**, not that it's stale. Their value is stopping
+decisions being re-litigated.
+
+| Item | What it holds |
+| --- | --- |
+| [DynamoDB known-next](dynamodb-known-next.md) | 9 items deferred from the v3.13 scalability plan — batch writes, the `consistent_read` audit, `SubscriptionDiff` seqnr ordering, import-time table-name freezing. Item 9 is row 7 above; row 5 is the adjacent per-partition defect. Line references are from `29783f8` and have **not** been re-verified since July — **decided 2026-08-14: fold a re-verification pass into the 3.13.0 GA work**, when the codebase settles |
+| [MCP cache lifecycle and revocation](mcp-cache-lifecycle-and-revocation.md) | 8 items scoped out of the trust-cache plan by name. §1 is row 6 above. §5 is worth reading even if never actioned: it records *why* the surviving substring peer-id match on the deletion path is not the bug the resolver fix closed — server-generated high-entropy client ids make it a collision, not a steerable attack |
+
+---
+
+## Conventions
+
+`thoughts/README.md` is authoritative for the directory. Four things worth
+repeating because they shape this list:
+
+- **`todo/` is living, undated.** A todo is deleted when its work lands — the
+  plan and verification are the record. Newer files here are undated by design;
+  `2026-06-15-postgres-parallel-delete-not-persisting.md` predates that
+  convention and is kept for its links.
+- **`mcp-2026-07-28-dual-era-support.md` is not a dated file.** `2026-07-28` is
+  the MCP **spec revision** the todo is about, part of the slug. Don't "fix" it
+  to an undated name and don't read it as a write date.
+- **A todo that grows phases becomes a plan.** `/create_plan` from it, then
+  either leave a stub pointing at the plan or delete the todo — the plan
+  supersedes it. Rows 1+2 are being planned jointly; row 4 is next nearest.
+- **A closed plan's unfinished remainder belongs here, not in an `active`
+  plan.** As of 2026-08-14 every plan in `plans/` is `status: done`, so
+  `grep -l "^status: active"` returning nothing is correct — it means "nobody is
+  mid-implementation", not "the grep is broken". Five plans were carrying a
+  wrong status from a 2026-07-26 bulk edit (`cc29c03`) that added the
+  frontmatter to all 27 at once; their artifacts were on disk all along. The one
+  genuine remainder that audit surfaced — the 2025-12 test-coverage plan's
+  deferred phases 5 and 6 — was filed, reviewed, and **deliberately dropped**:
+  the suite has grown far past that plan's target, so re-deriving today's gaps
+  would beat working from its list.

--- a/thoughts/todo/action-hook-output-schema-not-visible-to-mcp.md
+++ b/thoughts/todo/action-hook-output-schema-not-visible-to-mcp.md
@@ -55,6 +55,11 @@ point is to make one behaviour predictable.
 
 Option 4 is the cheapest real improvement and is independent of the rest.
 
+**Decided 2026-08-14** (owner walkthrough): **option 4 now.** It catches the
+confusion at registration rather than call time, cannot false-positive, and
+forecloses nothing. Options 2 and 3 stay open and stay tied to the
+structuredContent decision — do not take them as a side effect of this.
+
 ## Related
 
 - `thoughts/plans/2026-08-03-structuredcontent-promotion-drops-tool-text.md`

--- a/thoughts/todo/attribute-list-shift-design.md
+++ b/thoughts/todo/attribute-list-shift-design.md
@@ -42,6 +42,14 @@ the phased approach this plan used for `ListProperty`:
    `ListProperty`. The largest option, but the only one that actually
    closes the underlying design flaw rather than mitigating its symptoms.
 
+**Decided 2026-08-14** (owner walkthrough): **option 3, the full v2 port.** It
+is the only one that closes the corruption class rather than mitigating its
+symptoms, and it is materially cheaper than when this was filed — the
+fractional-rank format, its `verify()`/`compact()` primitives and its migration
+shape all now exist and are proven on `ListProperty`. Note the port inherits
+`thoughts/todo/v2-compact-staged-commit.md`'s open commit-protocol gap, so
+sequence it after that work rather than reproducing the gap in a second class.
+
 Whoever scopes this should re-read both research docs above for the
 measured corruption mechanics (they were reproduced against real
 dynamodb-local, not just reasoned about) before designing a fix — several

--- a/thoughts/todo/ci-postgres-parallel-flakiness.md
+++ b/thoughts/todo/ci-postgres-parallel-flakiness.md
@@ -1,0 +1,41 @@
+# Postgres parallel CI: the watchdog bounds the symptom, the flakiness remains
+
+**Origin:** `thoughts/research/2026-06-15-ci-postgres-test-hang.md`
+§"Follow-up (not done here)".
+**Status:** Open. The mitigation shipped; none of the three follow-ups did.
+
+## What already shipped
+
+The `Tests (Python 3.11, postgresql)` job used to reach ~99% of the suite in
+~2.5 min, go silent, and be cancelled at the 20-minute `timeout-minutes` wall
+**with no diagnostics**. A watchdog now bounds that, so a hang fails fast and
+says something. Root cause and the several attempts that did *not* help are in
+the research doc — read it before re-deriving them.
+
+**Decided 2026-08-14** (owner walkthrough): instrument now, on one branch shared
+with the DELETE todo below rather than waiting for the next hang.
+
+## The three follow-ups
+
+1. **Stabilise `test_oauth2_client_manager.py::TestOAuth2ClientCreation` under
+   parallel execution.** It combines a fixed `creator="user@example.com"` with
+   two process-global singletons — the psycopg pool and
+   `trust_type_registry._registry`.
+2. **Speed up the per-worker `alembic upgrade head` session fixture.** Every
+   xdist worker runs a subprocess through the full migration chain.
+3. **Decide whether `--dist loadgroup` is actually required**, or whether
+   disabling rerunfailures' xdist socket machinery under parallel runs is
+   viable instead.
+
+## Why this is not the same item as the DELETE todo
+
+`thoughts/todo/2026-06-15-postgres-parallel-delete-not-persisting.md` is a
+**correctness** question — a per-actor attribute `DELETE` that intermittently
+does not persist, with a mechanism that could drop writes in production. This
+one is **test-infrastructure reliability** only. Same date, same CI matrix, same
+`-n 4 --dist loadgroup` conditions, different defect.
+
+They are worth reading together anyway: follow-up 1's process-global singletons
+and follow-up 3's distribution-mode question both touch the pooled-connection
+behaviour that is the DELETE bug's leading hypothesis. If one investigation
+instruments the postgres CI matrix, it should collect for both.

--- a/thoughts/todo/dynamodb-known-next.md
+++ b/thoughts/todo/dynamodb-known-next.md
@@ -7,6 +7,10 @@ deliberately deferred — each needs design work or carries behavioural
 risk disproportionate to the v3.13 release. Line references are from
 commit `29783f8`; re-verify before implementing.
 
+**Decided 2026-08-14** (owner walkthrough): fold that re-verification into the
+**3.13.0 GA** work — walk all nine items against the settled codebase and
+refresh the line references then, rather than per-item at pick-up time.
+
 ## 1. batch_write for delete loops
 `batch_write`/`BatchWriteItem` is used nowhere. Item-by-item serial
 delete loops: `DbPropertyList.delete()`, `DbTrustList.delete()`,
@@ -16,6 +20,11 @@ fresh accessor + GetItem + DeleteItem — a 1000-item list delete is 1000
 serial round-trip pairs). `Actor.delete()` cascades through all of them.
 Needs 25-item chunking + unprocessed-item retry; lookup-row cleanup and
 property hooks stay per-item, so batching covers only the raw deletes.
+
+**Adjacent, filed separately:** `DbPropertyList.fetch()` reading the whole
+partition (`list:` rows included) is I0, and lives in
+`thoughts/todo/property-fetch-reads-whole-partition.md`. It is the per-*partition*
+read amplification; item 2 below is the per-*item* N+1. Item 3 touches both.
 
 ## 2. General ListProperty item N+1 and __delitem__ O(N) shift
 `ListProperty.__getitem__` does a fresh accessor + GetItem per item

--- a/thoughts/todo/mcp-2026-07-28-dual-era-support.md
+++ b/thoughts/todo/mcp-2026-07-28-dual-era-support.md
@@ -1,0 +1,148 @@
+# TODO: Dual-era MCP support (2026-07-28 stateless revision)
+
+**Status:** Open, deliberately unscheduled. Nothing is broken today and there
+is no client we serve that is confirmed to need this.
+**Severity:** None today; **high the day a client we serve ships modern-only**,
+because a modern-only client cannot talk to a legacy-only server at all — the
+spec's expected outcome is "Fails … the client then surfaces an actionable
+error to the user."
+**Origin:** `thoughts/research/2026-08-13-mcp-2026-07-28-stateless-revision.md`
+
+## Why this is deferred rather than done
+
+The MCP revision published 2026-07-28 removes `initialize`, protocol-level
+sessions, `ping`, and server-initiated elicitation, and adds a mandatory
+per-request `_meta` block, `server/discover`, caching hints and new required
+headers. The library speaks up to `2025-11-25` and is therefore a **legacy-era
+server**.
+
+That sounds urgent and isn't, because the spec has **three** client eras:
+
+| Client era | Against our legacy server |
+| --- | --- |
+| Legacy (`2025-11-25` and earlier) | Unaffected, indefinitely |
+| Dual-era | **Works** — falls back to `initialize` after one rejected request |
+| Modern-only | **Fails**, by design |
+
+The fallback works because `_resolve_request_protocol_version`
+(`actingweb/handlers/mcp.py:1390-1426`) answers an unknown version with HTTP
+400 + JSON-RPC `-32600`, a *standard* code outside the MCP-reserved
+`-32020`–`-32099` range. The spec: *"Anything else identifies a legacy
+server."*
+
+So the entire question is: **does any client we serve go modern-only, and
+when?** That is unknown and unverifiable from public sources as of 2026-08-13.
+
+## Pick this up when any one of these is true
+
+1. **A client we serve announces or ships modern-only 2026-07-28 support.**
+   The specific thing to watch for is *modern-only*, not "supports
+   2026-07-28" — a dual-era client needs nothing from us. Anthropic's
+   announcement (July 2026) said support was "rolling out across Claude
+   products soon" with no per-surface dates.
+2. **Unsupported-version rejections start appearing in production logs.** The
+   signal is `POST /mcp` → HTTP 400 + `-32600` where the request carried
+   `MCP-Protocol-Version: 2026-07-28` (or later). One per client origin is
+   normal and healthy — that *is* the fallback handshake. A *sustained* stream
+   from the same origin means a client is retrying rather than falling back,
+   i.e. it is modern-only or mis-implements the fallback. **Note this currently
+   logs at debug level only** — see "Cheap hardening" below.
+3. **A user reports an MCP client that can no longer connect** and the trace
+   shows no `initialize` ever arriving.
+4. **We want a feature that only exists in the modern revision** — most
+   plausibly elicitation via MRTR, which the library does not implement in any
+   form today (`elicit` appears nowhere in the codebase).
+5. **The Python SDK question is being reopened for another reason.** The
+   modern revision is the largest single argument for adopting the official SDK
+   since the library chose to hand-roll; if that decision is revisited, decide
+   both together rather than twice.
+
+## Do NOT pick it up merely because
+
+- The spec is published. It has been since 2026-07-28 and changed nothing for us.
+- An MCP client advertises 2026-07-28 support. Dual-era clients fall back.
+- A compliance checklist says we are on an old revision. `2025-11-25` remains a
+  valid revision for legacy-era clients, which is every client confirmed to
+  reach us today.
+
+## Trap: do not "fix" the `-32600` error
+
+The single most important thing to preserve. Returning a spec-shaped `-32022`
+(`UnsupportedProtocolVersion`) with a `data.supported` array **looks** more
+correct and would **break** dual-era clients: `-32022` identifies a *modern*
+server, so the client would stop falling back and instead retry a
+modern-shaped request declaring `2025-11-25` — incoherent, since that version
+requires `initialize`. A working fallback becomes a retry loop.
+
+`-32600` without `data.supported` is the correct legacy-only signal. It was
+written as ordinary spec compliance, not as a deliberate era signal, and **no
+test asserts it in that role** — `tests/test_mcp_wire_shape.py` covers version
+gating for `structuredContent`, not this.
+
+## Cheap hardening (does not require picking up the full work)
+
+Each is independent of the dual-era decision. **Decided 2026-08-14** (owner
+walkthrough): **do all three.** Item 1 is the one that matters — it is what
+stops a well-meaning `-32022` "fix" from breaking every dual-era client — and
+item 3 is what makes criterion 2 above observable in telemetry rather than via
+user reports. Item 2 stays in the `message` string; `data.supported` is the trap.
+
+1. **Regression test** asserting HTTP 400 + `-32600` **without**
+   `data.supported` for an unsupported future version, commented as the
+   dual-era fallback trigger. Guards the trap above.
+2. **Name supported versions in the error `message` string** (not
+   `data.supported`). The spec applies this reasoning to the mirror-image case:
+   a server SHOULD name its versions because for a client with no fall-forward
+   *"this message may be the only diagnostic they can surface to users."*
+3. **Raise the log level** on unsupported-version rejections so criterion 2
+   above is observable in telemetry rather than via user reports.
+
+## Scope when it is picked up
+
+Branch on **presence of modern `_meta`, never on method name** — `ping` is the
+documented era-ambiguous trap (no parameters, so nothing distinguishes eras),
+and `notifications/initialized` has the identical shape. Those are the
+library's only two unauthenticated methods
+(`actingweb/handlers/mcp.py:392-395`); both are removed in 2026-07-28.
+
+| Item | Notes |
+| --- | --- |
+| Modern `_meta` parsing + era branch | `protocolVersion` and `clientCapabilities` are required; `clientInfo` is optional |
+| `server/discover` | MUST implement |
+| Capability enforcement → `-32021` | Capabilities are never parsed today (`actingweb/handlers/mcp.py:492-562`) |
+| `MCP-Protocol-Version` header mirroring → `-32020` | Header MUST match the `_meta` field |
+| `404` + `-32601` for unknown modern methods | Legacy path must **not** adopt this — it is a modern-server tell |
+| `ttlMs` + `cacheScope` on list/read results | `tools/list` is permission-filtered per peer → **MUST be `"private"`** |
+| MRTR + signed `requestState` | Only if elicitation is wanted; requires HMAC/AEAD, principal binding, TTL |
+| `subscriptions/listen` | Needs SSE — unavailable on the primary consumer's API Gateway HTTP API v2 deployment |
+
+Dead-code cleanup that becomes available at the same time: `Mcp-Session-Id`
+handling (`:1428-1458`, `:2135-2168`) and `_mcp_client_info_cache` (`:21`,
+`:2114-2133`) lose their write path entirely under modern traffic, and
+`_handle_notifications_initialized` (`:1361-1370`) loses its caller. Durable
+client identity survives on the trust row (`:2088-2096`).
+
+## Downstream consumers to notify
+
+`actingweb_mcp` has an app-side middleware, `require_mcp_auth_for_init`, that
+forces Claude into the OAuth flow by intercepting unauthenticated `initialize`
+requests and matching `clientInfo.name` against "claude"/"anthropic". Under the
+modern revision **both** of its inputs disappear — there is no `initialize`
+method, and `clientInfo` becomes optional per-request metadata — so it would
+silently become a no-op. It is self-labelled TEMPORARY and exists because the
+library's standard 401 challenge was apparently not sufficient on its own.
+Any dual-era work must establish whether the library's
+`WWW-Authenticate` path (`actingweb/handlers/mcp.py:400-412`) can carry OAuth
+bootstrap alone, since consumers cannot keep sniffing for a method that no
+longer exists.
+
+## Related
+
+- `thoughts/research/2026-08-13-mcp-2026-07-28-stateless-revision.md` — the
+  full analysis, spec quotes, and the traced fallback path
+- `thoughts/todo/mcp-cache-lifecycle-and-revocation.md` — §2 cross-process
+  invalidation, §4 `_mcp_client_info_cache` keyed by a client-supplied header;
+  both overlap the cleanup above
+- `thoughts/plans/2026-05-26-mcp-version-negotiation-structuredcontent.md` — the
+  Phase 3 roadmap that `actingweb/mcp/protocol.py:8-13` defers transport
+  compliance to

--- a/thoughts/todo/mcp-cache-lifecycle-and-revocation.md
+++ b/thoughts/todo/mcp-cache-lifecycle-and-revocation.md
@@ -34,6 +34,14 @@ these paths still authenticates/authorizes from a warm process for up to the
 window, not the cross-client bypass the parent plan fixed — a revoked
 client still only ever gets *its own* prior permissions, not someone else's.
 
+**Decided 2026-08-14** (owner walkthrough): **do both halves** — token-keyed
+eviction on `revoke_token`, `revoke_all_tokens` and `/oauth/revoke`, *and*
+direct `_trust_cache` eviction on trust deletion and permission downgrade. That
+closes everything a single process can close. §2 (cross-process) is explicitly
+**not** a blocker for this. Sequence alongside item 4 of
+`thoughts/todo/subs-list-cache-asymmetry.md` — same cache module, and the
+actor-cache lifetime question decides what is left to evict.
+
 **Proposed fix:** wire eviction into each of the paths above, calling
 `MCPHandler.clear_token_from_cache()` (or, for trust changes where the token
 is unknown, `_evict_trust_entries_for_actor(actor_id)` directly). Needs a

--- a/thoughts/todo/migrate-to-v2-needs-a-claim.md
+++ b/thoughts/todo/migrate-to-v2-needs-a-claim.md
@@ -54,6 +54,11 @@ actor race for it), so this should not be left indefinitely.
 
 Option 1 is the cheapest that actually closes it.
 
+**Decided 2026-08-14** (owner walkthrough): planned jointly with
+`thoughts/todo/v2-compact-staged-commit.md` under one `/create_plan`. Both want
+a mutual-exclusion / recoverable-commit primitive over the same storage layer,
+and designing them separately risks two divergent mechanisms.
+
 ## Context
 
 - The narrower cousin of this bug (deciding from a cached format) IS fixed;

--- a/thoughts/todo/orphan-detection-in-verifier.md
+++ b/thoughts/todo/orphan-detection-in-verifier.md
@@ -1,0 +1,54 @@
+# Orphan-row detection in the offline verifier (DEL5)
+
+**Origin:** DEL5 in
+`thoughts/research/2026-07-26-actor-deletion-semantics-and-orphan-writes.md`;
+deferred in `thoughts/research/2026-07-26-actor-deletion-triage.md` (DEL1–DEL4
+landed in v3.13.0rc2, DEL5 did not) and listed there under "Not done".
+**Severity:** Low, purely additive. Nothing is broken; this is a tool that does
+not exist.
+
+## What it is
+
+`python -m actingweb.db.verify_tables` already exists and runs offline with the
+operator's own credentials. An orphan-row check is its natural companion:
+enumerate actor ids, then report attribute / property / trust rows whose
+`actor_id` is absent.
+
+Every consumer that has ever had a DEL1/DEL3 incident needs this, and each will
+otherwise write their own scan — the reference consumer already did.
+
+**Decided 2026-08-14** (owner walkthrough): **ship it in `verify_tables`**
+rather than leaving each consumer to write their own. The reasoning is below —
+the classification is not obvious, and getting it wrong deletes live data.
+
+## Why it is worth lifting rather than leaving to consumers
+
+The classification has four edge cases that are **not obvious**, and getting any
+of them wrong deletes live data:
+
+1. **An empty actor set must yield zero orphans.** If the actor-table read fails
+   or returns nothing, "every row is orphaned" is the catastrophic reading.
+2. **System actors must be excluded unconditionally.** The reference consumer
+   has `_actingweb_websocket` holding live registry data under an id
+   deliberately absent from the actors table; `_actingweb_oauth2` and
+   `_actingweb_system` exist as real actors. Any reserved-prefix id should be
+   reported **separately**, never as deletable.
+3. **Reads must be consistent.** An eventually-consistent scan can show a
+   seconds-old actor as absent.
+4. **Keep it out of automated jobs.** Today's ordering is what makes
+   classification safe: `Actor.create()` writes the actor row **first** and
+   `Actor.delete()` removes it **last**, so an actor mid-create or mid-delete
+   always still has its row. If that ordering ever changes (it was proposed as
+   DEL1 preference #2 and **rejected**, deliberately), a mid-deletion actor's
+   rows briefly classify as orphaned. Fine for a tool an operator runs on
+   purpose; not fine on a cron.
+
+Those four are already written into `docs/reference/actor-deletion.rst`
+§"Finding orphaned rows" — they were documented precisely so they would not be
+lost when the code was deferred. **Start there, not from scratch.**
+
+## Related
+
+- `thoughts/research/2026-07-26-actor-deletion-triage.md` — DEL1 (tombstone),
+  DEL2, DEL3, DEL4 all landed in rc2; the "discriminating question" section
+  records why the actor row still goes last, which is edge case 4's premise.

--- a/thoughts/todo/property-fetch-reads-whole-partition.md
+++ b/thoughts/todo/property-fetch-reads-whole-partition.md
@@ -1,0 +1,76 @@
+# `DbPropertyList.fetch()` reads the whole partition, `list:` rows included (I0)
+
+**Origin:** I0 in `thoughts/research/2026-07-25-v3.13.0rc1-consumer-feedback.md`
+— *"the most valuable thing in this document"*, measured in production, not
+reasoned about. Triaged in `thoughts/research/2026-07-25-rc2-triage.md`
+("Defer to 3.14") and re-listed as still-open in
+`thoughts/research/2026-07-26-actor-deletion-triage.md` §"Not done".
+**Status:** Open. Deliberately deferred from 3.13 as a hot-path rewrite on a
+release that was already validated in production.
+
+## What was measured
+
+The 3.13 `Scan`→`Query` fix constrains only the **hash** key. Property-list
+items share the actor's partition under range keys prefixed `list:`, so a query
+for plain properties reads every one of them and discards them client-side.
+
+Against the real production `AI_properties` table (16.7 MB, 43 actors), same
+actor, same code path, only the library version changed:
+
+| Actor's partition | 3.12.0 (`Scan`) | 3.13.0rc1 (`Query`) | Improvement |
+| --- | --- | --- | --- |
+| 86 rows (typical) | 1,872.5 RCU / 15 calls | **98.0 RCU / 1 call** | **≈19×** |
+| 1,014 rows (list-heavy) | 1,872.5 RCU / 15 calls | **1,027.0 RCU / 9 calls** | ≈1.8× |
+
+Both returned **5** plain properties. The heavy actor paid 1,027 RCU for 5 items
+because ~1,009 `list:*` rows sit in the same partition.
+
+## What 3.13 did and did not fix
+
+It removed the **cross-actor** superlinearity — one actor's data no longer
+inflates every other actor's reads, and cost is bounded by the caller's own
+partition rather than total table size. That was the important part and it
+holds. What remains is **within-actor** amplification proportional to that
+actor's property-list volume, which for a list-heavy application (the reference
+consumer stores user memory as property lists) is the dominant term.
+
+## The ask
+
+Constrain the range key too. `name` is the range key and list rows share the
+`list:` prefix, so plain-property reads can exclude them in the key condition
+instead of client-side:
+
+- a `name < 'list:'` / `name > 'list:~'` **pair** of range-constrained queries —
+  DynamoDB `Query` cannot `OR` on the sort key, which is why it is two, plus a
+  PostgreSQL equivalent plus tests. That is the whole reason this was deferred.
+- or, better, a deliberate key-prefix scheme (`prop#` / `list#`) so each access
+  pattern is a single bounded range query. Larger; a storage-format change.
+
+`fetch_all_including_lists()` legitimately wants the whole partition and must
+keep today's behaviour.
+
+Worth checking the equivalent **trust / peer-trustee** paths for the same shape
+while in there.
+
+**Decided 2026-08-14** (owner walkthrough): **re-measure against 3.13.0 GA
+before designing anything.** The table above is an rc1 snapshot from one
+consumer, and which fix shape is right — the two-query patch or the `prop#` /
+`list#` key scheme — depends on how dominant the `list:` rows still are. Use the
+acceptance recipe below to take the new measurement; it is the same instrument.
+
+## Acceptance
+
+D7's operation-counter recipe in `docs/migration/v3.13.rst` ("Proving the fixes
+actually landed") is the natural acceptance test — patch
+`BaseClient._make_api_call` and count consumed capacity per call. The defect is
+**invisible without per-call capacity instrumentation**, which is why it
+survived the 3.13 validation pass.
+
+## Related
+
+- `thoughts/todo/dynamodb-known-next.md` — item 2 is the adjacent but distinct
+  defect (per-**item** N+1 `GetItem`s when iterating one list); this item is the
+  per-**partition** read amplification when fetching plain properties. Item 3's
+  `consistent_read` audit touches the same call sites.
+- `thoughts/todo/subs-list-cache-asymmetry.md` — the other item deferred to 3.14
+  from the same triage; that todo already names this one as its sibling.

--- a/thoughts/todo/subs-list-cache-asymmetry.md
+++ b/thoughts/todo/subs-list-cache-asymmetry.md
@@ -146,6 +146,15 @@ operation profile: `{GetItem: 1, PutItem: 1, Query: 1}`) stays until then.
 
 ## Proposed fix
 
+**Decided 2026-08-14** (owner walkthrough): **take item 4 first — the
+cache-lifetime question — not the guard.** Deciding whether `_actor_cache` holds
+only identity/auth context with the `Actor` rebuilt per request, or whether
+instance caches need an explicit request-boundary reset, is what unblocks item 2
+*and* de-risks every future instance-level memo. The guard alone was rejected as
+trading a bounded cost bug for an unbounded correctness one. Pair the work with
+§1 of `thoughts/todo/mcp-cache-lifecycle-and-revocation.md` — same module, and
+the eviction wiring depends on what the cache ends up holding.
+
 1. ~~**Centralise invalidation.**~~ **DONE in rc2** — `create_subscription()`
    resets `self.subs_list`. The hand-rolled reset at
    `handlers/subscription.py:262` is now redundant; harmless, but it
@@ -187,7 +196,8 @@ operation profile: `{GetItem: 1, PutItem: 1, Query: 1}`) stays until then.
 ## Related
 
 - `thoughts/research/2026-07-25-rc2-triage.md` — the 3.13.0 triage this came
-  out of; I0 (whole-partition property reads) is the other deferred item.
+  out of; I0 (whole-partition property reads) is the other deferred item —
+  now filed as `thoughts/todo/property-fetch-reads-whole-partition.md`.
 - `thoughts/research/2026-07-25-v3.13.0rc1-consumer-feedback.md` — the consumer
   report; D7 documents the operation-counting technique and its `get_session()`
   trap.

--- a/thoughts/todo/v2-compact-staged-commit.md
+++ b/thoughts/todo/v2-compact-staged-commit.md
@@ -57,6 +57,10 @@ Any of these, roughly in increasing cost:
    reason `thoughts/plans/2026-08-08-property-list-index-integrity.md` ruled
    transactions out for the original shift-loop fix.
 
+**Decided 2026-08-14** (owner walkthrough): planned jointly with
+`thoughts/todo/migrate-to-v2-needs-a-claim.md` under one `/create_plan`, so the
+journal row here and the claim row there come out of one design rather than two.
+
 ## Why the current failure mode is at least loud
 
 Worth recording, because it is the strongest part of the argument for leaving


### PR DESCRIPTION
Documentation only — every file is under `thoughts/`. This is also the first real exercise of the CI filter from #123: expect the test matrix, `type-check` and `Documentation Build` all to skip.

## 1. `thoughts/todo/INDEX.md`

A prioritised index modelled on the one in `actingweb_mcp`: every file in the directory ordered by *impact ÷ effort*, one row each, saying what implementing it buys and why it is worth doing now. Decisions from an item-by-item walkthrough are recorded inline as **Decided 2026-08-14** clauses, in both the index row and the todo file itself — the index says the file wins on disagreement, so decisions living only in the index would be invisible to a file-first reader.

## 2. Plan status audit

Commit `cc29c03` added `status:` frontmatter to all 27 plans in one bulk pass; the values were never audited. Five were wrong — in every case because the work had landed and nothing updated the file:

| Plan | Was | Now | Evidence |
| --- | --- | --- | --- |
| `2025-10-03-actingweb-mcp-protection-tests` | proposed | done | all 5 promised test files exist |
| `2025-12-18-test-coverage-improvements` | active | done | all 8 test files exist (~287 tests) |
| `2026-01-20-auto-subscription-handling` | active | done | plan's own table: 6/6 phases COMPLETE |
| `2026-02-01-subscription-sync-redundancy-fix` | active | done | see below |
| `2026-01-25-fastapi-async-handler-optimization` | proposed | done | `handlers/async_mcp.py:18` |

Plus two missing `verified:` backlinks. `grep -l "^status: active"` now returns nothing, which is correct: nobody is mid-implementation.

`2026-02-01` also bannered an unfixed "New Critical Bug Found (Permission Diff)" and states incremental sync **must not** ship before it — while `_incremental_sync_granted_properties` is at `callbacks.py:804`. The fix had in fact landed as **Option A** (`_get_effective_permissions`, `trust_permissions.py:392`); phase 3 is superseded by how phase 1 shipped, and phase 4's premise was fixed in phase 0. The banner is struck with the evidence inline so nobody re-runs that investigation.

## 3. Research items with no todo

Three filed:

- **`property-fetch-reads-whole-partition.md`** (I0) — called *"the most valuable thing in this document"* by the consumer feedback that drove 3.13; one production actor paid **1,027 RCU to return 5 properties**. Referenced nowhere in `todo/` except one passing mention.
- **`orphan-detection-in-verifier.md`** (DEL5) — explicitly "Not done" since July.
- **`ci-postgres-parallel-flakiness.md`** — the hang watchdog shipped; its three follow-ups did not.

A fourth (test-coverage phases 5–6) was filed, reviewed, and **deliberately dropped** — the suite has grown well past that plan's target, so re-deriving today's gaps beats working from its list.

Deliberately not filed: **I1** (rejected on evidence — a startup `DescribeTable` sweep is wrong for exactly the audience it targets), **I3** (already absorbed by `legacy-property-gsi-removal` item 5), and the auto-subscription E2E remainder (consumer-repo work).

No CHANGELOG entry: nothing here is consumer-visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)