### PR TITLE
Release v3.13.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -425,6 +425,43 @@ CHANGED
 - A successful migration that closed holes (only reachable via
   ``--migrate-damaged``) now logs at WARNING rather than INFO.
 
+- **``--repair`` refuses a reverted migration instead of blessing it as
+  healthy.** A v1 list that is damaged **and** carries rows of the v2 storage
+  format is not an ordinary hole: it is a list whose migration was reverted,
+  with its items alive in the v2 rows and the v1 range empty. ``compact()``
+  used to rewrite that empty range, set the length to what it found, report
+  the list **healthy**, and leave the only surviving copy as unreferenced
+  residue for the next ``clear()``/``delete()``/migrate re-run to sweep — the
+  same unreportable loss the entry above refuses damaged lists to avoid, in
+  the other operator tool.
+
+  ``compact()`` now refuses that combination and says why;
+  ``allow_reverted=True`` (``actingweb-verify-property-lists
+  --repair-reverted``) is the deliberate override, mirroring
+  ``--migrate-damaged``. The verifier's log line for foreign-format rows
+  splits accordingly: on a healthy list it still reports inert residue and how
+  to clear it; on a damaged v1 list it now **warns** that those rows are
+  probably the data and that sweeping or repairing destroys them. The previous
+  text said "harmless to reads; clear it by re-running --migrate"
+  unconditionally, which in this shape was an instruction to delete the only
+  surviving copy.
+
+- **A write from a ``ListProperty`` held across a migration is no longer
+  silent.** Such an instance dispatches on its cached storage format, so the
+  item lands in a row of the old shape that readers of the new format never
+  return — and ``verify()`` reports the list **healthy**, because the row
+  surfaces only as ``foreign_format_rows``, which is documented as inert
+  residue. It now logs a WARNING naming the list, both formats, and what to
+  do. Bounded to one write per retained instance: the metadata write refreshes
+  the cache, so the instance self-corrects from there. The write itself is
+  still lost — closing that needs dispatch on a fresh metadata read, which is
+  deferred.
+
+  This needs an instance retained *across* a migration.
+  ``PropertyListStore.__getattr__`` builds a fresh ``ListProperty`` on every
+  attribute access, so ordinary ``actor.property_lists.<name>`` use has a
+  one-request window rather than a process-lifetime one.
+
 - **Each list mutation now costs one additional point read.** Merging into a
   fresh read of the metadata row is what makes the fix above work, and it is
   not free: where a mutation previously wrote metadata from cache, it now reads

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,604 +5,44 @@ CHANGELOG
 Unreleased
 ----------
 
-.. note::
-
-   Closes a data-loss defect in list properties that ordinary application
-   traffic could trigger. **Any deployment that has migrated, or intends to
-   migrate, property lists to the v2 storage format should take this.**
-
-FIXED
-~~~~~
-
-- **A concurrent write could revert a completed list migration and destroy
-  the entire list.** Metadata was persisted by writing a whole cached
-  metadata dictionary back, so a ``ListProperty`` instance that had read a
-  list before it was migrated would put ``format: 1`` back over the
-  migration's ``format: 2`` flip on its next ``append()``, ``insert()``,
-  ``clear()`` or ``delete()``. Metadata then claimed v1 while every item
-  lived in v2 rows nothing read — and migration's final step deletes the v1
-  rows. The list read back as **empty, with no error anywhere**. No
-  interruption or operator action was required: an ordinary write racing an
-  ordinary migration was enough, and because the metadata cache only clears
-  on an explicit invalidation, an instance an application holds on to stayed
-  dangerous **indefinitely**, not for one round trip.
-
-  Metadata writes now name the fields they change and merge them into a
-  fresh read of the stored row, so ``format`` is never carried over from a
-  cached view. ``length`` is likewise never written into a v2 row, ``clear()``
-  and ``delete()`` dispatch on the stored format rather than a cached one,
-  and a write whose metadata row has vanished (a concurrent ``delete()``
-  won) is skipped rather than recreating the list from stale state.
-
-  **This narrows the window rather than closing it, and the difference is
-  worth being precise about.** What is gone is the unbounded variant: a
-  retained instance could previously revert a migration that finished
-  arbitrarily long ago. What remains is the gap between reading the metadata
-  row and writing it back — two adjacent operations — because neither
-  backend's ``DbProperty`` offers a compare-and-set to condition the write
-  on. That residue is accepted and deferred, not overlooked; quiescing writes
-  during a migration is still what closes it.
-
-- **An interrupted format change left rows behind permanently, and
-  re-running did not clean them up.** Both ``migrate_to_v2()`` and the
-  emergency ``--downgrade`` write the new format's rows, flip metadata, then
-  delete the old format's rows. A crash between the flip and the delete left
-  the old rows in place — and every re-run saw the list already in the
-  target format and returned before reaching its own cleanup.
-  ``migrate_to_v2()``'s docstring claimed the opposite. Worse, the bulk
-  script skipped such a list without calling ``migrate_to_v2()`` at all, so
-  the cleanup was unreachable from the command operators actually run.
-
-  New ``ListProperty.sweep_foreign_format_rows()`` removes rows belonging to
-  the format a list is no longer in, and is now called from both re-run
-  paths, from the bulk script's already-migrated branch, and from
-  ``clear()`` and ``delete()``. The residue was inert to readers, which is
-  why it went unnoticed — but it outlived the list: ``exists()`` and
-  ``list_all()`` key off the metadata row, so a deleted list's residue was
-  invisible right up until a new list was created under the same name and
-  adopted it as its own items.
-
-- **``migrate_to_v2()`` no longer recreates a metadata row that was deleted
-  while it was running.** A list deleted mid-migration was resurrected in v2
-  form out of rows the migration had just written. The migration now rolls
-  its own writes back and returns ``reason: "deleted_concurrently"``, which
-  the bulk script reports without counting as a refusal.
-
-- ``_invalidate_cache()`` now clears the v2 rank cache along with the
-  metadata cache. The two are coupled — ranks are only meaningful for the
-  format the metadata reports — and nothing enforced it.
-
-CHANGED
-~~~~~~~
-
-- ``verify()`` reports ``foreign_format_rows`` in both storage formats: how
-  many rows of the *other* format share this list's name. Informational
-  only — it does not affect ``healthy``, because the rows are inert to every
-  reader of the current format and the sweep above removes them without
-  operator involvement.
-
-- **Each list mutation now costs one additional point read.** Merging into a
-  fresh read of the metadata row is what makes the fix above work, and it is
-  not free: where a mutation previously wrote metadata from cache, it now reads
-  the row first. One extra round trip per ``append()``/``insert()``/``pop()``/
-  ``remove()``/``__setitem__()``/``__delitem__()``, on both backends. The
-  alternative is a compare-and-set primitive neither backend's ``DbProperty``
-  exposes; correctness was preferred over the round trip, and the trade is
-  recorded rather than buried.
-
-- The migration and property-list guides now state what a whole-list rewrite
-  does and does not exclude. Nothing locks out a concurrent application
-  write, so "run repair when the actor is not taking writes" remains a real
-  requirement; what is now guaranteed is that such a write cannot change the
-  list's storage format. Two concurrent migrations resolve to
-  last-writer-wins at whole-list granularity — accepted and documented
-  rather than prevented.
-
-- **Two OAuth2 client-deletion assertions run on PostgreSQL again.**
-  ``test_trust_oauth_integration.py``'s
-  ``TestTrustDeletionOnClientDeletion`` tests were quarantined on the
-  PostgreSQL backend from 2026-06-15 because a per-actor attribute ``DELETE``
-  intermittently did not persist under the parallel CI matrix. Both mechanisms
-  the investigation ranked highest have since been removed by unrelated work —
-  ``DbPropertyLookup.create()``, the one ``INSERT`` that could abort a pooled
-  connection's transaction with ``property_lookup_pkey``, gained ``ON
-  CONFLICT``; and the connection pool now rebuilds rather than serving a mix
-  of connections bound to different ``search_path`` values. The quarantine is
-  lifted so CI can confirm or refute that, rather than leaving two deletion
-  assertions dark on one backend indefinitely.
-
-- **The MCP unsupported-protocol-version rejection now names the supported
-  versions and logs at WARNING.** A client sending an
-  ``MCP-Protocol-Version`` this server does not speak still gets HTTP 400 with
-  JSON-RPC ``-32600`` and no ``data`` payload — that response shape is
-  deliberately unchanged, because it is the signal dual-era MCP clients use to
-  recognise a legacy-era server and fall back to ``initialize``. What changed:
-  the error ``message`` now lists the versions that would have worked, which
-  for a client that cannot fall back is the only diagnostic it can show a
-  user; and the rejection is logged at all, which it previously was not.
-
-  The logging is graded per origin rather than uniform, because the rejection
-  is answered on an **unauthenticated** path. A lone rejection is the normal
-  legacy-server handshake and is recorded at INFO; only a sustained run from
-  the same origin — a client retrying instead of falling back, i.e. a
-  modern-only client — escalates to WARNING, once per origin per five-minute
-  window. That keeps the actionable signal visible without handing anonymous
-  callers a log-volume lever, and it makes the "one-off versus sustained"
-  judgement in code instead of leaving it to whoever reads the logs. Origin is
-  taken from ``Mcp-Session-Id`` or the ``User-Agent``; the number of tracked
-  origins is capped.
-
-  The response code and the absence of ``data.supported`` are now covered by
-  regression tests that state why, since "fixing" this to a spec-shaped
-  ``-32022`` with ``data.supported`` would silently convert every dual-era
-  client's working fallback into a retry loop.
-
-- **Revoking a token, deleting a trust relationship or downgrading a permission
-  now evicts the MCP caches.** ``MCPHandler.clear_token_from_cache()`` had
-  exactly one caller — the logout handler — so every other path that
-  invalidates a client's identity or authorization left the in-process MCP
-  caches serving the old answer for up to their five-minute TTL. A revoked
-  token kept authenticating, a deleted trust kept authorizing, and a narrowed
-  permission kept being honoured at the old level, from any warm process.
-
-  Eviction is now wired into ``TokenManager.revoke_token()``, the SPA session
-  paths ``revoke_access_token()`` / ``revoke_refresh_token()`` (which is what
-  ``/oauth/revoke`` reaches), ``revoke_token_chain()`` (the refresh-token-reuse
-  theft response), ``revoke_all_tokens()``, trust deletion, and both the store
-  and delete paths of ``TrustPermissionStore``. It is actor-wide by necessity
-  rather than scoped to one client: the cached ``ActorInterface`` carries the
-  trust list itself, so evicting a single ``(actor, client)`` entry would leave
-  the shared wrapper answering from stale state. One consequence worth knowing:
-  any permission change on one client invalidates the cache for every MCP
-  client connected to that actor.
-
-  Eviction alone would not have been enough. A request that read a token from
-  storage just before the revocation could write what it read back into the
-  cache just after, reviving the credential for a full TTL while the eviction
-  reported success. A generation counter, bumped by every eviction and
-  snapshotted by each request before the reads that feed the caches, makes such
-  a request decline to populate them.
-
-  **This closes the window within one process only.** Every MCP cache is a
-  module global, so a multi-worker or multi-container deployment still serves
-  the stale entry from every *other* process until its TTL expires. Closing
-  that needs a shared invalidation channel and is not attempted here.
-
-- **``tools/list`` now warns when a hook's ``output_schema`` will not be
-  advertised.** ``outputSchema`` comes solely from ``@mcp_tool``; a schema
-  passed to ``@app.action_hook(..., output_schema=...)`` or derived from a
-  ``TypedDict`` return annotation is stored separately and never bridged, so an
-  author who declares one either of those ways gets silence rather than an
-  advertised schema — and the missing-``structuredContent`` warning stays quiet
-  for them too, because it is gated on the same metadata. The warning fires once
-  per tool per process, at listing time.
-
-  Deliberately a warning and not a merge: merging would newly advertise
-  ``outputSchema`` for every ``TypedDict``-annotated tool, and each one that
-  does not also return ``structuredContent`` would begin failing on
-  spec-conforming clients. That decision belongs with the ``structuredContent``
-  work and is not foreclosed here.
-
-ADDED
-~~~~~
-
-- **Opt-in diagnostics for the PostgreSQL attribute ``DELETE`` path.** Set
-  ``ACTINGWEB_PG_DELETE_DIAGNOSTICS=1`` to log, per attribute delete, the
-  statement's ``rowcount``, the deleting connection's resolved schema and
-  ``search_path``, and a post-commit re-read on a freshly checked-out
-  connection. That combination distinguishes a delete that matched no rows
-  (wrong schema or wrong key) from one that matched and did not persist — the
-  question the quarantine above left unanswered for two months. Off by
-  default. When on it costs a savepoint-wrapped schema read plus a post-commit
-  re-read per delete, and cannot affect the delete it observes: the schema read
-  runs *before* the ``DELETE`` and inside a savepoint, because a server-side
-  failure there would otherwise abort the transaction and turn the later commit
-  into a silent rollback — the exact defect the diagnostics exist to find.
-
+v3.13.0: August 15, 2026
+------------------------
 
 .. note::
 
-   ``compact()`` crash atomicity is **not** addressed here and is deferred.
-   The ``rc6`` warning boxes describing that window stand: the damage it
-   leaves is visible in the data and ``verify()`` catches it.
+   **This is the consolidated release. It supersedes ``v3.13.0rc1`` through
+   ``v3.13.0rc6``, whose separate sections have been merged here.** Changes
+   that existed only between release candidates — defects introduced by one
+   pre-release and fixed by the next — are deliberately not listed: nothing
+   released before ``v3.13.0`` ever exhibited them, so they are noise for
+   anyone upgrading from ``v3.12.0``. If you pinned an rc and want the
+   intermediate history, it is in the git log for ``CHANGELOG.rst``.
 
-v3.13.0rc6: August 9, 2026
---------------------------
+.. warning::
 
-.. note::
+   **Upgrading from ``v3.12.0`` requires reading three things**, in this
+   order, because two of them change behaviour rather than only fixing it:
 
-   Refines the ``rc5`` property-list work: bulk migration now refuses lists
-   with holes or orphans instead of silently closing them. Only affects
-   deployments that run ``actingweb-migrate-property-lists``.
+   1. The **SECURITY** section below. An MCP authorization bypass affected
+      every release from ``v3.3`` (2025-10-04) onwards. The library cannot
+      tell you whether it was exploited in your deployment; the migration
+      guide says what to check.
+   2. The three entries marked **Breaking** under CHANGED — the
+      ``/properties/<name>/items`` response shape, list reads failing fast on
+      corruption instead of silently compacting, and out-of-bounds ``PUT``
+      now returning 404.
+   3. ``docs/migration/v3.13.rst``, in full. In particular: **a green test
+      suite is not evidence this release landed correctly.** The read-path
+      and capacity fixes are invisible to functional tests, and the guide
+      gives an operation-profile recipe for confirming them against your own
+      hot paths.
 
-CHANGED
-~~~~~~~
-
-- **Migration now refuses a damaged list.**
-  ``actingweb-migrate-property-lists --migrate`` and
-  ``ListProperty.migrate_to_v2()`` refuse a list whose ``verify()`` reports
-  missing or orphaned indices, and the dry run reports those lists as
-  needing repair rather than counting them as "would migrate" — it exits
-  ``1`` when any exist, so ``0`` means the migration has nothing to trip
-  over. Migrating damaged data is not merely lossy but *unreportably*
-  lossy: migration renumbers the survivors, so afterwards the hole is
-  gone, the list verifies healthy, and nothing is left to say an item was
-  destroyed. In ``rc5`` the dry run warned about duplicate residue and said
-  nothing whatsoever about holes, so a sweep over a fleet containing one
-  could report "0 refused, 0 errors" and an operator would proceed past the
-  last moment the damage was visible. Lazy migration already refused
-  damaged lists on exactly these grounds; this applies the same rule to the
-  deliberate path. Repair first
-  (``actingweb-verify-property-lists --repair``), or pass
-  ``--migrate-damaged`` / ``migrate_to_v2(allow_damaged=True)`` to migrate
-  anyway — which logs what it is giving up.
-
-  Duplicate residue is unaffected and still migrates: it stays visible
-  after conversion, since a v2 list's ``verify()`` reports duplicates the
-  same way a v1 list's does, so migrating it destroys no evidence. Only
-  holes and orphans gate.
-- A successful migration that closed holes (only reachable via
-  ``--migrate-damaged``) now logs at WARNING rather than INFO.
-
-DOCUMENTATION
-~~~~~~~~~~~~~
-
-- **Documented that ``compact()`` is not crash-safe in either storage
-  format, and that an interrupted repair leaves damage repair will not
-  itself fix.** Only the v2 rank-rebalance window was documented in
-  3.13.0rc5; the v1 path -- the one every upgrading operator runs via
-  ``actingweb-verify-property-lists --repair`` -- has the same shape.
-  Survivors are written to their new positions before the tail rows are
-  deleted, so an interruption leaves a copy at both, with the stored length
-  unchanged: the list reads back with **no error**. ``verify()`` catches it
-  through the adjacent-duplicate heuristic, but re-running ``--repair``
-  will not remove the copy, because duplicates are preserved by design --
-  including the one the interrupted repair created. Now covered in the
-  migration guide's repair step (where operators are told to run it), the
-  property-lists guide, and ``compact()``'s docstring, with a regression
-  test pinning the measured interruption states. No behaviour change.
-- Corrected two stale statements about lazy migration, left behind when its
-  default changed to off in 3.13.0rc5: the downgrade-ordering warning
-  described a 50-item list as "by definition a lazy-migration candidate"
-  (true only where an operator has raised the limit), and the bulk script's
-  own docstring still opened by describing lazy migration as the normal
-  path.
-
-v3.13.0rc5: August 9, 2026
---------------------------
-
-.. note::
-
-   This release changes the ``/properties/<name>/items`` GET response shape,
-   makes list-property reads fail fast on corruption (409 instead of a
-   silently compacted result), enforces the spec's PUT bounds rule, and
-   changes the on-disk storage format for NEW list properties (v2,
-   fractional rank keys). See the CHANGED entries below.
-
-CHANGED
-~~~~~~~
-
-- **New list properties now use a v2 storage format (fractional rank
-  keys) instead of dense integer indices.** Delete and insert are now a
-  single conditional write each instead of a shift loop over every
-  following item -- the interrupted-shift corruption class Phases 1-3
-  hardened against structurally cannot occur in a v2 list, because there
-  is no separate stored ``length`` a row could disagree with; position is
-  always derived by sorting present rows. ``to_list()``/``slice()``/
-  iteration remain a single query regardless of list size. Existing lists
-  are untouched and keep working exactly as before (the v1 format,
-  including everything Phases 1-3 hardened, is fully supported
-  indefinitely) until migrated. New list names may no longer contain
-  ``#`` (reserved for internal storage keys) -- ``ListProperty`` raises
-  ``ValueError`` immediately on first use of such a name; existing v1
-  lists already named this way are unaffected. ``list:``-prefixed
-  property names are now also structurally excluded from the
-  property-lookup table sync, regardless of configuration.
-  ``scripts/verify_property_lists.py`` now understands both formats --
-  v2's "unhealthy" signal is rank keys approaching the length cap
-  (``compact()`` rebalances them), not holes/orphans, which are
-  structurally impossible under v2.
-- **Existing v1 lists migrate to v2 automatically and gradually.** Small
-  lists (<= 50 items) migrate lazily the next time they're mutated
-  (``append``/``insert``/item ``__setitem__``/``__delitem__``); a failed
-  lazy migration is logged and the original mutation still succeeds as
-  v1 -- migration is a background upgrade, never a reason an ordinary
-  write can fail. Larger lists stay fully functional as v1 until swept by
-  the new ``scripts/migrate_property_lists.py`` (dry-run by default;
-  ``--migrate`` to perform it; reports refused names and duplicate
-  residue; ``--downgrade ACTOR_ID/list_name`` is an emergency-only v2->v1
-  converter for rollback scenarios). ``ListProperty.migrate_to_v2()`` is
-  idempotent and safe to interrupt and re-run at any point, including
-  across concurrent v1 mutations between attempts.
-- **Breaking: list-property reads now fail fast on corruption instead of
-  silently compacting past it.** ``ListProperty.to_list()``, ``.slice()``
-  and ``.to_list_from_rows()`` raise ``ListCorruptionError`` (an
-  ``IndexError`` subclass) when an item within the list's recorded length
-  is missing from storage, matching ``AttributeList``'s existing contract.
-  Every HTTP path that serves list content (``GET /properties/<name>``,
-  ``?format=full``, ``?metadata=true``, ``GET/POST /properties/<name>/items``,
-  the bulk list-item POST, list DELETE) now returns **409 Conflict** with
-  ``{"error": "list_corrupted", "list": ..., "detail": ..., "remedy": "compact"}``
-  instead of a 500 or a quietly-wrong compacted response. Repair with
-  ``ListProperty.compact()`` (see ADDED below) before retrying.
-- **Breaking: ``GET /properties/<name>/items`` response shape changed.**
-  Was a bare JSON array (identical to ``GET /properties/<name>``); is now
-  ``{"items": [{"index": i, "item": ...}, ...], "count": n}``. ``index`` is
-  the storage index, matching what ``action=update``/``action=delete``
-  already expect in ``item_index`` — GET and POST are now consistent with
-  each other. Flask gained this route for the first time (parity with
-  FastAPI, which already had it).
-- **Breaking: ``PUT /properties/<name>?index=N`` beyond the list length now
-  returns 404** instead of silently padding the list with ``None`` up to
-  ``N`` (an unbounded-write DoS vector as well as a spec violation — the
-  spec requires 404 for ``index > length``; ``index == length`` still MAY
-  append). ``docs/protocol/actingweb-spec.rst`` "List Property PUT".
-- The bulk list-item POST (``POST /properties`` with a
-  ``{"items": [{"index": N, ...}]}``-shaped list value) now applies every
-  update before any delete, regardless of the order items appear in the
-  request, then applies deletes in descending index order. Previously,
-  processing in request order meant a delete appearing before an update in
-  the same batch could shift the update onto the wrong item. All indices
-  in a batch are now interpreted against the list as it stood before the
-  batch, consistently.
-- **The bulk list-item POST now rejects an update index beyond the end of
-  the list with 400**, the same rule ``PUT ?index=N`` follows. A batch may
-  still populate a list with consecutive indices (``0, 1, 2, …``) — the
-  bound advances with each append the batch performs — but it can no longer
-  name an arbitrary index and have the gap padded with ``None`` one row at a
-  time, which turned a single request into as many database writes as the
-  index was large. The whole batch is validated before anything is written.
-
-- **``verify()`` accepts an ``identity_key``**, adding a
-  ``duplicate_identities`` report that catches duplicates the existing
-  byte-adjacency heuristic structurally cannot. That heuristic is blind two
-  ways, and both were hit in a real deployment: it stops finding a duplicate
-  the moment either copy is edited (so it misses exactly the lists that have
-  been used since the damage), and it only looks at neighbouring rows (so it
-  missed the same ``id`` at positions 31 and 36 and called the list healthy).
-  ``duplicate_identities`` compares the identifying field across the whole
-  list and survives later edits, and the report carries
-  ``identity_checked_count`` so an empty result is distinguishable from a
-  mistyped key that compared nothing. Both sweep tools gained
-  ``--identity-key``; the migrate tool's dry-run duplicate warning
-  previously used only the unreliable comparison.
-- **The operator tools now ship with the library** as the console commands
-  ``actingweb-verify-property-lists`` and
-  ``actingweb-migrate-property-lists`` (implementation moved to
-  ``actingweb.maintenance``; ``scripts/`` keeps thin wrappers). They were
-  previously absent from the wheel, which mattered once converting existing
-  lists became an explicit operator step rather than something that
-  happened on its own.
-- **Both sweep scripts now print the backend, region/host and table prefix
-  they are about to operate on**, and warn when ``AWS_DB_PREFIX`` is an unset
-  default. The library defaults it to ``demo_actingweb``; running a sweep
-  without the application's environment could silently target a different
-  deployment and report it clean, which looks exactly like good news.
-- ``scripts/verify_property_lists.py`` no longer deletes the checkpoint file
-  on a clean **read-only** run — it is now gated on ``--repair``, matching
-  the migrate script. A dry run could previously remove the resume state of
-  an interrupted ``--repair``.
-
-- **Lazy migration now refuses a list that ``verify()`` reports as
-  unhealthy**, logging what it found and how to fix it, instead of
-  migrating it. Migration closes holes in flight and reports what it
-  closed, which is right for an operator running
-  ``scripts/migrate_property_lists.py`` and reading the output — but doing
-  it silently under an ordinary ``append()`` destroyed the evidence: the
-  hole disappeared, the lost item stayed lost, duplicate residue was
-  promoted to real data, and ``verify()`` began reporting the list healthy.
-  Repair (``compact()`` or ``verify_property_lists.py --repair``) is now
-  always an explicit operator action; damaged lists keep serving v1 and
-  keep raising ``ListCorruptionError`` until then.
-- **Automatic conversion of existing lists to the v2 format is OFF by
-  default**, controlled by the new ``ACTINGWEB_LAZY_MIGRATION_MAX_LENGTH``
-  environment variable (default ``0``; set a positive number to allow v1
-  lists of at most that size to convert on their next write, or use
-  ``scripts/migrate_property_lists.py``). **This does not make v2 opt-in** —
-  every list created after upgrading is v2 with no operator action; only the
-  conversion of pre-existing data waits for a deliberate decision. The
-  default is off because it is a **rollback-safety control** before it is a
-  latency one. A pre-3.13.0rc5 process does not
-  error on a migrated list — it reads it as *empty*, because a v2 list
-  stores no ``length`` field and an older reader takes the absence as zero;
-  a write from that process then forks the list across both formats with
-  nothing reporting an error, and ``--downgrade`` cannot reconcile a forked
-  list. Deployment gives a brief mixed-version window; **rollback gives
-  none** — every list that migrated before the rollback reads as empty
-  afterwards, recoverable only one list at a time. With the limit at 0 the
-  release changes no data, so rolling back is a pure code rollback.
-  Secondarily: migration is synchronous, so one ``append()`` to a 40-item
-  list performs the whole migration — dozens of sequential writes plus two
-  full-partition reads — inside that request. The library logs one INFO per
-  process the first time it encounters a v1 list while conversion is
-  disabled, naming the script, so "off" does not quietly become "never".
-- ``ListProperty.storage_format()`` (new, public) returns 1 or 2 from a
-  single point read. ``scripts/migrate_property_lists.py`` now uses it
-  instead of ``verify()`` for format detection, which was fetching the
-  actor's entire property partition once per list.
-
-FIXED
-~~~~~
-
-- **``list.index()`` semantics for negative ``start``/``stop``.**
-  ``index(value, -1)`` could previously return ``-1`` as an index (the loop
-  ran ``range(-1, n)`` and then indexed negatively). Both storage formats
-  now normalize bounds exactly as ``list.index`` does, through one shared
-  helper so they cannot diverge across a migration.
-- **``pop()`` and ``remove()`` now delete conditionally on the value they
-  read.** Resolving the item's storage key once was not enough: a
-  concurrent assignment to that same key between the read and the delete
-  would discard the other writer's value while reporting the one this
-  caller saw — an outcome corresponding to no serial ordering of the two
-  operations. Both now use the new
-  ``DbPropertyProtocol.delete_if_value_equals()`` and re-resolve on a
-  failed condition, so ``pop()`` always returns exactly what it removed and
-  ``remove()`` always removes exactly what it matched.
-  ``__delitem__``/``__setitem__`` remain unconditional by design.
-- ``pop()`` on a v2 list no longer raises ``pop from empty list`` against a
-  list another writer has appended to (the empty check consulted a cached
-  length before the v2 path could refresh it).
-- **A v2 list could read, and delete, a legacy ``#``-named sibling list's
-  rows.** New list names may not contain ``#``, but lists created before
-  this release may, and migration deliberately refuses them so they keep
-  serving as v1. Such a list's rows (e.g. ``list:foo-#bar-0`` for a list
-  named ``foo-#bar``) sort inside the storage range a v2 list named ``foo``
-  reads, so ``foo`` returned the sibling's items as its own and
-  ``foo.clear()``/``foo.delete()``/migrating ``foo`` deleted the sibling's
-  rows. Every consumer of that range now additionally requires the key to
-  be a well-formed rank.
-- **``ListProperty.migrate_to_v2()`` could destroy an already-migrated
-  list.** It decided "this list is still v1" from possibly-cached metadata;
-  if another instance had migrated the list in the meantime, the v1 rows
-  were gone, so the migration saw an all-holes list, deleted the
-  now-authoritative v2 rows as leftover scratch, and wrote an empty list
-  over them. Metadata is now re-read from storage before that decision and
-  re-checked once more immediately before the first destructive write.
-- **v2 item ``__setitem__``/``__delitem__`` could act on a stale position
-  map.** Both resolved a position through a per-instance rank-key cache that
-  could be arbitrarily old on a long-lived instance; if another writer had
-  inserted an item earlier in the list, position ``i`` no longer named the
-  same row and the wrong item was overwritten or deleted. Both now re-read
-  the rank keys before committing. (``append``/``insert`` keep using the
-  cache — their conditional writes bound the effect to where an item lands,
-  never to destroying a different one.)
-- **``scripts/migrate_property_lists.py`` and
-  ``scripts/verify_property_lists.py`` checkpointed actors whose lists had
-  not actually been dealt with.** An actor with an errored or refused list
-  (migration) or one still unhealthy after ``--repair`` (verification) was
-  marked complete, so the next run skipped it, observed no problems, deleted
-  the checkpoint and exited 0 — reporting success over work that was never
-  done. Only fully successful actors are checkpointed now.
-
-- **``ListProperty.insert()`` destroyed data on every call into a non-empty
-  list on DynamoDB.** ``insert()`` reused one cached ``DbProperty`` handle
-  across its whole shift loop instead of taking a fresh handle per
-  get()/set() like every other list method; on DynamoDB this caused each
-  shifted row to be overwritten with the last value read instead of its
-  own. Fixed both at the call site (fresh handles, matching the rest of the
-  class) and in the DynamoDB and PostgreSQL backends' ``DbProperty.get()``/
-  ``set()`` (a cached handle for a different ``(actor_id, name)`` is now
-  always discarded rather than reused).
-- **Backend read/write failures on property (and property-list item) storage
-  were silently swallowed as absence or as a no-op.** ``DbProperty.get()``
-  now raises ``actingweb.db.exceptions.DbError`` on a genuine backend fault
-  instead of returning ``None`` (``None`` means the row does not exist, and
-  only that, on both backends). Every ``ListProperty`` mutation
-  (``append``, ``__setitem__``, ``__delitem__``, ``insert``, ``clear``,
-  ``delete``, metadata writes) now checks ``set()``'s return value and
-  raises ``RuntimeError`` instead of continuing past a failed write. This is
-  a breaking change for any code that relied on a backend fault degrading
-  to ``None``/no-op on a property read/write.
-- Backend exception text no longer reaches HTTP error responses from the
-  list-property handlers (``PUT``/POST/DELETE on ``/properties/<name>`` and
-  ``/properties/<name>/items``) — the client sees a generic message; the
-  original exception is still logged server-side.
-- Unparsable list metadata no longer self-heals into a fresh empty list
-  (which orphaned every existing item row with no way back to them) —
-  ``ListProperty`` now raises ``ValueError`` instead, and the row is left
-  untouched for repair.
-
-ADDED
-~~~~~
-
-- **Property-list repair primitives.** ``ListProperty.verify()`` reports a
-  list's health (holes, orphan rows, a duplicate-value heuristic) without
-  modifying anything; ``ListProperty.compact()`` closes holes and removes
-  orphans in one pass while preserving ``description``/``explanation``/
-  ``created_at`` (unlike the previous ``clear()`` + ``extend()`` workaround,
-  which reset them). Duplicate residue is reported but never rewritten — a
-  duplicate value always means a destroyed item, and silently collapsing
-  one copy would bless the data loss as intentional. Both are also
-  available through ``actor.property_lists.<name>.verify()``/``.compact()``.
-  New operator script: ``scripts/verify_property_lists.py`` (dry-run by
-  default; ``--repair`` invokes ``compact()`` on unhealthy lists).
-
-v3.13.0rc4: August 3, 2026
---------------------------
-
-.. note::
-
-   This release changes documented MCP behaviour that shipped in the stable
-   ``v3.11.0`` and ``v3.12.0`` releases. If you expose MCP tools, read
-   ``docs/migration/v3.13.rst`` before upgrading. The migration is a no-op
-   against the older releases, so you can update your hooks first and upgrade
-   afterwards.
-
-CHANGED
-~~~~~~~
-
-- **MCP ``structuredContent`` is now opt-in.** ``tools/call`` results emit
-  ``structuredContent`` only when a tool hook sets that key explicitly, and only
-  when its value is a JSON object. Extra top-level keys are **no longer promoted**
-  into ``structuredContent``.
-
-  Why this changed: at least one major MCP client discards **every** text content
-  block when ``structuredContent`` is present on a result. Under the previous
-  behaviour, adding a single scalar key to a hook's return value silently deleted
-  that tool's entire prose payload — the model received only the promoted keys,
-  and nothing in the protocol reported the loss to either side. Neither reference
-  server implementation promotes individual keys: the SDK's low-level server emits
-  ``structuredContent`` only when ``content`` is its exact serialization, and
-  FastMCP only for a declared return model.
-
-  This is also a hardening improvement. A hook doing
-  ``return {"content": [...], **rel.to_dict()}`` was shipping the trust row's
-  ``secret`` to the model; ``properties.to_dict()`` can likewise carry
-  ``oauth_token`` / ``oauth_refresh_token``. Only an explicitly named
-  ``structuredContent`` now leaves the process. Note the win is scoped to the
-  ``content`` branch — the legacy text-wrap path still stringifies the whole dict.
-
-  Migration: nest the data you want structured under an explicit
-  ``structuredContent`` key, and keep the same object serialized in a text
-  ``content`` block (the spec's backwards-compatibility guidance — some clients
-  ignore ``structuredContent`` entirely). For tools whose payload is prose, drop
-  the extras instead. The explicit passthrough already exists in ``v3.11.0`` and
-  ``v3.12.0``, so migrated hooks produce identical output on both, and no
-  coordinated deploy is needed.
-
-FIXED
-~~~~~
-
-- **MCP: an explicit ``isError`` is now honoured on the legacy text-wrap path.**
-  A hook returning ``{"isError": True, "error": "boom"}`` with no ``content`` key
-  previously reached the wire with no ``isError`` field at all, so the failure was
-  reported to the client as a **success**. ``isError`` is honoured only when the
-  hook sets it — it is never inferred from an ``"error"`` key or any other shape
-  heuristic, so applications that return ``{"error": ...}`` on their normal error
-  path see no change. The ``str(result)`` text serialization is unchanged, so
-  ``isError`` appears both inside that text and as a wire field.
-
-ADDED
-~~~~~
-
-- **MCP: a warning when a tool declares ``output_schema`` but returns no
-  ``structuredContent``.** Spec-conforming clients reject such a result outright
-  (``Tool X has an output schema but did not return structured content``), which
-  was already broken before this release for anyone declaring a schema — the
-  library advertises ``outputSchema`` in ``tools/list`` but never consulted it at
-  call time. The warning fires once per tool per process, at call time, and only
-  when the negotiated protocol version supports structured content, so a
-  correctly-written hook talking to an older client never trips it.
-  ``output_schema`` and ``structuredContent`` remain independent: declaring a
-  schema has never caused structured output to be emitted, and the library still
-  does not validate ``structuredContent`` against a declared schema.
-- **MCP: a warning when ``structuredContent`` is set to a non-object.** MCP
-  requires a JSON object there; a list, string or number was previously dropped
-  silently. ``None`` is exempt and stays silent — it carries no payload, both
-  reference clients read a null ``structuredContent`` as absent, and
-  ``{"structuredContent": value or None}`` is a legitimate way to express
-  "nothing structured this time". In that case the key is omitted from the
-  response rather than emitted as ``null``.
-
-v3.13.0rc3: August 1, 2026
---------------------------
-
-.. note::
-
-   **Security fix — please re-run any escalation/authorization tests before
-   pinning to this release.** MCP deployments serving more than one client
-   per actor should read the ``SECURITY`` section below in full and consult
-   ``docs/migration/v3.13.rst`` before upgrading.
+   **Two operator tools ship with this release** —
+   ``actingweb-verify-property-lists`` and
+   ``actingweb-migrate-property-lists``. Automatic conversion of existing
+   lists to the v2 storage format is **off by default**; read the migration
+   guide before turning it on, and note that ``compact()`` is documented as
+   not crash-safe (see DOCUMENTATION).
 
 SECURITY
 ~~~~~~~~
@@ -618,7 +58,7 @@ SECURITY
   after a read-write client authenticated against the same actor. The
   trust cache is now keyed by ``(actor_id, client_id)``, closing the bypass.
   **Affected versions:** every release since ``v3.3`` (2025-10-04) through
-  ``v3.13.0rc2``, roughly ten months. The library cannot detect whether this
+  ``v3.13.0rc2``, roughly ten months (i.e. fixed in this release). The library cannot detect whether this
   was exploited in your deployment; see the migration guide for what to
   check.
 
@@ -669,181 +109,6 @@ SECURITY
   any trust row touched while the cache-crossing bug was live. Current
   values self-heal on that client's next request after upgrading (current
   state, not history — the metadata is a live cache with no audit trail).
-
-- **Still open, deferred:** revoking a token or modifying a trust
-  relationship does not evict the corresponding cache entries, so a revoked
-  token or a just-changed permission can still authenticate/apply from a
-  warm process for up to the 5-minute token cache TTL. Tracked in
-  ``thoughts/todo/mcp-cache-lifecycle-and-revocation.md``.
-
-FIXED
-~~~~~
-
-- **Config-bound singletons no longer serve one application's state to
-  another.** ``get_actingweb_oauth2_server()``,
-  ``get_mcp_client_registry()``, ``get_actingweb_token_manager()``,
-  ``get_oauth2_state_manager()``, ``get_permission_evaluator()``,
-  ``get_registry()`` (trust types), ``get_trust_permission_store()``,
-  ``get_peer_permission_store()``, ``get_peer_profile_store()`` and
-  ``get_cached_capabilities_store()`` each take a ``config`` argument but,
-  once built, ignored it — they bound to the **first** config the process
-  ever passed and returned that instance to every later caller. (One of them
-  documented this explicitly: "config parameter kept for interface
-  consistency but not used".) Any process hosting more than one ActingWeb
-  application therefore had the second application silently using the
-  first's configuration, **including its database backend**. The observed
-  consequence: MCP dynamic client registration wrote a trust row to one
-  backend while trust resolution read another, so the client's trust was
-  never found. Under the old fail-open behavior that granted the client
-  *full access*; under the fail-closed behavior above it returns ``-32003``.
-  Each getter now rebuilds when handed a different ``Config`` instance, and
-  still returns the cached instance for the same one. Single-application
-  deployments — the overwhelming majority — are unaffected either way.
-
-  Note that ``ActingWebOAuth2Server`` *composes* three of these, so rebinding
-  the server alone was not sufficient: ``client_registry``, ``token_manager``
-  and ``state_manager`` had to rebind too. ``get_oauth2_state_manager()``
-  re-reads its encryption key from the new config's system actor on rebind;
-  the key is stored rather than generated, so it is stable.
-
-CHANGED
-~~~~~~~
-
-- **``RuntimeContext`` is now genuinely request-scoped, and
-  ``set_custom_context()`` no longer persists across requests.** Runtime
-  context (MCP/OAuth2/web) was stored as a mutable attribute on the actor
-  object, while the MCP handler deliberately hands the *same* cached
-  ``ActorInterface`` to every request for a hot actor — so context could
-  leak between requests and, under concurrency, between callers. It is now
-  stored in a ``contextvars.ContextVar`` keyed by actor id (task-local
-  under asyncio, thread-local under a WSGI worker), and the Flask and
-  FastAPI integrations clear it at the end of every request including when
-  a handler raises. The public API (``RuntimeContext(actor)`` and all its
-  getters/setters) is unchanged, and read-only use inside request-scoped
-  hooks needs no changes. **The one behavior change for application code:**
-  data written with ``set_custom_context()`` is gone by the next request,
-  even against the same actor object. If your hooks used it as a
-  cross-request cache rather than as request-scoped data, move that to
-  actor properties or the caching guide's patterns
-  (``docs/guides/caching.md``). See ``docs/guides/hooks.rst``.
-
-- **``tools/call`` permission checks now pass ``operation="use"`` on
-  FastAPI, matching Flask.** The async handler passed ``"invoke"`` while
-  the sync handler passed ``"use"``, a transport-dependent divergence. It
-  is unread by every trust type shipped with ActingWeb (they express
-  ``tools`` as allowed/denied lists, which do not consult ``operation``),
-  so this changes nothing unless your application defines a
-  patterns/operations-based tools rule — in which case a rule that
-  matched ``invoke`` on FastAPI must now match ``use``.
-
-v3.13.0rc2: July 26, 2026
--------------------------
-
-Everything from ``v3.13.0rc1`` (July 24, 2026), plus the items marked
-*(since rc1)* below — all from the first consumer to run a real production
-upgrade on the release candidate.
-
-.. note::
-
-   **rc1 deployments should re-validate before pinning to rc2.** Three changes
-   touch a code path rather than only docs: ``register_diffs()`` now resolves
-   subscriptions before consulting suspension state, ``create_subscription()``
-   invalidates the actor's cached subscription list, and **actor deletion now
-   writes a tombstone before the wipe begins** (one extra write per deletion;
-   no change to any read path). All are argued below and covered by the suite,
-   but the lesson of this release is that read-path changes are invisible to
-   functional tests — use the operation-profile recipe in
-   ``docs/migration/v3.13.rst`` to confirm the profile on your own hot paths.
-
-ADDED
-~~~~~
-
-- **DynamoDB table auto-creation can now be disabled** for deployments that
-  manage tables via infrastructure-as-code: set
-  ``AWS_DB_AUTO_CREATE_TABLES=false`` or call
-  ``with_dynamodb(auto_create_tables=False)``. With auto-creation off, the
-  library never calls ``DescribeTable``/``CreateTable``, so both permissions
-  can be dropped from the runtime IAM role.
-
-- *(since rc1)* **Actor deletion tombstones and a tri-state deletion check.**
-  ``ActorInterface.get_deletion_status(actor_id, config)`` returns
-  ``DeletionStatus.DELETED`` / ``NOT_DELETED`` / ``UNKNOWN`` from a tombstone
-  written *before* the ``actor_deleted`` hook runs — so an external call made
-  from that hook, and any provider callback racing it, already sees
-  ``DELETED`` — and retained for 30 days, past every provider's webhook retry
-  window.
-
-  This exists because a guard of the form "skip this work if the actor no
-  longer exists" could not be written correctly. ``Actor.delete()`` removes the
-  actor row **last**, so ``get_by_id()`` keeps returning a live actor for the
-  entire wipe: the check fails **open** in exactly the window it matters,
-  which the documented cleanup pattern enters deliberately (``actor_deleted``
-  cancels an external subscription; the provider's callback races the wipe).
-  Checking harder is not available either, because ``get_by_id()`` returns
-  ``None`` for a deleted actor *and* for a failed read — so the same guard
-  fails **closed** on a throttle, which for a paid-subscription webhook means
-  the customer paid and silently never got access. A consumer hit both:
-  4 attribute rows in production belonged to fully deleted accounts.
-
-  A tombstone is *positive* evidence, so it has a safe failure direction:
-  ``UNKNOWN`` means proceed, costing at most one orphan row an operator sweep
-  can find, rather than dropping work for a paying customer. The read is a
-  single strongly-consistent point read — measured at exactly one ``GetItem``,
-  not asserted. Tombstones live under a reserved id that is never itself an
-  actor, so no deletion can destroy them, and expired ones are filtered at
-  read time so TTL means the same thing on both backends. Re-creating an actor
-  clears its tombstone (``create(actor_id=...)`` accepts a caller-supplied id).
-
-  The actor row deliberately still goes last. Deleting it first would make
-  existence checks fail closed rather than open, but "missing" is
-  indistinguishable from "read failed" anyway, and it would cost the two
-  properties that ordering buys: deletion stays retriable if a wipe step
-  fails, and rows are never briefly classifiable as orphaned. The tombstone
-  answers the question without that trade.
-
-- *(since rc1)* **``actor_deleted_complete`` lifecycle hook**, fired after the
-  wipe completes with ``actor=None`` and ``actor_id=<id>``. There was
-  previously nowhere to put "do this once the actor is definitely gone", which
-  forced applications into the race above by design: ``actor_deleted`` is the
-  only place the actor's data is readable, so it was also the only place to
-  act on it. Now the work splits — read in ``actor_deleted``, act in
-  ``actor_deleted_complete`` — which removes the race at its source
-  independently of the tombstone. The absent ``ActorInterface`` is the point,
-  not an omission.
-
-- *(since rc1)* **``get_attr_strict()`` on both attribute backends** —
-  a point read that raises on infrastructure errors instead of collapsing them
-  into ``None``, and treats an expired row as absent. Used by the tombstone
-  read; available to applications with the same need. Building the tombstone
-  read on ``get_attr()`` would have reintroduced the very bug it fixes.
-
-  **Custom backend implementers:** this method is now part of
-  ``DbAttributeProtocol``, which is ``@runtime_checkable`` — an out-of-tree
-  attribute backend must add ``get_attr_strict()`` to keep satisfying
-  ``isinstance()`` checks against the protocol. Both bundled backends
-  implement it.
-
-- *(since rc1)* **Operator-facing table verifier:**
-  ``python -m actingweb.db.verify_tables`` reports which required DynamoDB
-  tables exist and which are missing. With auto-creation disabled, "all
-  tables exist" becomes a precondition the library deliberately no longer
-  checks (an existence check would cost an ``AccessDenied`` per accessor
-  construction on a slimmed role), and the required set previously had to be
-  read out of the source. Run it out-of-band with operator credentials —
-  it only reads, never creates, and adds nothing to the request path.
-  ``--list`` prints the names without calling AWS. Exit codes: ``0`` all
-  present, ``1`` one or more missing, ``2`` the check could not run. The
-  same list now drives table pre-warm, so what the library creates and what
-  operators are told to pre-create cannot drift apart.
-
-- *(since rc1)* **``auto_create_enabled()`` is public API**
-  (``from actingweb.db.dynamodb import auto_create_enabled``). Dropping
-  ``DescribeTable``/``CreateTable`` from the runtime role affects the whole
-  role, not just the library, so application code that probes its own tables
-  (boto3 ``table.load()``/``describe_table``, pynamodb ``exists()``) needs
-  the same switch — previously it had to re-implement the environment
-  parsing. ``set_auto_create()`` and ``reset_ensure_cache()`` are exported
-  alongside it.
 
 CHANGED
 ~~~~~~~
@@ -931,23 +196,468 @@ CHANGED
   concurrently at Flask/FastAPI integration time instead of serially on the
   first request.
 
-FIXED
+- **``RuntimeContext`` is now genuinely request-scoped, and
+  ``set_custom_context()`` no longer persists across requests.** Runtime
+  context (MCP/OAuth2/web) was stored as a mutable attribute on the actor
+  object, while the MCP handler deliberately hands the *same* cached
+  ``ActorInterface`` to every request for a hot actor — so context could
+  leak between requests and, under concurrency, between callers. It is now
+  stored in a ``contextvars.ContextVar`` keyed by actor id (task-local
+  under asyncio, thread-local under a WSGI worker), and the Flask and
+  FastAPI integrations clear it at the end of every request including when
+  a handler raises. The public API (``RuntimeContext(actor)`` and all its
+  getters/setters) is unchanged, and read-only use inside request-scoped
+  hooks needs no changes. **The one behavior change for application code:**
+  data written with ``set_custom_context()`` is gone by the next request,
+  even against the same actor object. If your hooks used it as a
+  cross-request cache rather than as request-scoped data, move that to
+  actor properties or the caching guide's patterns
+  (``docs/guides/caching.md``). See ``docs/guides/hooks.rst``.
+
+- **``tools/call`` permission checks now pass ``operation="use"`` on
+  FastAPI, matching Flask.** The async handler passed ``"invoke"`` while
+  the sync handler passed ``"use"``, a transport-dependent divergence. It
+  is unread by every trust type shipped with ActingWeb (they express
+  ``tools`` as allowed/denied lists, which do not consult ``operation``),
+  so this changes nothing unless your application defines a
+  patterns/operations-based tools rule — in which case a rule that
+  matched ``invoke`` on FastAPI must now match ``use``.
+
+- **MCP ``structuredContent`` is now opt-in.** ``tools/call`` results emit
+  ``structuredContent`` only when a tool hook sets that key explicitly, and only
+  when its value is a JSON object. Extra top-level keys are **no longer promoted**
+  into ``structuredContent``.
+
+  Why this changed: at least one major MCP client discards **every** text content
+  block when ``structuredContent`` is present on a result. Under the previous
+  behaviour, adding a single scalar key to a hook's return value silently deleted
+  that tool's entire prose payload — the model received only the promoted keys,
+  and nothing in the protocol reported the loss to either side. Neither reference
+  server implementation promotes individual keys: the SDK's low-level server emits
+  ``structuredContent`` only when ``content`` is its exact serialization, and
+  FastMCP only for a declared return model.
+
+  This is also a hardening improvement. A hook doing
+  ``return {"content": [...], **rel.to_dict()}`` was shipping the trust row's
+  ``secret`` to the model; ``properties.to_dict()`` can likewise carry
+  ``oauth_token`` / ``oauth_refresh_token``. Only an explicitly named
+  ``structuredContent`` now leaves the process. Note the win is scoped to the
+  ``content`` branch — the legacy text-wrap path still stringifies the whole dict.
+
+  Migration: nest the data you want structured under an explicit
+  ``structuredContent`` key, and keep the same object serialized in a text
+  ``content`` block (the spec's backwards-compatibility guidance — some clients
+  ignore ``structuredContent`` entirely). For tools whose payload is prose, drop
+  the extras instead. The explicit passthrough already exists in ``v3.11.0`` and
+  ``v3.12.0``, so migrated hooks produce identical output on both, and no
+  coordinated deploy is needed.
+
+- **New list properties now use a v2 storage format (fractional rank
+  keys) instead of dense integer indices.** Delete and insert are now a
+  single conditional write each instead of a shift loop over every
+  following item -- the interrupted-shift corruption class Phases 1-3
+  hardened against structurally cannot occur in a v2 list, because there
+  is no separate stored ``length`` a row could disagree with; position is
+  always derived by sorting present rows. ``to_list()``/``slice()``/
+  iteration remain a single query regardless of list size. Existing lists
+  are untouched and keep working exactly as before (the v1 format,
+  including everything Phases 1-3 hardened, is fully supported
+  indefinitely) until migrated. New list names may no longer contain
+  ``#`` (reserved for internal storage keys) -- ``ListProperty`` raises
+  ``ValueError`` immediately on first use of such a name; existing v1
+  lists already named this way are unaffected. ``list:``-prefixed
+  property names are now also structurally excluded from the
+  property-lookup table sync, regardless of configuration.
+  ``scripts/verify_property_lists.py`` now understands both formats --
+  v2's "unhealthy" signal is rank keys approaching the length cap
+  (``compact()`` rebalances them), not holes/orphans, which are
+  structurally impossible under v2.
+
+- **Existing v1 lists migrate to v2 automatically and gradually.** Small
+  lists (<= 50 items) migrate lazily the next time they're mutated
+  (``append``/``insert``/item ``__setitem__``/``__delitem__``); a failed
+  lazy migration is logged and the original mutation still succeeds as
+  v1 -- migration is a background upgrade, never a reason an ordinary
+  write can fail. Larger lists stay fully functional as v1 until swept by
+  the new ``scripts/migrate_property_lists.py`` (dry-run by default;
+  ``--migrate`` to perform it; reports refused names and duplicate
+  residue; ``--downgrade ACTOR_ID/list_name`` is an emergency-only v2->v1
+  converter for rollback scenarios). ``ListProperty.migrate_to_v2()`` is
+  idempotent and safe to interrupt and re-run at any point, including
+  across concurrent v1 mutations between attempts.
+
+- **Breaking: list-property reads now fail fast on corruption instead of
+  silently compacting past it.** ``ListProperty.to_list()``, ``.slice()``
+  and ``.to_list_from_rows()`` raise ``ListCorruptionError`` (an
+  ``IndexError`` subclass) when an item within the list's recorded length
+  is missing from storage, matching ``AttributeList``'s existing contract.
+  Every HTTP path that serves list content (``GET /properties/<name>``,
+  ``?format=full``, ``?metadata=true``, ``GET/POST /properties/<name>/items``,
+  the bulk list-item POST, list DELETE) now returns **409 Conflict** with
+  ``{"error": "list_corrupted", "list": ..., "detail": ..., "remedy": "compact"}``
+  instead of a 500 or a quietly-wrong compacted response. Repair with
+  ``ListProperty.compact()`` (see ADDED below) before retrying.
+
+- **Breaking: ``GET /properties/<name>/items`` response shape changed.**
+  Was a bare JSON array (identical to ``GET /properties/<name>``); is now
+  ``{"items": [{"index": i, "item": ...}, ...], "count": n}``. ``index`` is
+  the storage index, matching what ``action=update``/``action=delete``
+  already expect in ``item_index`` — GET and POST are now consistent with
+  each other. Flask gained this route for the first time (parity with
+  FastAPI, which already had it).
+
+- **Breaking: ``PUT /properties/<name>?index=N`` beyond the list length now
+  returns 404** instead of silently padding the list with ``None`` up to
+  ``N`` (an unbounded-write DoS vector as well as a spec violation — the
+  spec requires 404 for ``index > length``; ``index == length`` still MAY
+  append). ``docs/protocol/actingweb-spec.rst`` "List Property PUT".
+- The bulk list-item POST (``POST /properties`` with a
+  ``{"items": [{"index": N, ...}]}``-shaped list value) now applies every
+  update before any delete, regardless of the order items appear in the
+  request, then applies deletes in descending index order. Previously,
+  processing in request order meant a delete appearing before an update in
+  the same batch could shift the update onto the wrong item. All indices
+  in a batch are now interpreted against the list as it stood before the
+  batch, consistently.
+
+- **The bulk list-item POST now rejects an update index beyond the end of
+  the list with 400**, the same rule ``PUT ?index=N`` follows. A batch may
+  still populate a list with consecutive indices (``0, 1, 2, …``) — the
+  bound advances with each append the batch performs — but it can no longer
+  name an arbitrary index and have the gap padded with ``None`` one row at a
+  time, which turned a single request into as many database writes as the
+  index was large. The whole batch is validated before anything is written.
+
+- **``verify()`` accepts an ``identity_key``**, adding a
+  ``duplicate_identities`` report that catches duplicates the existing
+  byte-adjacency heuristic structurally cannot. That heuristic is blind two
+  ways, and both were hit in a real deployment: it stops finding a duplicate
+  the moment either copy is edited (so it misses exactly the lists that have
+  been used since the damage), and it only looks at neighbouring rows (so it
+  missed the same ``id`` at positions 31 and 36 and called the list healthy).
+  ``duplicate_identities`` compares the identifying field across the whole
+  list and survives later edits, and the report carries
+  ``identity_checked_count`` so an empty result is distinguishable from a
+  mistyped key that compared nothing. Both sweep tools gained
+  ``--identity-key``; the migrate tool's dry-run duplicate warning
+  previously used only the unreliable comparison.
+
+- **The operator tools now ship with the library** as the console commands
+  ``actingweb-verify-property-lists`` and
+  ``actingweb-migrate-property-lists`` (implementation moved to
+  ``actingweb.maintenance``; ``scripts/`` keeps thin wrappers). They were
+  previously absent from the wheel, which mattered once converting existing
+  lists became an explicit operator step rather than something that
+  happened on its own.
+
+- **Both sweep scripts now print the backend, region/host and table prefix
+  they are about to operate on**, and warn when ``AWS_DB_PREFIX`` is an unset
+  default. The library defaults it to ``demo_actingweb``; running a sweep
+  without the application's environment could silently target a different
+  deployment and report it clean, which looks exactly like good news.
+- ``scripts/verify_property_lists.py`` no longer deletes the checkpoint file
+  on a clean **read-only** run — it is now gated on ``--repair``, matching
+  the migrate script. A dry run could previously remove the resume state of
+  an interrupted ``--repair``.
+
+- **Lazy migration now refuses a list that ``verify()`` reports as
+  unhealthy**, logging what it found and how to fix it, instead of
+  migrating it. Migration closes holes in flight and reports what it
+  closed, which is right for an operator running
+  ``scripts/migrate_property_lists.py`` and reading the output — but doing
+  it silently under an ordinary ``append()`` destroyed the evidence: the
+  hole disappeared, the lost item stayed lost, duplicate residue was
+  promoted to real data, and ``verify()`` began reporting the list healthy.
+  Repair (``compact()`` or ``verify_property_lists.py --repair``) is now
+  always an explicit operator action; damaged lists keep serving v1 and
+  keep raising ``ListCorruptionError`` until then.
+
+- **Automatic conversion of existing lists to the v2 format is OFF by
+  default**, controlled by the new ``ACTINGWEB_LAZY_MIGRATION_MAX_LENGTH``
+  environment variable (default ``0``; set a positive number to allow v1
+  lists of at most that size to convert on their next write, or use
+  ``scripts/migrate_property_lists.py``). **This does not make v2 opt-in** —
+  every list created after upgrading is v2 with no operator action; only the
+  conversion of pre-existing data waits for a deliberate decision. The
+  default is off because it is a **rollback-safety control** before it is a
+  latency one. A pre-3.13.0 process does not
+  error on a migrated list — it reads it as *empty*, because a v2 list
+  stores no ``length`` field and an older reader takes the absence as zero;
+  a write from that process then forks the list across both formats with
+  nothing reporting an error, and ``--downgrade`` cannot reconcile a forked
+  list. Deployment gives a brief mixed-version window; **rollback gives
+  none** — every list that migrated before the rollback reads as empty
+  afterwards, recoverable only one list at a time. With the limit at 0 the
+  release changes no data, so rolling back is a pure code rollback.
+  Secondarily: migration is synchronous, so one ``append()`` to a 40-item
+  list performs the whole migration — dozens of sequential writes plus two
+  full-partition reads — inside that request. The library logs one INFO per
+  process the first time it encounters a v1 list while conversion is
+  disabled, naming the script, so "off" does not quietly become "never".
+- ``ListProperty.storage_format()`` (new, public) returns 1 or 2 from a
+  single point read. ``scripts/migrate_property_lists.py`` now uses it
+  instead of ``verify()`` for format detection, which was fetching the
+  actor's entire property partition once per list.
+
+- **Migration now refuses a damaged list.**
+  ``actingweb-migrate-property-lists --migrate`` and
+  ``ListProperty.migrate_to_v2()`` refuse a list whose ``verify()`` reports
+  missing or orphaned indices, and the dry run reports those lists as
+  needing repair rather than counting them as "would migrate" — it exits
+  ``1`` when any exist, so ``0`` means the migration has nothing to trip
+  over. Migrating damaged data is not merely lossy but *unreportably*
+  lossy: migration renumbers the survivors, so afterwards the hole is
+  gone, the list verifies healthy, and nothing is left to say an item was
+  destroyed. An earlier form of the dry run warned about duplicate residue
+  and said nothing whatsoever about holes, so a sweep over a fleet containing one
+  could report "0 refused, 0 errors" and an operator would proceed past the
+  last moment the damage was visible. Lazy migration already refused
+  damaged lists on exactly these grounds; this applies the same rule to the
+  deliberate path. Repair first
+  (``actingweb-verify-property-lists --repair``), or pass
+  ``--migrate-damaged`` / ``migrate_to_v2(allow_damaged=True)`` to migrate
+  anyway — which logs what it is giving up.
+
+  Duplicate residue is unaffected and still migrates: it stays visible
+  after conversion, since a v2 list's ``verify()`` reports duplicates the
+  same way a v1 list's does, so migrating it destroys no evidence. Only
+  holes and orphans gate.
+- A successful migration that closed holes (only reachable via
+  ``--migrate-damaged``) now logs at WARNING rather than INFO.
+
+- **Each list mutation now costs one additional point read.** Merging into a
+  fresh read of the metadata row is what makes the fix above work, and it is
+  not free: where a mutation previously wrote metadata from cache, it now reads
+  the row first. One extra round trip per ``append()``/``insert()``/``pop()``/
+  ``remove()``/``__setitem__()``/``__delitem__()``, on both backends. The
+  alternative is a compare-and-set primitive neither backend's ``DbProperty``
+  exposes; correctness was preferred over the round trip, and the trade is
+  recorded rather than buried.
+
+- The migration and property-list guides now state what a whole-list rewrite
+  does and does not exclude. Nothing locks out a concurrent application
+  write, so "run repair when the actor is not taking writes" remains a real
+  requirement; what is now guaranteed is that such a write cannot change the
+  list's storage format. Two concurrent migrations resolve to
+  last-writer-wins at whole-list granularity — accepted and documented
+  rather than prevented.
+
+- **The MCP unsupported-protocol-version rejection now names the supported
+  versions and logs at WARNING.** A client sending an
+  ``MCP-Protocol-Version`` this server does not speak still gets HTTP 400 with
+  JSON-RPC ``-32600`` and no ``data`` payload — that response shape is
+  deliberately unchanged, because it is the signal dual-era MCP clients use to
+  recognise a legacy-era server and fall back to ``initialize``. What changed:
+  the error ``message`` now lists the versions that would have worked, which
+  for a client that cannot fall back is the only diagnostic it can show a
+  user; and the rejection is logged at all, which it previously was not.
+
+  The logging is graded per origin rather than uniform, because the rejection
+  is answered on an **unauthenticated** path. A lone rejection is the normal
+  legacy-server handshake and is recorded at INFO; only a sustained run from
+  the same origin — a client retrying instead of falling back, i.e. a
+  modern-only client — escalates to WARNING, once per origin per five-minute
+  window. That keeps the actionable signal visible without handing anonymous
+  callers a log-volume lever, and it makes the "one-off versus sustained"
+  judgement in code instead of leaving it to whoever reads the logs. Origin is
+  taken from ``Mcp-Session-Id`` or the ``User-Agent``; the number of tracked
+  origins is capped.
+
+  The response code and the absence of ``data.supported`` are now covered by
+  regression tests that state why, since "fixing" this to a spec-shaped
+  ``-32022`` with ``data.supported`` would silently convert every dual-era
+  client's working fallback into a retry loop.
+
+- **Revoking a token, deleting a trust relationship or downgrading a permission
+  now evicts the MCP caches.** ``MCPHandler.clear_token_from_cache()`` had
+  exactly one caller — the logout handler — so every other path that
+  invalidates a client's identity or authorization left the in-process MCP
+  caches serving the old answer for up to their five-minute TTL. A revoked
+  token kept authenticating, a deleted trust kept authorizing, and a narrowed
+  permission kept being honoured at the old level, from any warm process.
+
+  Eviction is now wired into ``TokenManager.revoke_token()``, the SPA session
+  paths ``revoke_access_token()`` / ``revoke_refresh_token()`` (which is what
+  ``/oauth/revoke`` reaches), ``revoke_token_chain()`` (the refresh-token-reuse
+  theft response), ``revoke_all_tokens()``, trust deletion, and both the store
+  and delete paths of ``TrustPermissionStore``. It is actor-wide by necessity
+  rather than scoped to one client: the cached ``ActorInterface`` carries the
+  trust list itself, so evicting a single ``(actor, client)`` entry would leave
+  the shared wrapper answering from stale state. One consequence worth knowing:
+  any permission change on one client invalidates the cache for every MCP
+  client connected to that actor.
+
+  Eviction alone would not have been enough. A request that read a token from
+  storage just before the revocation could write what it read back into the
+  cache just after, reviving the credential for a full TTL while the eviction
+  reported success. A generation counter, bumped by every eviction and
+  snapshotted by each request before the reads that feed the caches, makes such
+  a request decline to populate them.
+
+  **This closes the window within one process only.** Every MCP cache is a
+  module global, so a multi-worker or multi-container deployment still serves
+  the stale entry from every *other* process until its TTL expires. Closing
+  that needs a shared invalidation channel and is not attempted here.
+
+- **``tools/list`` now warns when a hook's ``output_schema`` will not be
+  advertised.** ``outputSchema`` comes solely from ``@mcp_tool``; a schema
+  passed to ``@app.action_hook(..., output_schema=...)`` or derived from a
+  ``TypedDict`` return annotation is stored separately and never bridged, so an
+  author who declares one either of those ways gets silence rather than an
+  advertised schema — and the missing-``structuredContent`` warning stays quiet
+  for them too, because it is gated on the same metadata. The warning fires once
+  per tool per process, at listing time.
+
+  Deliberately a warning and not a merge: merging would newly advertise
+  ``outputSchema`` for every ``TypedDict``-annotated tool, and each one that
+  does not also return ``structuredContent`` would begin failing on
+  spec-conforming clients. That decision belongs with the ``structuredContent``
+  work and is not foreclosed here.
+
+ADDED
 ~~~~~
 
-- *(since rc1)* **A failed actor read on DynamoDB was completely silent.**
-  ``DbActor.get()`` caught bare ``Exception`` and returned ``None`` with no log
-  line at any level. The comment said "PynamoDB DoesNotExist", but the clause
-  also swallowed ``ProvisionedThroughputExceededException``, request timeouts,
-  credential errors and ``TableDoesNotExist`` — every one of which then
-  presented to callers as "this actor does not exist". An infrastructure fault
-  causing an existence check to answer "no" was undiagnosable from outside the
-  process. Genuine absence now returns ``None`` quietly as before; anything
-  else logs at ERROR naming the exception type and the consequence. It still
-  returns ``None`` rather than raising: raising would turn every transient
-  throttle across authentication, OAuth2 and MCP into an HTTP 500 on a release
-  already validated in production. Callers needing the distinction should use
-  ``get_deletion_status()``, which reports ``UNKNOWN`` rather than guessing.
-  (PostgreSQL already logged this at ERROR; DynamoDB was the asymmetric one.)
+- **DynamoDB table auto-creation can now be disabled** for deployments that
+  manage tables via infrastructure-as-code: set
+  ``AWS_DB_AUTO_CREATE_TABLES=false`` or call
+  ``with_dynamodb(auto_create_tables=False)``. With auto-creation off, the
+  library never calls ``DescribeTable``/``CreateTable``, so both permissions
+  can be dropped from the runtime IAM role.
+
+- **Actor deletion tombstones and a tri-state deletion check.**
+  ``ActorInterface.get_deletion_status(actor_id, config)`` returns
+  ``DeletionStatus.DELETED`` / ``NOT_DELETED`` / ``UNKNOWN`` from a tombstone
+  written *before* the ``actor_deleted`` hook runs — so an external call made
+  from that hook, and any provider callback racing it, already sees
+  ``DELETED`` — and retained for 30 days, past every provider's webhook retry
+  window.
+
+  This exists because a guard of the form "skip this work if the actor no
+  longer exists" could not be written correctly. ``Actor.delete()`` removes the
+  actor row **last**, so ``get_by_id()`` keeps returning a live actor for the
+  entire wipe: the check fails **open** in exactly the window it matters,
+  which the documented cleanup pattern enters deliberately (``actor_deleted``
+  cancels an external subscription; the provider's callback races the wipe).
+  Checking harder is not available either, because ``get_by_id()`` returns
+  ``None`` for a deleted actor *and* for a failed read — so the same guard
+  fails **closed** on a throttle, which for a paid-subscription webhook means
+  the customer paid and silently never got access. A consumer hit both:
+  4 attribute rows in production belonged to fully deleted accounts.
+
+  A tombstone is *positive* evidence, so it has a safe failure direction:
+  ``UNKNOWN`` means proceed, costing at most one orphan row an operator sweep
+  can find, rather than dropping work for a paying customer. The read is a
+  single strongly-consistent point read — measured at exactly one ``GetItem``,
+  not asserted. Tombstones live under a reserved id that is never itself an
+  actor, so no deletion can destroy them, and expired ones are filtered at
+  read time so TTL means the same thing on both backends. Re-creating an actor
+  clears its tombstone (``create(actor_id=...)`` accepts a caller-supplied id).
+
+  The actor row deliberately still goes last. Deleting it first would make
+  existence checks fail closed rather than open, but "missing" is
+  indistinguishable from "read failed" anyway, and it would cost the two
+  properties that ordering buys: deletion stays retriable if a wipe step
+  fails, and rows are never briefly classifiable as orphaned. The tombstone
+  answers the question without that trade.
+
+- **``actor_deleted_complete`` lifecycle hook**, fired after the
+  wipe completes with ``actor=None`` and ``actor_id=<id>``. There was
+  previously nowhere to put "do this once the actor is definitely gone", which
+  forced applications into the race above by design: ``actor_deleted`` is the
+  only place the actor's data is readable, so it was also the only place to
+  act on it. Now the work splits — read in ``actor_deleted``, act in
+  ``actor_deleted_complete`` — which removes the race at its source
+  independently of the tombstone. The absent ``ActorInterface`` is the point,
+  not an omission.
+
+- **``get_attr_strict()`` on both attribute backends** —
+  a point read that raises on infrastructure errors instead of collapsing them
+  into ``None``, and treats an expired row as absent. Used by the tombstone
+  read; available to applications with the same need. Building the tombstone
+  read on ``get_attr()`` would have reintroduced the very bug it fixes.
+
+  **Custom backend implementers:** this method is now part of
+  ``DbAttributeProtocol``, which is ``@runtime_checkable`` — an out-of-tree
+  attribute backend must add ``get_attr_strict()`` to keep satisfying
+  ``isinstance()`` checks against the protocol. Both bundled backends
+  implement it.
+
+- **Operator-facing table verifier:**
+  ``python -m actingweb.db.verify_tables`` reports which required DynamoDB
+  tables exist and which are missing. With auto-creation disabled, "all
+  tables exist" becomes a precondition the library deliberately no longer
+  checks (an existence check would cost an ``AccessDenied`` per accessor
+  construction on a slimmed role), and the required set previously had to be
+  read out of the source. Run it out-of-band with operator credentials —
+  it only reads, never creates, and adds nothing to the request path.
+  ``--list`` prints the names without calling AWS. Exit codes: ``0`` all
+  present, ``1`` one or more missing, ``2`` the check could not run. The
+  same list now drives table pre-warm, so what the library creates and what
+  operators are told to pre-create cannot drift apart.
+
+- **``auto_create_enabled()`` is public API**
+  (``from actingweb.db.dynamodb import auto_create_enabled``). Dropping
+  ``DescribeTable``/``CreateTable`` from the runtime role affects the whole
+  role, not just the library, so application code that probes its own tables
+  (boto3 ``table.load()``/``describe_table``, pynamodb ``exists()``) needs
+  the same switch — previously it had to re-implement the environment
+  parsing. ``set_auto_create()`` and ``reset_ensure_cache()`` are exported
+  alongside it.
+
+- **MCP: a warning when a tool declares ``output_schema`` but returns no
+  ``structuredContent``.** Spec-conforming clients reject such a result outright
+  (``Tool X has an output schema but did not return structured content``), which
+  was already broken before this release for anyone declaring a schema — the
+  library advertises ``outputSchema`` in ``tools/list`` but never consulted it at
+  call time. The warning fires once per tool per process, at call time, and only
+  when the negotiated protocol version supports structured content, so a
+  correctly-written hook talking to an older client never trips it.
+  ``output_schema`` and ``structuredContent`` remain independent: declaring a
+  schema has never caused structured output to be emitted, and the library still
+  does not validate ``structuredContent`` against a declared schema.
+
+- **MCP: a warning when ``structuredContent`` is set to a non-object.** MCP
+  requires a JSON object there; a list, string or number was previously dropped
+  silently. ``None`` is exempt and stays silent — it carries no payload, both
+  reference clients read a null ``structuredContent`` as absent, and
+  ``{"structuredContent": value or None}`` is a legitimate way to express
+  "nothing structured this time". In that case the key is omitted from the
+  response rather than emitted as ``null``.
+
+- **Property-list repair primitives.** ``ListProperty.verify()`` reports a
+  list's health (holes, orphan rows, a duplicate-value heuristic) without
+  modifying anything; ``ListProperty.compact()`` closes holes and removes
+  orphans in one pass while preserving ``description``/``explanation``/
+  ``created_at`` (unlike the previous ``clear()`` + ``extend()`` workaround,
+  which reset them). Duplicate residue is reported but never rewritten — a
+  duplicate value always means a destroyed item, and silently collapsing
+  one copy would bless the data loss as intentional. Both are also
+  available through ``actor.property_lists.<name>.verify()``/``.compact()``.
+  New operator script: ``scripts/verify_property_lists.py`` (dry-run by
+  default; ``--repair`` invokes ``compact()`` on unhealthy lists).
+
+- **Opt-in diagnostics for the PostgreSQL attribute ``DELETE`` path.** Set
+  ``ACTINGWEB_PG_DELETE_DIAGNOSTICS=1`` to log, per attribute delete, the
+  statement's ``rowcount``, the deleting connection's resolved schema and
+  ``search_path``, and a post-commit re-read on a freshly checked-out
+  connection. That combination distinguishes a delete that matched no rows
+  (wrong schema or wrong key) from one that matched and did not persist — the
+  question the quarantine above left unanswered for two months. Off by
+  default. When on it costs a savepoint-wrapped schema read plus a post-commit
+  re-read per delete, and cannot affect the delete it observes: the schema read
+  runs *before* the ``DELETE`` and inside a savepoint, because a server-side
+  failure there would otherwise abort the transaction and turn the later commit
+  into a silent rollback — the exact defect the diagnostics exist to find.
+
+
+.. note::
+
+   ``compact()`` crash atomicity is **not** addressed here and is deferred.
+   The warning boxes describing that window stand: the damage it
+   leaves is visible in the data and ``verify()`` catches it.
+
+FIXED
+~~~~~
 
 - **Changing an indexed property left its old reverse-lookup row behind on
   DynamoDB.** When an indexed value (e.g. ``email``) was updated through the
@@ -978,7 +688,7 @@ FIXED
   these settings were explicitly configured; precedence is consistently
   explicit builder call > environment variable > library default.
 
-- *(since rc1)* **Every property write issued a subscription-suspension read,
+- **Every property write issued a subscription-suspension read,
   even with no subscribers.** ``register_diffs()`` runs on each write and
   checked suspension *before* fetching subscriptions, so an actor with no
   subscriptions on the target paid a DynamoDB ``GetItem`` **and** the
@@ -991,7 +701,7 @@ FIXED
   ``{GetItem: 1, PutItem: 1, Query: 1}`` — no suspension read, no
   ``DescribeTable``, no ``Scan``.
 
-- *(since rc1)* **A failed subscription-suspension check was indistinguishable
+- **A failed subscription-suspension check was indistinguishable
   from "not suspended".** ``Actor.is_subscription_suspended()`` logged any
   failure at DEBUG and returned ``False``, so a missing suspensions table
   (pynamodb raises ``TableDoesNotExist``, which is *not* ``DoesNotExist``) or
@@ -1008,7 +718,7 @@ FIXED
   and then stay silent through every later failure, including a different
   one. Throttled failures are logged at DEBUG.
 
-- *(since rc1)* **Suspending a target suppressed nothing.**
+- **Suspending a target suppressed nothing.**
   ``suspend_subscriptions("properties")`` — the documented bulk-import usage —
   had no effect on property writes. ``PropertyStore`` registers every diff
   with the property name as the **subtarget**, so the check looked up
@@ -1034,7 +744,7 @@ FIXED
   suspended is still recorded separately, so resuming the target does not
   silently lift it.
 
-- *(since rc1)* **Subscriptions created through the interface layer received
+- **Subscriptions created through the interface layer received
   no diffs for the lifetime of the actor instance.**
   ``Actor.create_subscription()`` did not invalidate the actor's cached
   subscription list (``subs_list``); only the *delete* paths did, and only the
@@ -1048,10 +758,93 @@ FIXED
   ``Actor``, still leaves that instance's list stale until it is rebuilt —
   tracked in ``thoughts/todo/subs-list-cache-asymmetry.md``.
 
+- **Config-bound singletons no longer serve one application's state to
+  another.** ``get_actingweb_oauth2_server()``,
+  ``get_mcp_client_registry()``, ``get_actingweb_token_manager()``,
+  ``get_oauth2_state_manager()``, ``get_permission_evaluator()``,
+  ``get_registry()`` (trust types), ``get_trust_permission_store()``,
+  ``get_peer_permission_store()``, ``get_peer_profile_store()`` and
+  ``get_cached_capabilities_store()`` each take a ``config`` argument but,
+  once built, ignored it — they bound to the **first** config the process
+  ever passed and returned that instance to every later caller. (One of them
+  documented this explicitly: "config parameter kept for interface
+  consistency but not used".) Any process hosting more than one ActingWeb
+  application therefore had the second application silently using the
+  first's configuration, **including its database backend**. The observed
+  consequence: MCP dynamic client registration wrote a trust row to one
+  backend while trust resolution read another, so the client's trust was
+  never found. Under the old fail-open behavior that granted the client
+  *full access*; under the fail-closed behavior above it returns ``-32003``.
+  Each getter now rebuilds when handed a different ``Config`` instance, and
+  still returns the cached instance for the same one. Single-application
+  deployments — the overwhelming majority — are unaffected either way.
+
+  Note that ``ActingWebOAuth2Server`` *composes* three of these, so rebinding
+  the server alone was not sufficient: ``client_registry``, ``token_manager``
+  and ``state_manager`` had to rebind too. ``get_oauth2_state_manager()``
+  re-reads its encryption key from the new config's system actor on rebind;
+  the key is stored rather than generated, so it is stable.
+
+- **MCP: an explicit ``isError`` is now honoured on the legacy text-wrap path.**
+  A hook returning ``{"isError": True, "error": "boom"}`` with no ``content`` key
+  previously reached the wire with no ``isError`` field at all, so the failure was
+  reported to the client as a **success**. ``isError`` is honoured only when the
+  hook sets it — it is never inferred from an ``"error"`` key or any other shape
+  heuristic, so applications that return ``{"error": ...}`` on their normal error
+  path see no change. The ``str(result)`` text serialization is unchanged, so
+  ``isError`` appears both inside that text and as a wire field.
+
+- **``list.index()`` semantics for negative ``start``/``stop``.**
+  ``index(value, -1)`` could previously return ``-1`` as an index (the loop
+  ran ``range(-1, n)`` and then indexed negatively). Both storage formats
+  now normalize bounds exactly as ``list.index`` does, through one shared
+  helper so they cannot diverge across a migration.
+
+- **``pop()`` and ``remove()`` now delete conditionally on the value they
+  read.** Resolving the item's storage key once was not enough: a
+  concurrent assignment to that same key between the read and the delete
+  would discard the other writer's value while reporting the one this
+  caller saw — an outcome corresponding to no serial ordering of the two
+  operations. Both now use the new
+  ``DbPropertyProtocol.delete_if_value_equals()`` and re-resolve on a
+  failed condition, so ``pop()`` always returns exactly what it removed and
+  ``remove()`` always removes exactly what it matched.
+  ``__delitem__``/``__setitem__`` remain unconditional by design.
+- ``pop()`` on a v2 list no longer raises ``pop from empty list`` against a
+  list another writer has appended to (the empty check consulted a cached
+  length before the v2 path could refresh it).
+
+- **``ListProperty.insert()`` destroyed data on every call into a non-empty
+  list on DynamoDB.** ``insert()`` reused one cached ``DbProperty`` handle
+  across its whole shift loop instead of taking a fresh handle per
+  get()/set() like every other list method; on DynamoDB this caused each
+  shifted row to be overwritten with the last value read instead of its
+  own. Fixed both at the call site (fresh handles, matching the rest of the
+  class) and in the DynamoDB and PostgreSQL backends' ``DbProperty.get()``/
+  ``set()`` (a cached handle for a different ``(actor_id, name)`` is now
+  always discarded rather than reused).
+
+- **Backend read/write failures on property (and property-list item) storage
+  were silently swallowed as absence or as a no-op.** ``DbProperty.get()``
+  now raises ``actingweb.db.exceptions.DbError`` on a genuine backend fault
+  instead of returning ``None`` (``None`` means the row does not exist, and
+  only that, on both backends). Every ``ListProperty`` mutation
+  (``append``, ``__setitem__``, ``__delitem__``, ``insert``, ``clear``,
+  ``delete``, metadata writes) now checks ``set()``'s return value and
+  raises ``RuntimeError`` instead of continuing past a failed write. This is
+  a breaking change for any code that relied on a backend fault degrading
+  to ``None``/no-op on a property read/write.
+- Backend exception text no longer reaches HTTP error responses from the
+  list-property handlers (``PUT``/POST/DELETE on ``/properties/<name>`` and
+  ``/properties/<name>/items``) — the client sees a generic message; the
+  original exception is still logged server-side.
+- Unparsable list metadata no longer self-heals into a fresh empty list
+  (which orphaned every existing item row with no way back to them) —
+  ``ListProperty`` now raises ``ValueError`` instead, and the row is left
+  untouched for repair.
+
 DOCUMENTATION
 ~~~~~~~~~~~~~
-
-*All since rc1, from a production upgrade of the release candidate.*
 
 - **New page: Actor Deletion Semantics** (``docs/reference/actor-deletion.rst``).
   States the contract that previously had to be read out of the source: the
@@ -1077,39 +870,69 @@ DOCUMENTATION
   and it previously existed only in source. ``<prefix>_subscription_suspensions``
   is called out specifically: its accessor had no auto-create guard before
   3.13, so long-lived deployments frequently never created it.
+
 - **The pre-warm/IaC race is documented.** Declaring the new tables in
   CloudFormation/Terraform in the *same* deploy as the library bump lets a
   cold start create ``<prefix>_property_lookup_v2`` first, failing the stack
   with ``ResourceInUseException``. Sequence the deploys, or let auto-creation
   own the tables — not both.
+
 - **The rollback instruction is qualified.** Legacy mode needs the
   ``property-index`` GSI on the properties table; a table created before that
   index existed has no rollback path for reverse lookup. Check
   ``describe-table`` before upgrading.
+
 - **Migration rehearsal against DynamoDB Local** is documented end-to-end —
   table creation, fallback tiers, backfill, tripwire — so the backfill is not
   performed for the first time in production.
+
 - **A recipe for proving the fixes landed**, since both are invisible to
   functional tests: count DynamoDB operations via
   ``botocore.client.BaseClient._make_api_call``. Includes the trap that a
   ``before-call.dynamodb`` session handler counts *nothing* under pynamodb
   (``get_session()`` returns a fresh session per call), which makes
   ``assert scans == 0`` pass vacuously.
+
 - **Validating this release requires a DynamoDB backend** — a green suite on
   PostgreSQL exercises none of the changed code.
+
 - **Auditing your own ``DescribeTable``/``CreateTable`` use** is called out
   when recommending the flag: the IAM change is account-wide, not
   library-scoped.
+
 - **Reverse lookup is not always the login path** — apps resolving via
   ``get_from_creator()`` are unaffected, which changes how urgent the backfill
   is. The doc now says to check rather than assume.
+
 - **Direct ``DbPropertyLookup().get()`` use bypasses the fallback tiers**
   (v2-only), so operational scripts return ``None`` during the migration
   window while the app is healthy. ``get_actor_id_from_property()`` is named
   as the supported entry point.
+
 - **``describe-table``'s ``ItemCount`` refreshes only every ~6 hours**, so a
   freshly backfilled lookup table still reports ``ItemCount: 0``. Verify with
   ``scan --select COUNT``.
+
+- **Documented that ``compact()`` is not crash-safe in either storage
+  format, and that an interrupted repair leaves damage repair will not
+  itself fix.** Only the v2 rank-rebalance window was documented in
+  this release; the v1 path -- the one every upgrading operator runs via
+  ``actingweb-verify-property-lists --repair`` -- has the same shape.
+  Survivors are written to their new positions before the tail rows are
+  deleted, so an interruption leaves a copy at both, with the stored length
+  unchanged: the list reads back with **no error**. ``verify()`` catches it
+  through the adjacent-duplicate heuristic, but re-running ``--repair``
+  will not remove the copy, because duplicates are preserved by design --
+  including the one the interrupted repair created. Now covered in the
+  migration guide's repair step (where operators are told to run it), the
+  property-lists guide, and ``compact()``'s docstring, with a regression
+  test pinning the measured interruption states. No behaviour change.
+- Corrected two stale statements about lazy migration, which is **off by
+  default** in this release: the downgrade-ordering warning described a
+  50-item list as "by definition a lazy-migration candidate" (true only where
+  an operator has raised the limit), and the bulk script's own docstring
+  opened by describing lazy migration as the normal path.
+
 
 v3.12.0: July 9, 2026
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -846,6 +846,20 @@ FIXED
 DOCUMENTATION
 ~~~~~~~~~~~~~
 
+- **The migration guide is organised by where you are upgrading from, not by
+  which release candidate added what.** ``docs/migration/v3.13.rst`` had grown
+  five sections titled "Behaviour change in rcN", each opening with a note
+  telling you to read every section between your version and the target. That
+  works while the rcs are current and stops working the moment they are one
+  release. It now opens with a **Start here** section giving two paths — from
+  ``3.12.x`` (do all four pieces of work, in the stated order, because two have
+  pre-upgrade steps) and from a release candidate (a table saying exactly what
+  is left to do for each of ``rc1`` through ``rc6``) — followed by what changed
+  after ``rc6`` for anyone tracking the pre-releases. The four work sections
+  are named for what they cover rather than for the rc that introduced them,
+  and the DynamoDB material is now nested under its own heading instead of
+  sitting as a flat run of peers titled "Overview".
+
 - **New page: Actor Deletion Semantics** (``docs/reference/actor-deletion.rst``).
   States the contract that previously had to be read out of the source: the
   exact deletion order and why the actor row goes last, that ``get_by_id()``

--- a/actingweb/__init__.py
+++ b/actingweb/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.13.0rc6"
+__version__ = "3.13.0"
 
 # Modules are lazy-loaded on-demand, so they're not imported here
 __all__ = [

--- a/actingweb/maintenance/verify_property_lists.py
+++ b/actingweb/maintenance/verify_property_lists.py
@@ -324,9 +324,11 @@ def main() -> int:
             "with --repair, also compact a v1 list that is damaged AND carries "
             "rows of the v2 format. That combination is a REVERTED MIGRATION, "
             "not an ordinary hole: the items are probably intact in the v2 "
-            "rows, and compacting reports the list healthy while stranding "
-            "them. Refused by default; pass this only after deciding to "
-            "abandon those items"
+            "rows. Compacting does not delete them -- it makes the list report "
+            "HEALTHY while they become unreferenced, so the warning that they "
+            "matter disappears and the NEXT clear()/delete()/migrate re-run "
+            "sweeps them for real. Pass this only after extracting those rows, "
+            "or after deciding to abandon them"
         ),
     )
     parser.add_argument(

--- a/actingweb/maintenance/verify_property_lists.py
+++ b/actingweb/maintenance/verify_property_lists.py
@@ -140,6 +140,7 @@ def sweep_actor(
     repair: bool,
     limiter: RateLimiter,
     identity_key: str | None = None,
+    repair_reverted: bool = False,
 ) -> tuple[int, int, int]:
     """Verify (and optionally repair) every list belonging to one actor.
 
@@ -170,6 +171,10 @@ def sweep_actor(
             errored += 1
             continue
 
+        # v1 and v2 reports carry different fields, and the foreign-row
+        # handling below branches on the format, so resolve it first.
+        is_v2 = report.get("format") == 2
+
         # Rows of the OTHER storage format sharing this list's name: what an
         # interrupted migration or downgrade leaves. Not a health failure --
         # they are inert to every reader of the current format, and the
@@ -177,13 +182,39 @@ def sweep_actor(
         # an operator runs that would ever surface them, and the remedy is a
         # command rather than a manual repair. So: say it, then move on.
         if report.get("foreign_format_rows"):
-            logger.info(
-                f"actor={actor_id} list={name}: {report['foreign_format_rows']} "
-                f"row(s) of the other storage format present -- residue from "
-                f"an interrupted migration/downgrade. Harmless to reads; "
-                f"clear it by re-running actingweb-migrate-property-lists "
-                f"--migrate"
+            # Two very different situations share this field, and the
+            # difference decides whether those rows are junk or the data.
+            #
+            # On a HEALTHY list they are residue from an interrupted
+            # migration or downgrade: inert, and cleared by a re-run.
+            #
+            # On a DAMAGED v1 list they are almost certainly the list --
+            # a migration that got format-reverted, with the items alive in
+            # the v2 rows and the v1 range empty. Telling an operator to
+            # "clear it by re-running --migrate" there is telling them to
+            # delete the only surviving copy. This line used to say exactly
+            # that, unconditionally.
+            reverted = not is_v2 and (
+                report["missing_indices"] or report["orphan_indices"]
             )
+            if reverted:
+                logger.warning(
+                    f"actor={actor_id} list={name}: DAMAGED **and** carrying "
+                    f"{report['foreign_format_rows']} row(s) of the v2 storage "
+                    f"format. This is a REVERTED MIGRATION, not an ordinary "
+                    f"hole -- the items are probably intact in those v2 rows. "
+                    f"Do NOT sweep them and do NOT run --repair on this list: "
+                    f"both destroy the only surviving copy and leave the list "
+                    f"reporting healthy. Recover first."
+                )
+            else:
+                logger.info(
+                    f"actor={actor_id} list={name}: {report['foreign_format_rows']} "
+                    f"row(s) of the other storage format present -- residue from "
+                    f"an interrupted migration/downgrade. Inert to readers of "
+                    f"this list's format; clear it by re-running "
+                    f"actingweb-migrate-property-lists --migrate"
+                )
 
         if report["healthy"]:
             continue
@@ -193,8 +224,6 @@ def sweep_actor(
         # present); v2 lists structurally cannot (position is always
         # derived from what's present), so their report carries rank-length
         # info instead. See ListProperty.verify()/._v2_verify().
-        is_v2 = report.get("format") == 2
-
         if is_v2:
             logger.warning(
                 f"actor={actor_id} list={name}: UNHEALTHY (v2) "
@@ -257,10 +286,17 @@ def sweep_actor(
             continue
 
         try:
-            list_prop.compact()
+            compact_report = list_prop.compact(allow_reverted=repair_reverted)
         except Exception as e:
             logger.error(f"actor={actor_id} list={name}: compact() failed: {e}")
             errored += 1
+            continue
+
+        if compact_report.get("compacted") is False:
+            # compact() refused a reverted migration and said why. Counted
+            # as still-unhealthy rather than errored: nothing failed, the
+            # tool declined to make it worse.
+            unhealthy_after += 1
             continue
 
         post = list_prop.verify(identity_key=identity_key)
@@ -280,6 +316,18 @@ def main() -> int:
         "--repair",
         action="store_true",
         help="invoke compact() on unhealthy lists (default: dry-run report only)",
+    )
+    parser.add_argument(
+        "--repair-reverted",
+        action="store_true",
+        help=(
+            "with --repair, also compact a v1 list that is damaged AND carries "
+            "rows of the v2 format. That combination is a REVERTED MIGRATION, "
+            "not an ordinary hole: the items are probably intact in the v2 "
+            "rows, and compacting reports the list healthy while stranding "
+            "them. Refused by default; pass this only after deciding to "
+            "abandon those items"
+        ),
     )
     parser.add_argument(
         "--rps",
@@ -329,7 +377,12 @@ def main() -> int:
         if not actor_id or checkpoint.is_done(actor_id):
             continue
         checked, unhealthy, errored = sweep_actor(
-            actor_id, config, args.repair, limiter, args.identity_key
+            actor_id,
+            config,
+            args.repair,
+            limiter,
+            args.identity_key,
+            repair_reverted=args.repair_reverted,
         )
         total_checked += checked
         total_unhealthy += unhealthy

--- a/actingweb/property_list.py
+++ b/actingweb/property_list.py
@@ -2060,6 +2060,14 @@ class ListProperty:
                 pre-revert metadata, or reading the v2 rows out by hand --
                 and the question does not arise.
 
+                Note this is one step removed from deletion rather than
+                deletion itself, which is what makes it sharper than it
+                looks: the v2 rows survive this call. What it removes is
+                the *report* that they matter -- the list goes from loudly
+                unhealthy to healthy -- so the next
+                ``clear()``/``delete()``/migrate re-run sweeps them with
+                nothing left to say they were the data.
+
         Returns:
             The ``verify()`` report this call acted on (taken before any
             write). On a refusal, that report plus ``compacted: False``

--- a/actingweb/property_list.py
+++ b/actingweb/property_list.py
@@ -499,8 +499,46 @@ class ListProperty:
             # check that creating a list must go through.
             stored = dict(self._load_metadata())
 
+        stored_format = int(stored.get("format", 1) or 1)
+
+        # Did this instance dispatch the mutation it is now recording against
+        # a format the list no longer has?
+        #
+        # The write itself is already done by the time we get here -- append()
+        # stores the item row, then calls this -- so an item written by a
+        # stale v1 instance into a list that is now v2 is sitting in a
+        # v1-shaped row that no v2 reader will ever return. It is not lost
+        # data, it is unreachable data, and until this warning existed the
+        # only trace was a DEBUG line and a `foreign_format_rows` count that
+        # verify() reports while calling the list HEALTHY.
+        #
+        # Self-limiting: _replace_metadata() below caches the merged row, so
+        # this instance's NEXT mutation dispatches correctly. One write per
+        # retained instance, which is why this warns rather than raises --
+        # the caller's operation succeeded, it just landed somewhere nothing
+        # reads. Found by consumer verification against 3.13.0 GA.
+        if self._meta_cache is not None:
+            believed_format = int(self._meta_cache.get("format", 1) or 1)
+            if believed_format != stored_format:
+                logger.warning(
+                    "List '%s' (actor %s): this instance believed the storage "
+                    "format was v%d but the stored row says v%d -- it was "
+                    "migrated by someone else while this instance was held. "
+                    "Any item this operation wrote went into a v%d-shaped row "
+                    "that v%d readers do not see; verify() will still report "
+                    "the list healthy, and the row shows up only as "
+                    "foreign_format_rows. Re-issue the write. This instance "
+                    "self-corrects from here.",
+                    self.name,
+                    self.actor_id,
+                    believed_format,
+                    stored_format,
+                    believed_format,
+                    stored_format,
+                )
+
         meta = dict(stored)
-        if int(meta.get("format", 1) or 1) == 2:
+        if stored_format == 2:
             updates = {k: v for k, v in updates.items() if k != "length"}
         meta.update(updates)
         for field in remove:
@@ -1960,7 +1998,7 @@ class ListProperty:
         self._v2_rank_cache = sorted(written_ranks)
         return report
 
-    def compact(self) -> dict[str, Any]:
+    def compact(self, allow_reverted: bool = False) -> dict[str, Any]:
         """Repair holes and orphans by rewriting the list densely.
 
         v2: rebalances rank keys -- see ``_v2_compact()``.
@@ -1999,14 +2037,54 @@ class ListProperty:
         Prefer running repair when the actor is not taking writes, and
         re-run ``verify()`` afterwards rather than assuming success.
 
+        REFUSES A REVERTED MIGRATION. A v1 list that is damaged **and**
+        has ``foreign_format_rows > 0`` is not an ordinary hole: it is a
+        list whose migration to v2 was reverted, and its items are
+        probably alive in the v2 rows. Compacting it would rewrite the
+        (empty) v1 range, set the length to what it found, report the
+        list **healthy**, and strand the only surviving copy as residue
+        for the next ``clear()``/``delete()``/migrate re-run to sweep.
+        That is the same unreportable loss ``migrate_to_v2()`` refuses
+        damaged lists to avoid, in the other tool -- so this refuses too,
+        and ``allow_reverted=True`` is the deliberate override.
+
+        Found by consumer verification against 3.13.0 GA, not by the
+        library's own tests: the shape needs a migration that got
+        reverted, which no unit test built.
+
+        Args:
+            allow_reverted: compact a v1 list that has rows of the other
+                storage format, accepting that the items in them stop
+                being reachable and stop being reported. Off by default.
+                Recover first -- re-running ``migrate_to_v2()`` on the
+                pre-revert metadata, or reading the v2 rows out by hand --
+                and the question does not arise.
+
         Returns:
             The ``verify()`` report this call acted on (taken before any
-            write).
+            write). On a refusal, that report plus ``compacted: False``
+            and ``reason``.
         """
         if self._is_v2():
             return self._v2_compact()
 
         report = self.verify()
+
+        damaged = bool(report["missing_indices"] or report["orphan_indices"])
+        if damaged and report["foreign_format_rows"] and not allow_reverted:
+            logger.error(
+                "Refusing to compact list '%s' for actor %s: it is damaged AND "
+                "carries %d row(s) of the v2 storage format. That combination "
+                "means a migration was reverted, not that the list has an "
+                "ordinary hole -- the items are probably intact in the v2 rows, "
+                "and compacting would report this list healthy while stranding "
+                "them. Recover the v2 rows first. Pass allow_reverted=True "
+                "(--repair-reverted) only after deciding to abandon them.",
+                self.name,
+                self.actor_id,
+                report["foreign_format_rows"],
+            )
+            return {**report, "compacted": False, "reason": "reverted_migration"}
 
         if not self._db:
             raise RuntimeError("No database connection available")

--- a/docs/guides/troubleshooting.rst
+++ b/docs/guides/troubleshooting.rst
@@ -55,7 +55,8 @@ MCP client sees an empty tool list or ``-32003`` after upgrading
   request — check the logs over a short window, not just the exact moment
   you reproduce the symptom.
 - **Fix**: Work through the pre-upgrade checklist in
-  ``docs/migration/v3.13.rst`` ("Security fix in rc3") — it covers finding
+  ``docs/migration/v3.13.rst`` ("Security: MCP trust-cache authorization
+  bypass") — it covers finding
   at-risk trust rows, auditing Flask resource URIs against your trust
   type's allowed patterns, and what happens to per-peer permission
   overrides when a client re-authorizes. In most cases the client simply
@@ -77,7 +78,8 @@ MCP tool's structured data disappeared after upgrading
   deliberate migration, not an error.
 - **Fix**: Nest the data under an explicit ``structuredContent`` key, and keep
   the same object serialized in a text ``content`` block so clients that ignore
-  ``structuredContent`` still receive it. See the ``rc4`` section of
+  ``structuredContent`` still receive it. See "MCP: ``structuredContent`` is
+  now opt-in" in
   ``docs/migration/v3.13.rst``. If the tool's real payload is prose, returning
   prose alone is now the correct shape.
 - **Note when verifying with ``curl``**: a request with no

--- a/docs/migration/index.rst
+++ b/docs/migration/index.rst
@@ -23,13 +23,15 @@ Version Migrations
 ==================
 
 **v3.13 Migration**
-   Guide for upgrading to ActingWeb 3.13, covering the DynamoDB scalability
-   work (``rc1``/``rc2``), the MCP trust-cache authorization fix (``rc3``),
-   the MCP ``structuredContent`` behaviour change in ``rc4``, the
-   property-list changes in ``rc5``, and migration's refusal to convert
-   damaged lists in ``rc6``. **If you use list properties, read the ``rc5``
-   section before upgrading** — list reads now fail loudly on pre-existing
-   data damage that earlier releases silently skipped past, so sweeping and
+   Guide for upgrading to ActingWeb 3.13. It covers four largely independent
+   pieces of work — the DynamoDB scalability change and its **required**
+   reverse-lookup backfill, an MCP trust-cache authorization fix, the MCP
+   ``structuredContent`` behaviour change, and the property-list storage
+   format — and opens with a "Start here" section that says which of them
+   apply depending on whether you are coming from 3.12.x or from one of the
+   3.13 release candidates. **If you use list properties, do the sweep in
+   step 1 before upgrading** — list reads now fail loudly on pre-existing data
+   damage that earlier releases silently skipped past, so sweeping and
    repairing comes first.
 
 **v3.11 Migration**

--- a/docs/migration/v3.13.rst
+++ b/docs/migration/v3.13.rst
@@ -2,52 +2,127 @@
 Migrating to ActingWeb 3.13
 ===========================
 
-Behaviour change in rc6: migration refuses damaged lists
-========================================================
+Start here
+==========
+
+3.13 bundles four largely independent pieces of work: a **property-list**
+storage change with pre-upgrade steps, an **MCP** behaviour change, an **MCP
+security fix**, and a **DynamoDB scalability** change with a required backfill.
+Which of them you need depends only on where you are coming from.
+
+Upgrading from 3.12.x or earlier
+--------------------------------
+
+**Do all four sections, and do them in the order below**, because two of them
+have work that must happen *before* you deploy the new version:
+
+1. **Property lists** — step 1 sweeps for pre-existing damage and **must run
+   on the old version**. 3.13 turns damage that was previously invisible into
+   a visible error, so a sweep afterwards tells you less than a sweep before.
+2. **Security: MCP trust-cache bypass** — the "find trust rows that predate
+   exact resolver matching" audit is also a before-you-upgrade step.
+3. **DynamoDB scalability** — the reverse-lookup backfill is **required** for
+   any deployment using reverse lookup, and has a rollback window worth
+   understanding before you start.
+4. **MCP structuredContent** and the remaining behaviour changes — these need
+   code changes on your side if you are affected, but no pre-upgrade sweep.
+
+If you do not use list properties, do not expose MCP, and do not use reverse
+lookup, the only thing left that can affect you is "Property reads now raise
+on backend faults" — read that and you are done.
+
+Upgrading from a 3.13 release candidate
+---------------------------------------
+
+Do the sections that were added after the rc you are running. Nothing in this
+table is optional for the rcs it names — the earlier rcs' pre-upgrade steps
+still apply if you never did them.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 82
+
+   * - You are on
+     - Still to do
+   * - ``rc1``
+     - Everything except the reverse-lookup **backfill**, which you have
+       already run. Property lists, the security audit and MCP
+       ``structuredContent`` are all new to you — and re-read the rest of the
+       DynamoDB section, because three of its changes touch a code path rather
+       than only docs: ``register_diffs()`` now resolves subscriptions before
+       consulting suspension state, ``create_subscription()`` invalidates the
+       actor's cached subscription list, and actor deletion writes a tombstone
+       before the wipe begins.
+   * - ``rc2``
+     - Everything except the DynamoDB section, whose backfill you have already
+       run. Property lists, the security audit, and MCP ``structuredContent``
+       are all new to you.
+   * - ``rc3``
+     - Property lists, ``Migration refuses damaged lists``, and MCP
+       ``structuredContent``. **Run the step-1 sweep before upgrading** — see
+       the ``rc4`` row for why.
+   * - ``rc4``
+     - Property lists and ``Migration refuses damaged lists``. **Run the
+       step-1 sweep before upgrading**: you are on the last release that hides
+       pre-existing list damage. 3.13.0 surfaces it as a 409 instead of
+       silently compacting past it, so a list that has been quietly broken for
+       months starts erroring the moment you deploy — and the sweep is easier
+       to reason about before that than after.
+   * - ``rc5``
+     - ``Migration refuses damaged lists``, plus the note below.
+   * - ``rc6``
+     - Only the note below.
+
+What changed after ``rc6``
+--------------------------
+
+Between ``rc6`` and ``3.13.0`` the release gained four changes. **None
+requires operator action, and there is no data migration between them** — but
+two are worth knowing about:
+
+- **A list-metadata fix that matters if you are mid-migration.** Before
+  ``3.13.0``, a concurrent write could put ``format: 1`` back over a completed
+  migration's format flip by writing a whole cached metadata dictionary back;
+  migration then deleted the v1 rows and the list read back **empty, with no
+  error**. If you have been running ``actingweb-migrate-property-lists``
+  against a live deployment on ``rc5`` or ``rc6``, run
+  ``actingweb-verify-property-lists`` once after upgrading. There is no repair
+  step to run — the fix is preventative — but a list that was destroyed this
+  way is already gone and you would rather know.
+- **MCP revocation now evicts the in-process caches.** A revoked token, a
+  deleted trust relationship or a downgraded permission previously kept
+  working from a warm process for up to five minutes. It no longer does,
+  **within the process that served the revocation** — a multi-worker or
+  multi-container deployment still serves the stale answer from every *other*
+  process until its TTL expires. If your threat model depended on the old
+  behaviour being instantaneous, it never was.
+
+The other two are an opt-in PostgreSQL diagnostic
+(``ACTINGWEB_PG_DELETE_DIAGNOSTICS``, off by default) and a change in how
+unsupported-``MCP-Protocol-Version`` rejections are logged: a lone rejection is
+now INFO rather than unlogged, and a sustained run from one origin escalates to
+WARNING once. If you alert on WARNING from ``actingweb.handlers.mcp``, that is
+a new line you may see — it means a client is retrying instead of falling back,
+which is worth investigating rather than silencing.
+
+.. warning::
+
+   **A green test suite is not evidence this release landed correctly.** The
+   read-path and capacity fixes are invisible to functional tests — they
+   change how much a request costs, not what it returns. Use the
+   operation-profile recipe in "Proving the fixes actually landed" at the end
+   of this document to confirm them against your own hot paths.
+
+Property lists: storage format, repair, and fail-fast reads
+===========================================================
 
 .. note::
 
-   This is a refinement of the ``rc5`` property-list work below, and only
-   affects you if you run ``actingweb-migrate-property-lists`` (step 4). If
-   you are upgrading from a release older than ``rc5``, read the ``rc5``
-   section first — it is the one with the pre-upgrade steps.
-
-``actingweb-migrate-property-lists --migrate`` and
-``ListProperty.migrate_to_v2()`` now **refuse a list with holes or orphans**,
-and the dry run reports those lists as needing repair instead of counting
-them as "would migrate". A dry run that finds any exits ``1``.
-
-The reason is that migrating damaged data is not just lossy, it is
-*unreportably* lossy. Migration renumbers the surviving rows, so the hole is
-gone afterwards — and so is the evidence. The migrated list verifies healthy,
-and nothing remains to say an item ever went missing. In ``rc5`` the dry run
-said nothing about holes at all, so a sweep over a fleet containing one could
-report "0 refused, 0 errors" and an operator would proceed in good faith,
-past the last moment at which the damage was still visible.
-
-Lazy migration already refused damaged lists in ``rc5``, for exactly this
-reason. ``rc6`` applies the same rule to the deliberate path.
-
-What to do: **repair first** (step 2), then migrate. If you have looked at
-the damage and decided to migrate anyway, ``--migrate-damaged`` (or
-``migrate_to_v2(allow_damaged=True)``) does it, and says clearly in the log
-what it is giving up.
-
-Duplicate residue is **not** affected — it never blocked migration and still
-does not. A duplicate stays visible after conversion, because v2's
-``verify()`` reports duplicates just as v1's does, so migrating it destroys
-no evidence. Only holes and orphans gate.
-
-Behaviour change in rc5: property-list storage, repair, and fail-fast reads
-===========================================================================
-
-.. note::
-
-   This section covers ``v3.13.0rc5``. It is independent of the ``rc4`` MCP
-   change and the ``rc3``/``rc1``/``rc2`` sections below. It applies to every
-   deployment that uses **list properties** (``actor.property_lists.*``,
-   ``/properties/<name>`` on a list). If you use only scalar properties, read
-   just "Property reads now raise on backend faults" below and skip the rest.
+   Applies to every deployment that uses **list properties**
+   (``actor.property_lists.*``, ``/properties/<name>`` on a list), and is
+   independent of the MCP and DynamoDB sections. If you use only scalar
+   properties, read just "Property reads now raise on backend faults" below
+   and skip the rest.
 
 Read this section before upgrading, not after. One of the changes turns
 pre-existing, previously-invisible data damage into a visible error, so the
@@ -65,14 +140,15 @@ transaction, so an interruption anywhere in the middle left a hole, a
 duplicate, or a length that disagreed with reality — and reads silently
 compacted past the damage, so nothing ever surfaced it.
 
-rc5 fixes the write paths, adds repair tooling, makes reads fail loudly
+3.13 fixes the write paths, adds repair tooling, makes reads fail loudly
 instead of quietly, and introduces a storage format in which the whole class
 of defect is structurally impossible.
 
 Step 1: sweep for existing damage BEFORE upgrading
 --------------------------------------------------
 
-Any list damaged by the old code is still damaged. rc4 hid that; rc5 will
+Any list damaged by the old code is still damaged. Releases before 3.13 hid
+that; 3.13 will
 not. Find out what you have first::
 
     actingweb-verify-property-lists
@@ -149,7 +225,7 @@ gone.
    nice-to-have. What 3.13 *does* guarantee is that such a write can no
    longer corrupt the list's **format** *from a stale cache*: a concurrent
    write updates only the metadata fields it changes, merged into a fresh
-   read. In ``rc6`` and earlier it wrote a whole cached dictionary back,
+   read. In ``v3.13.0rc6`` and earlier it wrote a whole cached dictionary back,
    putting ``format: 1`` over a completed migration, and the result was total
    silent loss — see the CHANGELOG.
 
@@ -169,7 +245,7 @@ list's recorded length is missing from storage. Every HTTP path that serves
 list content returns **409** with
 ``{"error": "list_corrupted", "list": ..., "detail": ..., "remedy": "compact"}``.
 
-This is the change that makes step 1 non-optional: a hole that rc4 silently
+This is the change that makes step 1 non-optional: a hole that earlier releases silently
 skipped becomes a raised exception or a 409. Audit your call sites — anything
 that reads a list and cannot tolerate an exception needs a
 ``ListCorruptionError`` handler, and the underlying list needs repairing::
@@ -207,7 +283,7 @@ Step 4: decide when lists are allowed to change format
 
 .. danger::
 
-   **Automatic conversion of existing lists is OFF by default in rc5**
+   **Automatic conversion of existing lists is OFF by default**
    (``ACTINGWEB_LAZY_MIGRATION_MAX_LENGTH=0``). Leave it that way for this
    release's deployment: no list changes format, so rolling back stays a
    pure code rollback with no data to reconcile. Convert later, deliberately.
@@ -216,7 +292,7 @@ Step 4: decide when lists are allowed to change format
    v2 with no action from you. Only the conversion of data you already have
    waits for your go-ahead.
 
-   The reason is not latency, it is rollback. A pre-rc5 process does not
+   The reason is not latency, it is rollback. A pre-3.13 process does not
    error on a migrated list -- it reads it as **empty**, silently. The
    metadata row still exists, so the list "exists"; a v2 list stores no
    ``length`` field, and an older reader takes the absence as zero. A write
@@ -238,7 +314,7 @@ Step 4: decide when lists are allowed to change format
    become v2 until every process that might serve it can read v2, including
    the release you would roll back to.**
 
-Once rc5 has been live long enough that rollback is off the table, migrate
+Once 3.13 has been live long enough that rollback is off the table, migrate
 as a deliberate operator action::
 
     actingweb-migrate-property-lists              # dry run
@@ -249,7 +325,7 @@ the gate.** Migration refuses a list with holes or orphans, and the dry run
 names them and exits ``1``; a dry run that exits ``0`` is telling you the
 migration has nothing to trip over. This matters more than it sounds:
 migration renumbers survivors, so a hole that goes through it stops existing
-*and* stops being reportable. See the rc6 section at the top.
+*and* stops being reportable. See "Migration refuses damaged lists" below.
 
 Step 5: understand the new storage format
 -----------------------------------------
@@ -341,17 +417,49 @@ Repair API, if you would rather not use the scripts
 there: detecting and rebalancing sort keys that have grown long from repeated
 inserts at the same position.
 
-Behaviour change in rc4: MCP ``structuredContent`` is now opt-in
-=================================================================
+Migration refuses damaged lists
+===============================
 
 .. note::
 
-   This section covers the ``v3.13.0rc4`` behaviour change. It is independent
-   of the ``rc5`` property-list changes above, the ``rc3`` security fix and
-   the ``rc1``/``rc2`` DynamoDB-scalability steps below — read every section
-   that falls between the version you are on and the version you are
-   upgrading to. It applies only if you expose MCP tools; if you do not, skip
-   to the next section.
+   A refinement of the property-list steps above, and it only affects you if
+   you run ``actingweb-migrate-property-lists`` (step 4). Do the steps above
+   first — they are the ones with the pre-upgrade work.
+
+``actingweb-migrate-property-lists --migrate`` and
+``ListProperty.migrate_to_v2()`` now **refuse a list with holes or orphans**,
+and the dry run reports those lists as needing repair instead of counting
+them as "would migrate". A dry run that finds any exits ``1``.
+
+The reason is that migrating damaged data is not just lossy, it is
+*unreportably* lossy. Migration renumbers the surviving rows, so the hole is
+gone afterwards — and so is the evidence. The migrated list verifies healthy,
+and nothing remains to say an item ever went missing. An earlier form of the
+dry run said nothing about holes at all, so a sweep over a fleet containing one
+could report "0 refused, 0 errors" and an operator would proceed in good faith,
+past the last moment at which the damage was still visible.
+
+Lazy migration has always refused damaged lists, for exactly this reason. The
+deliberate path now applies the same rule.
+
+What to do: **repair first** (step 2), then migrate. If you have looked at
+the damage and decided to migrate anyway, ``--migrate-damaged`` (or
+``migrate_to_v2(allow_damaged=True)``) does it, and says clearly in the log
+what it is giving up.
+
+Duplicate residue is **not** affected — it never blocked migration and still
+does not. A duplicate stays visible after conversion, because v2's
+``verify()`` reports duplicates just as v1's does, so migrating it destroys
+no evidence. Only holes and orphans gate.
+
+MCP: ``structuredContent`` is now opt-in
+========================================
+
+.. note::
+
+   Applies only if you expose MCP tools. If you do not, skip to the next
+   section. Independent of the property-list section above and the security
+   and DynamoDB sections below.
 
 What changed
 ------------
@@ -441,19 +549,16 @@ Two related fixes in the same release
   that ``output_schema`` and ``structuredContent`` are independent — declaring
   a schema has never caused structured output to be emitted.
 
-Security fix in rc3: MCP trust-cache authorization bypass
-===========================================================
+Security: MCP trust-cache authorization bypass
+==============================================
 
 .. note::
 
-   This section covers the ``v3.13.0rc3`` security fix. It applies **in
-   addition to** the DynamoDB-scalability migration steps later in this
-   document (``rc1``/``rc2``) and the ``rc4`` MCP change above — read every
-   section between the version you are on and the version you are upgrading
-   to. If you are only running MCP with a single client per actor,
-   most of this section does not apply to you, but the ``resources/read``
-   and resolver-matching items below can still be relevant; read the
-   summary before skipping ahead.
+   **Read this even if you skipped the MCP section above.** It applies in
+   addition to every other section here. If you run MCP with a single client
+   per actor, most of it does not apply to you — but the ``resources/read``
+   and resolver-matching items still can, so read the summary before skipping
+   ahead.
 
 See the ``SECURITY`` section of ``CHANGELOG.rst`` for what changed and why.
 This section is the operational checklist: what to check *before*
@@ -535,16 +640,15 @@ entirely on the legacy peer-id fallback described in step 1 — so a row
 that fails the step-1 check does not "self-heal" on its own until the
 client goes through the OAuth2 flow again, not just makes another API call.
 
-Overview
-========
+DynamoDB scalability: reverse lookup, capacity, and table management
+====================================================================
 
 .. note::
 
-   This "Overview" and everything below it describes the ``rc1``/``rc2``
-   DynamoDB-scalability content of the 3.13 line. The ``rc3`` security fix and
-   the ``rc4`` MCP ``structuredContent`` change covered above are separate,
-   later additions to the same release line — read all three sections if you
-   are upgrading from before ``rc1``.
+   This section and everything below it is the DynamoDB-scalability half of
+   3.13, and it is the one with the **required backfill**. It is independent
+   of the property-list, MCP and security sections above; upgrading from
+   3.12.x means doing all of them.
 
 ActingWeb 3.13 is a **DynamoDB scalability release**. It fixes two measured
 superlinear cost defects (full-table scans on per-actor reads; a
@@ -580,7 +684,7 @@ How urgent that step is depends on how your app resolves the logged-in user
    Local or a real table; see `Rehearse the migration first`_.
 
 Which deployment am I?
-======================
+----------------------
 
 Find your row; do what its column says. "Implicit legacy" means you never
 called ``with_legacy_property_index()`` and never set
@@ -621,7 +725,7 @@ called ``with_legacy_property_index()`` and never set
      - None.
 
 Rehearse the migration first
-============================
+----------------------------
 
 The backfill is the riskiest step in this release and it is easy to treat as
 a one-shot production procedure. It isn't: the **whole** migration — new-table
@@ -651,7 +755,7 @@ An operator who has done this once is not doing it for the first time in
 production.
 
 Required: run the backfill (all upgrading deployments using reverse lookup)
-===========================================================================
+---------------------------------------------------------------------------
 
 The lookup table is **derived data**; the properties table is the source
 of truth. The script rebuilds the v2 table from it — streaming,
@@ -704,7 +808,7 @@ Verify, then clean up:
    the index.
 
 Rollback — check *before* you upgrade
-=====================================
+-------------------------------------
 
 Setting ``USE_PROPERTY_LOOKUP_TABLE=false`` (or
 ``with_legacy_property_index(enable=True)``) restores the legacy path. (3.13
@@ -726,7 +830,7 @@ the fluent builder — the rollback now actually works.)
    delete the GSI in the cleanup step above.)
 
 Direct use of the lookup accessor degrades during the migration window
-======================================================================
+----------------------------------------------------------------------
 
 The three-tier read path (v2 → deprecated v1 → legacy GSI) lives in
 ``DbProperty.get_actor_id_from_property()``. Code that constructs
@@ -742,7 +846,7 @@ usual offenders. Audit yours: resolve actors through
 carries the fallbacks.
 
 Recommended: convert old auto-created tables to on-demand billing
-=================================================================
+-----------------------------------------------------------------
 
 Tables the library auto-created before 3.13 are PROVISIONED with tiny
 capacities — typically ``<prefix>_property_lookup`` (2 RCU / 1 WCU: a
@@ -760,7 +864,7 @@ Convert them in place::
   ``aws dynamodb list-tables`` + ``describe-table``.
 
 Recommended: disable auto-creation in production
-================================================
+------------------------------------------------
 
 If your tables are managed by CloudFormation/Terraform, turn off the
 library's table auto-creation and slim the runtime role::
@@ -823,7 +927,7 @@ have one, honour the same switch rather than restoring the permission::
         ...  # tables are managed externally — skip the probe
 
 Proving the fixes actually landed
-=================================
+---------------------------------
 
 Both headline fixes are invisible to functional tests: a ``Scan`` → ``Query``
 conversion returns identical data, and removing ``DescribeTable`` calls
@@ -891,7 +995,7 @@ residual. Make sure the measurement window contains a cold start, or the zero
 is vacuous.
 
 Behaviour changes to be aware of
-================================
+--------------------------------
 
 - **Reverse-lookup matching is now (name, value)**, not value-only: the
   legacy GSI matched on value alone, so a value shared across *different*

--- a/docs/migration/v3.13.rst
+++ b/docs/migration/v3.13.rst
@@ -38,6 +38,9 @@ Do the sections that were added after the rc you are running. Nothing in this
 table is optional for the rcs it names — the earlier rcs' pre-upgrade steps
 still apply if you never did them.
 
+Every row names sections by their exact title, so the table works as a
+checklist and not only as prose.
+
 .. list-table::
    :header-rows: 1
    :widths: 18 82
@@ -46,32 +49,35 @@ still apply if you never did them.
      - Still to do
    * - ``rc1``
      - Everything except the reverse-lookup **backfill**, which you have
-       already run. Property lists, the security audit and MCP
-       ``structuredContent`` are all new to you — and re-read the rest of the
-       DynamoDB section, because three of its changes touch a code path rather
-       than only docs: ``register_diffs()`` now resolves subscriptions before
-       consulting suspension state, ``create_subscription()`` invalidates the
-       actor's cached subscription list, and actor deletion writes a tombstone
-       before the wipe begins.
+       already run: ``Property lists``, ``Migration refuses damaged lists``,
+       ``Security: MCP trust-cache authorization bypass`` and ``MCP:
+       structuredContent is now opt-in`` are all new to you. Also re-read the
+       rest of the DynamoDB section, because three of its changes touch a code
+       path rather than only docs: ``register_diffs()`` now resolves
+       subscriptions before consulting suspension state,
+       ``create_subscription()`` invalidates the actor's cached subscription
+       list, and actor deletion writes a tombstone before the wipe begins.
    * - ``rc2``
      - Everything except the DynamoDB section, whose backfill you have already
-       run. Property lists, the security audit, and MCP ``structuredContent``
-       are all new to you.
+       run: ``Property lists``, ``Migration refuses damaged lists``,
+       ``Security: MCP trust-cache authorization bypass`` and ``MCP:
+       structuredContent is now opt-in`` are all new to you.
    * - ``rc3``
-     - Property lists, ``Migration refuses damaged lists``, and MCP
-       ``structuredContent``. **Run the step-1 sweep before upgrading** — see
-       the ``rc4`` row for why.
+     - ``Property lists``, ``Migration refuses damaged lists`` and ``MCP:
+       structuredContent is now opt-in``. **Run the step-1 sweep before
+       upgrading** — see the ``rc4`` row for why.
    * - ``rc4``
-     - Property lists and ``Migration refuses damaged lists``. **Run the
+     - ``Property lists`` and ``Migration refuses damaged lists``. **Run the
        step-1 sweep before upgrading**: you are on the last release that hides
        pre-existing list damage. 3.13.0 surfaces it as a 409 instead of
        silently compacting past it, so a list that has been quietly broken for
        months starts erroring the moment you deploy — and the sweep is easier
        to reason about before that than after.
    * - ``rc5``
-     - ``Migration refuses damaged lists``, plus the note below.
+     - ``Migration refuses damaged lists``, plus "What changed after ``rc6``"
+       below.
    * - ``rc6``
-     - Only the note below.
+     - Only "What changed after ``rc6``" below.
 
 What changed after ``rc6``
 --------------------------

--- a/docs/migration/v3.13.rst
+++ b/docs/migration/v3.13.rst
@@ -103,6 +103,17 @@ two are worth knowing about:
   process until its TTL expires. If your threat model depended on the old
   behaviour being instantaneous, it never was.
 
+- **A repair-tool guard, added after consumer verification of GA.**
+  ``--repair`` now refuses a v1 list that is damaged *and* carries v2-format
+  rows, because that combination is a reverted migration rather than a hole,
+  and repairing it strands the data while reporting success. If you swept with
+  ``--repair`` on ``rc5`` or ``rc6``, see the warning under "Step 2" above.
+- **A stale-instance write now warns.** A ``ListProperty`` retained across a
+  migration writes its next item in the old format's row shape, where nothing
+  reads it — and ``verify()`` calls the list healthy. That now logs a WARNING.
+  It affects code that stashes the list object; ordinary
+  ``actor.property_lists.<name>`` access builds a fresh one per use.
+
 The other two are an opt-in PostgreSQL diagnostic
 (``ACTINGWEB_PG_DELETE_DIAGNOSTICS``, off by default) and a change in how
 unsupported-``MCP-Protocol-Version`` rejections are logged: a lone rejection is
@@ -194,6 +205,28 @@ Step 2: repair what it found
 ``--repair`` calls ``compact()``, which rewrites the surviving rows densely,
 removes orphans, corrects the recorded length, and preserves
 ``description``/``explanation``/``created_at``. It closes holes.
+
+**It refuses a reverted migration, by design.** A v1 list that is damaged
+**and** reports ``foreign_format_rows > 0`` is not an ordinary hole. It is a
+list whose migration to v2 was reverted: the v1 rows are gone, the metadata
+still claims v1 with the old length, and **the items are almost certainly
+alive in the v2 rows**. Compacting it would rewrite the empty v1 range, set
+the length to what it found, report the list healthy, and leave the only
+surviving copy as unreferenced residue for the next
+``clear()``/``delete()``/migrate re-run to sweep.
+
+So ``--repair`` skips those lists, logs a WARNING naming the shape, and counts
+them as still unhealthy. Recover them first — the v2 rows are readable
+directly, and re-running the migration against corrected metadata restores the
+list. ``--repair-reverted`` overrides the refusal and is the wrong answer
+unless you have looked at the rows and decided to abandon them.
+
+.. warning::
+
+   Earlier releases logged those rows at INFO as "harmless to reads; clear it
+   by re-running ``--migrate``". In this shape that advice deletes the data.
+   If you ran a sweep on ``3.13.0rc5`` or ``rc6`` and acted on that line,
+   check the affected lists before assuming they are empty by design.
 
 **It does not resolve duplicates, by design.** A duplicate always means an
 item was destroyed; collapsing one copy would bless that loss as intentional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "actingweb"
-version = "3.13.0rc6"
+version = "3.13.0"
 description = "The official ActingWeb library"
 authors = ["Greger Wedel <support@actingweb.io>"]
 maintainers = ["Greger Wedel <support@actingweb.io>"]

--- a/tests/integration/test_verify_property_lists_script.py
+++ b/tests/integration/test_verify_property_lists_script.py
@@ -13,7 +13,7 @@ from pathlib import Path
 
 import pytest
 
-from actingweb.db import get_property
+from actingweb.db import get_property, get_property_list
 from actingweb.interface.actor_interface import ActorInterface
 from actingweb.interface.app import ActingWebApp
 
@@ -133,6 +133,65 @@ class TestSweepActor:
         fresh = test_actor.property_lists.sweep_test_list_2
         assert fresh.verify()["healthy"] is True
         assert fresh.to_list() == ["a", "c"]
+
+    def test_repair_refuses_a_reverted_migration_and_warns(self, test_actor, caplog):
+        """The operator path must not bless a reverted migration as healthy.
+
+        Found by consumer verification against 3.13.0 GA. The shape — v1
+        metadata with a stale length, no v1 rows, items alive in v2 rows —
+        used to be repaired into an empty list reporting ``healthy``, with the
+        only surviving copy left as residue for the next sweep to delete.
+        """
+        import logging
+
+        import verify_property_lists as script  # type: ignore[import-not-found]
+
+        name = "reverted_list"
+        _seed_v1_list(test_actor.config, test_actor.id, name, ["a", "b", "c"])
+        assert (
+            test_actor.property_lists.reverted_list.migrate_to_v2()["migrated"] is True
+        )
+
+        # Put the pre-flip v1 metadata dict back over the flipped row: what a
+        # concurrent write landing inside the read-modify-write gap does.
+        db = get_property(test_actor.config)
+        raw = db.get(actor_id=test_actor.id, name=f"list:{name}-meta")
+        assert raw is not None
+        meta = json.loads(raw)
+        meta["format"] = 1
+        meta["length"] = 3
+        assert get_property(test_actor.config).set(
+            actor_id=test_actor.id, name=f"list:{name}-meta", value=json.dumps(meta)
+        )
+
+        with caplog.at_level(logging.INFO, logger="verify_property_lists"):
+            checked, unhealthy, errored = script.sweep_actor(
+                test_actor.id,
+                test_actor.config,
+                repair=True,
+                limiter=script.RateLimiter(0),
+            )
+
+        assert checked >= 1
+        assert errored == 0
+        assert unhealthy >= 1, "a refused list must be reported as still unhealthy"
+
+        messages = " ".join(r.getMessage() for r in caplog.records)
+        assert "REVERTED MIGRATION" in messages
+        assert "Do NOT sweep them" in messages
+        # And it must NOT be the old advice, which pointed at the sweep that
+        # deletes the surviving copy.
+        assert "Harmless to reads" not in messages
+
+        # The items are still there, still reachable by recovery.
+        rows = (
+            get_property_list(test_actor.config).fetch_all_including_lists(
+                actor_id=test_actor.id
+            )
+            or {}
+        )
+        v2_rows = [k for k in rows if k.startswith(f"list:{name}-#")]
+        assert len(v2_rows) == 3
 
     def test_v2_lists_swept_alongside_v1_without_crashing(self, test_actor):
         """A v2 list's verify() report has a different shape than v1's

--- a/tests/test_property_list_integrity.py
+++ b/tests/test_property_list_integrity.py
@@ -2257,3 +2257,219 @@ class TestMigrationRollbackDoesNotEatASuccessorList:
             "rows this migration wrote, and that nobody else touched, must "
             "still be rolled back"
         )
+
+
+def _seed_reverted_migration(store, actor_id, name, items):
+    """Build the shape a format-reverted migration leaves behind.
+
+    Metadata claims v1 with the pre-migration length, the v1 item rows are
+    gone (migration's last step deleted them), and the items are alive in v2
+    rows. Reachable two ways: a concurrent write landing inside
+    ``_save_metadata()``'s read-modify-write gap, and any list left this way
+    by a ``v3.13.0rc5``/``rc6`` migration.
+    """
+    import fractional_indexing as fi
+
+    ranks = fi.generate_n_keys_between(None, None, len(items))
+    for rank, item in zip(ranks, items, strict=True):
+        store[(actor_id, f"list:{name}-#{rank}")] = json.dumps(item)
+    store[(actor_id, f"list:{name}-meta")] = json.dumps(
+        {
+            "length": len(items),
+            "created_at": "2026-01-01T00:00:00",
+            "updated_at": "2026-01-01T00:00:00",
+            "item_type": "json",
+            "chunk_size": 1,
+            "version": "1.0",
+            "description": "",
+            "explanation": "",
+        }
+    )
+
+
+class TestCompactRefusesARevertedMigration:
+    """``--repair`` must not bless a reverted migration as healthy.
+
+    Found by consumer verification against 3.13.0 GA, and reproduced before
+    fixing: ``verify()`` reported the list unhealthy with
+    ``foreign_format_rows > 0``, reads raised loudly, and then ``compact()``
+    rewrote the empty v1 range, set the length to 0, and reported the list
+    **healthy** — with the only surviving copy left as unreferenced residue
+    for the next ``clear()``/``delete()``/migrate re-run to sweep.
+
+    That is the same unreportable loss ``migrate_to_v2()`` refuses damaged
+    lists to avoid, in the other operator tool.
+    """
+
+    NAME = "reverted"
+    ITEMS = ["alpha", "beta", "gamma"]
+
+    def _prepare(self, monkeypatch):
+        store = {}
+        _seed_reverted_migration(store, "actor1", self.NAME, self.ITEMS)
+        _patch_get_property(monkeypatch, lambda config: FakePropertyDb(store))
+        monkeypatch.setattr(
+            "actingweb.property_list.get_property_list",
+            lambda config: _FakePropertyList(store),
+        )
+        return store
+
+    def test_the_shape_is_detected_as_damaged_with_foreign_rows(
+        self, monkeypatch
+    ) -> None:
+        store = self._prepare(monkeypatch)
+        report = ListProperty(
+            actor_id="actor1", name=self.NAME, config=object()
+        ).verify()
+        assert report["healthy"] is False
+        assert report["missing_indices"] == [0, 1, 2]
+        assert report["foreign_format_rows"] == 3
+        assert len([k for k in store if "-#" in k[1]]) == 3
+
+    def test_compact_refuses_and_says_why(self, monkeypatch) -> None:
+        self._prepare(monkeypatch)
+        result = ListProperty(
+            actor_id="actor1", name=self.NAME, config=object()
+        ).compact()
+        assert result["compacted"] is False
+        assert result["reason"] == "reverted_migration"
+
+    def test_the_override_strands_the_data_and_reports_healthy(
+        self, monkeypatch
+    ) -> None:
+        """What the refusal is protecting against, asserted rather than argued.
+
+        ``compact()`` does not itself delete the v2 rows — it rewrites the
+        (empty) v1 range. The harm is what it leaves: a list that reports
+        **healthy** and reads **empty** while its contents sit in rows nothing
+        references, waiting for the next ``clear()``/``delete()``/migrate
+        re-run to sweep them. Loss with nothing left to report it, which is
+        exactly the trade ``migrate_to_v2(allow_damaged=...)`` gates on.
+        """
+        store = self._prepare(monkeypatch)
+        ListProperty(actor_id="actor1", name=self.NAME, config=object()).compact(
+            allow_reverted=True
+        )
+
+        after = ListProperty(actor_id="actor1", name=self.NAME, config=object())
+        assert after.verify()["healthy"] is True
+        assert after.to_list() == []
+        # The items are still on disk — unreachable, and no longer reported as
+        # a problem by anything.
+        stranded = sorted(json.loads(v) for k, v in store.items() if "-#" in k[1])
+        assert stranded == sorted(self.ITEMS)
+
+    def test_the_list_stays_loudly_unhealthy(self, monkeypatch) -> None:
+        """A refusal must not quietly look like a successful repair."""
+        self._prepare(monkeypatch)
+        ListProperty(actor_id="actor1", name=self.NAME, config=object()).compact()
+        after = ListProperty(
+            actor_id="actor1", name=self.NAME, config=object()
+        ).verify()
+        assert after["healthy"] is False
+        assert after["foreign_format_rows"] == 3
+
+    def test_allow_reverted_is_the_deliberate_override(self, monkeypatch) -> None:
+        self._prepare(monkeypatch)
+        result = ListProperty(
+            actor_id="actor1", name=self.NAME, config=object()
+        ).compact(allow_reverted=True)
+        assert result.get("compacted") is not False
+
+    def test_an_ordinary_hole_still_compacts(self, monkeypatch) -> None:
+        """The gate must be narrow: damage alone is not a reverted migration.
+
+        Without the ``foreign_format_rows`` half of the condition this would
+        refuse every damaged list and break repair entirely.
+        """
+        store = {}
+        _seed_list(store, "actor1", "ordinary", ["a", "b", "c"])
+        del store[("actor1", "list:ordinary-1")]
+        _patch_get_property(monkeypatch, lambda config: FakePropertyDb(store))
+        monkeypatch.setattr(
+            "actingweb.property_list.get_property_list",
+            lambda config: _FakePropertyList(store),
+        )
+        result = ListProperty(
+            actor_id="actor1", name="ordinary", config=object()
+        ).compact()
+        assert result.get("compacted") is not False
+        assert ListProperty(
+            actor_id="actor1", name="ordinary", config=object()
+        ).to_list() == ["a", "c"]
+
+
+class TestAStaleFormatWriteIsLoud:
+    """A write from an instance retained across a migration must not be silent.
+
+    Also from consumer verification: the item lands in a row of the format
+    the instance believed, which readers of the current format never return.
+    ``verify()`` reports the list **healthy** — the row shows up only as
+    ``foreign_format_rows``, which is documented as inert residue. So before
+    this warning the only trace was a DEBUG line.
+    """
+
+    def test_appending_from_a_stale_instance_warns(self, monkeypatch, caplog) -> None:
+        import logging
+
+        store = {}
+        _seed_list(store, "actor1", "held", ["alpha", "beta"])
+        _patch_get_property(monkeypatch, lambda config: FakePropertyDb(store))
+        monkeypatch.setattr(
+            "actingweb.property_list.get_property_list",
+            lambda config: _FakePropertyList(store),
+        )
+
+        stale = ListProperty(actor_id="actor1", name="held", config=object())
+        assert stale.to_list() == ["alpha", "beta"]  # caches format v1
+
+        ListProperty(actor_id="actor1", name="held", config=object()).migrate_to_v2()
+
+        with caplog.at_level(logging.WARNING, logger="actingweb.property_list"):
+            stale.append("gamma")
+
+        assert any(
+            "believed the storage format was v1" in r.getMessage()
+            for r in caplog.records
+        ), "a write against a migrated-away format must not be silent"
+
+    def test_the_instance_self_corrects_after_the_warning(self, monkeypatch) -> None:
+        """Bounded to one write: the metadata write refreshes the cache."""
+        store = {}
+        _seed_list(store, "actor1", "held", ["alpha", "beta"])
+        _patch_get_property(monkeypatch, lambda config: FakePropertyDb(store))
+        monkeypatch.setattr(
+            "actingweb.property_list.get_property_list",
+            lambda config: _FakePropertyList(store),
+        )
+        stale = ListProperty(actor_id="actor1", name="held", config=object())
+        stale.to_list()
+        ListProperty(actor_id="actor1", name="held", config=object()).migrate_to_v2()
+
+        stale.append("gamma")  # lost to v1-shaped row
+        stale.append("delta")  # must land correctly
+
+        assert (
+            "delta"
+            in ListProperty(actor_id="actor1", name="held", config=object()).to_list()
+        )
+
+    def test_no_warning_when_nothing_changed_underneath(
+        self, monkeypatch, caplog
+    ) -> None:
+        import logging
+
+        store = {}
+        _seed_list(store, "actor1", "quiet", ["alpha"])
+        _patch_get_property(monkeypatch, lambda config: FakePropertyDb(store))
+        monkeypatch.setattr(
+            "actingweb.property_list.get_property_list",
+            lambda config: _FakePropertyList(store),
+        )
+        lp = ListProperty(actor_id="actor1", name="quiet", config=object())
+        lp.to_list()
+        with caplog.at_level(logging.WARNING, logger="actingweb.property_list"):
+            lp.append("beta")
+        assert not [
+            r for r in caplog.records if "believed the storage format" in r.getMessage()
+        ]

--- a/thoughts/todo/whole-list-rewrite-atomicity.md
+++ b/thoughts/todo/whole-list-rewrite-atomicity.md
@@ -108,6 +108,29 @@ second of which is the most valuable constraint any of this produced.
   cut designs violated, and it is why the current duplicate residue, for all its
   awkwardness, was kept in the first place.
 
+## Adjacent residual: mutations dispatch on a cached format (found 2026-08-16)
+
+Consumer verification of 3.13.0 GA reproduced a second, smaller consequence of
+the same missing primitive. A `ListProperty` retained across a migration
+dispatches its next mutation on its **cached** `format`, so a v1-shaped item
+row is written into a list that is now v2. The item is unreachable, `verify()`
+reports the list **healthy** (the row surfaces only as `foreign_format_rows`,
+documented as inert residue), and the instance self-corrects afterwards because
+the metadata write refreshes its cache — so it is exactly one write per
+retained instance.
+
+GA ships a WARNING at the mismatch, which makes it visible but does not save
+the write. **The fix is to dispatch on a fresh metadata read rather than the
+cache**, and it may be close to free: a mutation already pays one fresh read in
+`_save_metadata()`, so moving that read to *before* the dispatch and merging
+into the dict it returned trades one gap for another rather than adding a round
+trip. It was not attempted at the 3.13.0 tag point because it changes the hot
+write path.
+
+Note the interaction with this file's main subject: reading before dispatch
+does not close the read-modify-write gap, it just stops the *format decision*
+being made from arbitrarily stale state. Closing the gap still needs the CAS.
+
 ## Related
 
 - `thoughts/plans/2026-08-15-property-list-metadata-integrity.md` — the GA plan


### PR DESCRIPTION
The release PR. Consolidates six pre-release changelog sections into one `v3.13.0` section and bumps both version files, per the process in `CLAUDE.md` — the bump rides in the release PR itself, and the tag goes on the merge commit on master afterwards.

## What the consolidation actually did

`Unreleased` and `v3.13.0rc2` … `v3.13.0rc6` became a single `v3.13.0: August 15, 2026` section. Entries are kept **verbatim** where they describe something visible to someone upgrading from `v3.12.0` — paraphrasing a thousand lines of carefully-worded release notes is how accuracy gets lost — and reorganised into SECURITY / CHANGED / ADDED / FIXED / DOCUMENTATION, chronological within each so related entries stay adjacent.

**Eight entries were dropped**, because they describe defects introduced by one release candidate and fixed by the next. No released version ever exhibited them, so for a `v3.12.0` upgrader they are noise:

- Three list-migration fixes from `Unreleased` — the v2 storage format and its migration only ever existed in rc5/rc6, so the concurrent-write revert, the interrupted-rewrite residue and the recreated metadata row were never reachable from a release.
- Four rc5 fixes to rc5's own new code: `migrate_to_v2()` destroying an already-migrated list, the `#`-named sibling collision, the stale v2 position map, and the scripts checkpointing actors they had refused.
- The postgres test-quarantine entry, which is test infrastructure.

**One drop is worth calling out separately.** rc3's SECURITY section ended with *"Still open, deferred: revoking a token or modifying a trust does not evict the MCP caches"*. That landed in #130. Carrying it forward would have had the release notes contradict themselves two sections apart — the exact failure mode a consolidation is supposed to remove.

## Edits beyond selection

*(This list was corrected after review — it originally said "two edits" and undercounted. The PR stakes its trustworthiness on "kept verbatim", so the exceptions are enumerated in full.)*

- Every `*(since rc1)*` marker is gone. It labelled which pre-release introduced an entry, which means nothing once they are one release.
- **Six** sentences positioned a change relative to an rc section that no longer exists. Five rewrite the reference to name the release or describe the behaviour directly (*"A pre-3.13.0rc5 process does not…"*, *"In rc5 the dry run warned…"*, *"the rc6 warning boxes…"*, *"documented in 3.13.0rc5"*, *"changed to off in 3.13.0rc5"*).
- The sixth is an **insertion**, not a rewrite, and is the one real deviation from verbatim: the SECURITY entry's *"Affected versions: … through `v3.13.0rc2`, roughly ten months"* gained *"(i.e. fixed in this release)"*. Kept deliberately — with rc2 no longer having a section, a reader of a GA-only changelog has nothing to anchor "through rc2" against, so whether the bypass is fixed in the release they are reading becomes genuinely ambiguous. That seemed the wrong thing to leave ambiguous in a security disclosure.
- **Formatting:** entries are separated by a blank line throughout, where some previously ran tightly packed. A by-product of reassembling the section rather than a deliberate restyle, kept because it reads better.

## The new opening

The section leads with what an upgrader must read and in what order, because two of the three are behaviour changes rather than fixes:

1. **SECURITY** — the MCP authorization bypass reaches back to `v3.3` (2025-10-04). The library cannot tell you whether it was exploited.
2. The three **Breaking** entries: the `/properties/<name>/items` response shape, list reads failing fast on corruption instead of silently compacting, and out-of-bounds `PUT` returning 404.
3. `docs/migration/v3.13.rst` in full — in particular that **a green test suite is not evidence this release landed correctly**, since the read-path and capacity fixes are invisible to functional tests.

## The migration guide, restructured

Added after the first review round, because the guide had the same problem the changelog did and consolidating one without the other would have left the fix half-done.

`docs/migration/v3.13.rst` had grown five top-level sections titled *"Behaviour change in rcN"*, stacked newest-first, each opening with a note telling the reader to *"read every section between the version you are on and the version you are upgrading to"*. That is a workable instruction while the rcs are current and a useless one the moment they are a single release: someone on 3.12.x meets rc-labelled sections in an order that means nothing to them, and someone on an rc has to reverse-engineer which ones they already did.

It now opens with **Start here**, covering the two paths that actually exist:

- **From 3.12.x** — do all four pieces of work, in an order chosen by what must happen *before* deploying: the property-list damage sweep (which must run on the old version), the security audit, the required reverse-lookup backfill, then the code-level MCP changes. Plus the escape hatch — no list properties, no MCP, no reverse lookup means exactly one paragraph applies to you.
- **From a release candidate** — a table saying what remains for each of `rc1` … `rc6`, then **what changed after `rc6`**, which is the part an rc6 deployment has no other way to learn. Two of those four changes deserve attention (the list-metadata fix, which is a reason to run `verify` once if you migrated against a live deployment on rc5/rc6; and revocation now evicting the MCP caches, with the multi-process caveat stated rather than implied). The other two are named and dismissed.

Structural changes: the four work sections are retitled for what they cover rather than which rc introduced them; *"Migration refuses damaged lists"* moved from the **top** of the document — where the narrowest item led, ahead of the steps it refines — to directly after those steps; and the DynamoDB material is nested under its own heading instead of nine flat peers headed *"Overview"*.

rc references in prose are removed where they were structural (*"rc5 fixes the write paths"*, *"see the rc6 section at the top"*) and kept where they genuinely name a starting point (*"in `v3.13.0rc6` and earlier it wrote a whole cached dictionary back"*). Cross-references in `docs/migration/index.rst` and `docs/guides/troubleshooting.rst` follow the new titles.

**One correction found while restructuring:** the rc4 row first said rc4 was where list damage became visible. It is the opposite — rc4 is the last release that *hides* it, which inverts the advice for exactly the readers most at risk.

## Version files

`pyproject.toml` and `actingweb/__init__.py` both now read `3.13.0`, and a fresh empty `Unreleased` section sits at the top. `docs/requirements.txt` was regenerated by the repo's own pre-commit hook.

## Verification

- `make test-all-parallel`: **2862 passed, 26 skipped, 0 failed**
- `poetry run ruff check actingweb tests`: clean; `poetry run pyright actingweb tests`: 0 errors
- `tests/test_version_consistency.py`: passes — the two version files agree and an `Unreleased` section is present
- Docs built locally with CI's exact flags (`-W --keep-going`, same suppressions): clean

## What this release contains

All of 3.13.0's pre-release work, plus the four GA branches merged today: #128 (postgres DELETE quarantine lifted and instrumented), #129 (the MCP legacy-era signal guarded), #130 (revocation evicts the MCP caches; hook `output_schema` warning), #131 (the `dynamodb-known-next` re-verification). Every review comment on all four was actioned; four were real defects the reviews caught rather than restatements.

After merge: `git tag v3.13.0` on the merge commit on master, then `git push --tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wTmWvkPKhpcZfqM8dA2dp

