### PR TITLE
Re-rank todo/INDEX.md for the post-GA state; prune landed narration

### DIFF
--- a/thoughts/todo/2026-06-15-postgres-parallel-delete-not-persisting.md
+++ b/thoughts/todo/2026-06-15-postgres-parallel-delete-not-persisting.md
@@ -4,7 +4,7 @@
 **Status:** **Symptom gone, root cause never found.** Both leading hypotheses
 had their proximate mechanism removed by unrelated work (#115, #117); the
 quarantine was lifted on 2026-08-15 and the postgres matrix has been green on
-every run since, across four PRs, with zero reruns. That is evidence the
+every run since, across five PRs (#128 through #132), with zero reruns. That is evidence the
 symptom is gone, **not** evidence of a diagnosis — so this file stays rather
 than being deleted, and `ACTINGWEB_PG_DELETE_DIAGNOSTICS` stays on in CI to
 name the mechanism if it ever returns. Delete this file after a few weeks of

--- a/thoughts/todo/INDEX.md
+++ b/thoughts/todo/INDEX.md
@@ -56,15 +56,16 @@ settles for this list, in one place, so no row has to re-explain it:
   postgres matrix has been green on every run since. Row 3 is now *waiting*, not
   *working* — it moved to §5.
 - **Row 5's re-measurement was scheduled "at GA, not before".** GA has happened,
-  so it is now the first thing in §1.
+  so it is live and sits in §1, behind only row 9c.
 
 **GA-day finding.** Consumer verification of the tag (actingweb_mcp) reproduced
-two defects in the property-list tooling, both fixed inside #132: `--repair`
-blessing a *reverted* migration as healthy and stranding the only surviving copy
-of the data, and a write from a `ListProperty` held across a migration landing
-silently in a row shape the current format never reads. The second one's *real*
-fix — dispatch on a fresh metadata read instead of the cached format — was not
-attempted at a tag point, and is **row 9c** below.
+two defects in the property-list tooling, and #132 closed **one** of them:
+`--repair` blessing a *reverted* migration as healthy and stranding the only
+surviving copy of the data now refuses. The second — a write from a
+`ListProperty` held across a migration landing silently in a row shape the
+current format never reads — got a WARNING and nothing more: **the write is
+still lost.** Its real fix, dispatching on a fresh metadata read instead of the
+cached format, was not attempted at a tag point and is **row 9c** below.
 
 ## 1. Do next
 

--- a/thoughts/todo/INDEX.md
+++ b/thoughts/todo/INDEX.md
@@ -2,22 +2,19 @@
 
 Every file in this directory, ordered by what to do next. **Built 2026-08-13**
 from a full read of every file. **Reviewed 2026-08-14** — an audit of all
-27 plans and 17 research docs for uncovered work (6 plan statuses corrected, 4
-todos added), followed by an item-by-item walkthrough with the owner (1 todo
-dropped, every row given a direction). **Last reviewed 2026-08-15** — the
-2026-08-14 directions scoped against the 3.13.0 GA release; see §0.
+27 plans and 17 research docs for uncovered work, followed by an item-by-item
+walkthrough with the owner that gave every row a direction. **Reviewed
+2026-08-15** — those directions scoped against the pending 3.13.0 release.
+**Last reviewed 2026-08-16** — post-GA pass: v3.13.0 is tagged (#132), so the
+release lens is gone and the rows it was holding are live again. See §0.
 
-**Rows 1 and 2 are gone, and the numbering below is deliberately not
+**Rows 1, 2, 6 and 11 are gone, and the numbering below is deliberately not
 re-flowed** — too many rows cite each other by number for renumbering to be a
-cheap edit. Row 1 (`migrate_to_v2()` needs a claim) was closed on 2026-08-15 by
-an accepted last-writer-wins trade rather than by a claim row; the reasoning now
-lives in `docs/guides/property-lists.rst`. Row 2 (`compact()` needs a
-recoverable commit protocol) was deferred to 3.14 and survives as row 9b.
-
-Each row's **Decided 2026-08-14** clause is the outcome of that walkthrough. It
-records the direction taken and, where it matters, the option *not* taken.
-Rows 12 and 13 carry no such clause by design — a blocked item's trigger *is*
-its decision, and both triggers were reconfirmed unfired.
+cheap edit. Rows 1 and 2 were closed or deferred by the GA plan (row 2 survives
+as row 9b); rows 6 and 11 landed in #130 and #129. Their files stay where the
+work they carried is not finished — a landed row is not the same as a closed
+file. §4 (cheap cleanups) went with row 11 and the section numbers are not
+re-flowed either, for the same reason: other files cite them.
 
 **This file is a table of contents, not a source of truth.** Each row says what
 implementing it buys and why it's worth doing — one line each, deliberately.
@@ -33,65 +30,41 @@ moderate problem outranks an expensive fix to a slightly worse one.
 
 ---
 
-## 0. 3.13.0 GA scope
+## 0. 3.13.0 shipped — 2026-08-16
 
-**Decided 2026-08-15.** A lens over the rows below, not a second ordering — it
-assigns each 2026-08-14 direction to *before GA*, *at GA*, or *3.14*. Nothing
-here re-decides a row; if this section and a row disagree, the row wins, and if
-a row and its file disagree, the file wins.
+Tagged `v3.13.0` on 2026-08-16 (#132), straight to GA with no rc7. What that
+settles for this list, in one place, so no row has to re-explain it:
 
-The organising argument: **GA is the event that triggers fleet-wide
-`actingweb-migrate-property-lists` and `actingweb-verify-property-lists
---repair` runs.** Rows 1 and 2 are what make those two tools safe to run. A
-release whose point is "safe to migrate onto" cannot ship with the migration
-and repair tools themselves not crash-safe.
+- **The GA blocker — former rows 1 and 2 — landed** as
+  `thoughts/plans/2026-08-15-property-list-metadata-integrity.md`
+  (`status: done`). Not what those rows asked for: three review passes over two
+  candidate designs surfaced something worse than the crash windows they
+  targeted — a concurrent `append()` writing stale cached metadata back over a
+  completed migration, reverting the format flip and **destroying the whole list
+  on ordinary traffic**. The plan landed that plus re-run convergence for both
+  format-changing rewrites, closed row 1 by an accepted last-writer-wins trade
+  (the reasoning now lives in `docs/guides/property-lists.rst`), and deferred
+  row 2 — which survives as **row 9b**, whose file records why shipping a third
+  design under time pressure was judged worse than shipping the documented
+  window.
+- **Rows 6 and 11 landed in full, and row 8's cheap half with them**, grouped
+  per subsystem rather than as independent branches: #129 (MCP protocol signal,
+  row 11), #130 (MCP cache eviction and hook metadata, rows 6 + 8). Row 8's
+  actual fix is still open and stays in §3. The `dynamodb-known-next`
+  re-verification ran last (#131), against the settled codebase.
+- **Row 3's quarantine was lifted and the path instrumented** (#128). The
+  postgres matrix has been green on every run since. Row 3 is now *waiting*, not
+  *working* — it moved to §5.
+- **Row 5's re-measurement was scheduled "at GA, not before".** GA has happened,
+  so it is now the first thing in §1.
 
-| Tier | Items | Note |
-| --- | --- | --- |
-| **Gated GA — LANDED 2026-08-15** | `thoughts/plans/2026-08-15-property-list-metadata-integrity.md` (`status: done`) | **Not what rows 1+2 asked for.** Three review passes over two candidate designs surfaced something worse than the crash windows they targeted: a concurrent `append()` writes stale cached metadata back over a completed migration, reverting the format flip and **destroying the whole list on ordinary traffic**. Previously unfiled. The plan landed that plus the re-run non-convergence of both format-changing rewrites, closed row 1 by an accepted trade, and deferred row 2 to 3.14. Rows 1 and 2 are gone from §1 as a result; row 2 survives as row 9b |
-| **Gating question, ANSWERED 2026-08-15** | Rows 3 + 10's shared instrumentation branch (#128) | It did not gate: the quarantine was lifted and the postgres matrix has been green on every run since, across four PRs. Both ranked hypotheses had been removed by #115 and #117 without anyone noticing. Original plan: start **in parallel** — CI turnaround is its latency. If it shows the DELETE matched rows but did not commit, the PG backend can drop a committed write under concurrency and this becomes a hard blocker needing lead time. If it shows 0 rows matched or a wrong `search_path`, it is test infra and does not gate |
-| **In GA scope — ALL LANDED 2026-08-15** | Rows 6, 11, 8, and the `dynamodb-known-next` re-verification pass | Grouped per subsystem rather than as the four independent branches this row planned: #129 (MCP protocol signal, row 11), #130 (MCP caches and hook metadata, rows 6+8), then the re-verification pass last so "the settled codebase" was true when the nine items were walked. Every review comment on all three PRs was actioned; two were real defects the reviews caught rather than restatements |
-| **At GA, not before** | Row 5's re-measurement | The decision is to measure against GA before designing. First post-GA action; the fix is 3.14 |
-| **Not GA** | Row 9b ([whole-list rewrite atomicity](whole-list-rewrite-atomicity.md), the former row 2), rows 4, 9, 7's guard, 12, 13 | Row 2 was **deferred on 2026-08-15** after two designs failed adversarial review — rc6 already documents the window, the damage is visible, and `verify()` catches it. Shipping a third design under GA time pressure was judged worse. Row 4 sequences after it either way. Row 9 is post-incident tooling. Rows 12 and 13 are blocked, triggers unfired |
-
-The organising argument above is the one that made rows 1+2 the blocker. It
-survives the retiering, but weaker than it looks: the tools operators run at GA
-are now *convergent on re-run* (plan Phase 2) and can no longer be reverted by an
-ordinary write (Phase 1), while `compact()`'s remaining crash window stays
-documented, visible, and detectable. That is the trade — read the plan's
-"Designs cut" before reopening it.
-
-**With that landed, nothing in this index gates GA.** The tier above is kept
-rather than deleted because it records *why* the release was held and what was
-accepted in exchange — the next person to ask "why did 3.13 ship with
-`compact()` not crash-safe?" needs this paragraph, not a git log.
-
-Two couplings that decide sequencing inside the GA tier:
-
-- **Row 6 before row 7's guard, and the cache-lifetime question before row 6's
-  code.** Both rows point at item 4 of `subs-list-cache-asymmetry.md` — whether
-  `_actor_cache` should hold instance state at all. Answer it **on paper before
-  writing row 6's eviction wiring**, because what the cache ends up holding
-  changes the eviction surface. Any Actor-cache restructuring that answer
-  implies, and the `is None` guard itself, are 3.14.
-- **Row 11 makes row 13's trigger observable.** Raising the log level is what
-  lets a sustained `-32600` stream from one origin be seen before the consumer
-  fleet grows past the point where anyone would notice. Do it while the fleet
-  is small.
-
-**Release shape — decided 2026-08-15: straight to GA, no rc7.** `rc6` shipped
-2026-08-09 with an empty `Unreleased`. The GA plan landed 2026-08-15 and does
-touch the migrate path and metadata writes on every mutation, which is what made
-an rc7 soak the earlier reading — but the migrate/repair machinery was not
-restructured in the end, so the case for another pre-release fell away. The
-maintainer's call: the next tag is **`v3.13.0`**.
-
-**All GA-scope work landed on 2026-08-15** (#128, #129, #130, and this
-re-verification), so the bump does not ride in a feature PR after all: it goes
-in a **dedicated release PR** that also consolidates the six `rc` changelog
-sections into one `v3.13.0` section, dropping the rc-to-rc churn that never
-existed in a released version. Per `CLAUDE.md` the bump goes in that PR and the
-tag is pushed to master afterwards.
+**GA-day finding.** Consumer verification of the tag (actingweb_mcp) reproduced
+two defects in the property-list tooling, both fixed inside #132: `--repair`
+blessing a *reverted* migration as healthy and stranding the only surviving copy
+of the data, and a write from a `ListProperty` held across a migration landing
+silently in a row shape the current format never reads. The second one's *real*
+fix — dispatch on a fresh metadata read instead of the cached format — was not
+attempted at a tag point, and is **row 9c** below.
 
 ## 1. Do next
 
@@ -99,7 +72,8 @@ Real problems, in production or under it, with a known shape.
 
 | # | Item | Impact of doing it | Why now |
 | --- | --- | --- | --- |
-| 3 | [Postgres parallel DELETE not persisting](2026-06-15-postgres-parallel-delete-not-persisting.md) | Answers whether the PG backend can silently drop a committed `DELETE` under concurrency, and lifts the quarantine on two assertions currently dark on postgresql | Open since June with no root cause — but the **decisive step is cheap and nobody has run it**: log `cur.rowcount` and `search_path` from `delete_attr` in CI, and the leading hypothesis (a pooled connection contaminated by the `property_lookup_pkey` error) either falls or stands. **Decided 2026-08-14: one instrumentation branch covering this and row 10** — same matrix, and row 10's process-global psycopg pool is this row's leading hypothesis. **Ran 2026-08-15**, and it found something first: both ranked hypotheses had their proximate mechanism removed by #115 and #117 after this was filed. The branch therefore lifts the quarantine *and* instruments, so a green matrix closes it with evidence and a red one names the mechanism in the first failing run. **Verdict 2026-08-15: green**, on every run across four PRs, zero reruns. Not proof of a root cause — proof the symptom is gone and the quarantine was obsolete. Diagnostics stay on in CI to catch a recurrence |
+| 9c | **Mutations dispatch on a cached format** — "Adjacent residual" in [whole-list rewrite atomicity](whole-list-rewrite-atomicity.md) | Stops a `ListProperty` held across a migration silently losing exactly one write per retained instance — the row lands in the old format's shape, is unreachable, and `verify()` still reports the list **healthy** | Reachable **only during a migration**, which is precisely what GA triggers fleet-wide, so this is live now and quiet later. GA ships a WARNING at the mismatch, which makes it visible without saving the write. The fix may be close to free — a mutation already pays a fresh metadata read in `_save_metadata()`, so moving that read *before* the dispatch trades one gap for another rather than adding a round trip. Not attempted at the tag point because it changes the hot write path. Does **not** close row 9b's read-modify-write gap; that still needs the CAS |
+| 5 | [Property fetch reads the whole partition](property-fetch-reads-whole-partition.md) (I0) | Cuts the dominant remaining read cost for list-heavy actors: one measured production actor paid **1,027 RCU to return 5 properties**, because ~1,009 `list:*` rows share its partition and are discarded client-side | Called *"the most valuable thing in this document"* by the consumer feedback that drove 3.13, and deferred to 3.14 only because it is a hot-path rewrite on an already-validated release — **that window is now open**. 3.13 removed the *cross-actor* superlinearity, which was the important half; this is the *within-actor* half. **Invisible without per-call capacity instrumentation**, so it will not resurface on its own. **Decided 2026-08-14: re-measure against GA before designing** — the deferral rationale rests on rc1 numbers, and which fix shape is right depends on how dominant the `list:` rows still are. That measurement is the first post-GA action |
 
 ## 2. High leverage
 
@@ -107,27 +81,17 @@ Bigger, designed, and each buys more than it costs.
 
 | # | Item | Impact of doing it | Why now |
 | --- | --- | --- | --- |
-| 4 | [`ListAttribute` shift-loop design](attribute-list-shift-design.md) | Removes the **last instance** of the design that caused the production list corruption — `ListAttribute` still has, verbatim, what `ListProperty` had before the 3.13 fix | Materially cheaper than when filed: the fractional-rank v2 format, its `verify()`/`compact()` primitives and its migration shape now exist and are proven, so option 3 — the only option that closes the corruption class rather than mitigating it — is mostly a port. It waited on **lower blast radius**, not on being safe. **Decided 2026-08-14: option 3, the full v2 port** — the only one that closes the class rather than mitigating it |
-| 5 | [Property fetch reads the whole partition](property-fetch-reads-whole-partition.md) (I0) | Cuts the dominant remaining read cost for list-heavy actors: one measured production actor paid **1,027 RCU to return 5 properties**, because ~1,009 `list:*` rows share its partition and are discarded client-side | Called *"the most valuable thing in this document"* by the consumer feedback that drove 3.13, and deferred **to 3.14** only because it is a hot-path rewrite on an already-validated release — that window opens at GA. 3.13 removed the *cross-actor* superlinearity, which was the important half; this is the *within-actor* half. **Invisible without per-call capacity instrumentation**, so it will not resurface on its own. **Decided 2026-08-14: re-measure against GA before designing** — the deferral rationale rests on rc1 numbers, and which fix shape is right depends on how dominant the `list:` rows still are |
-| 6 | **Revocation doesn't evict the MCP caches** — §1 of [cache-lifecycle register](mcp-cache-lifecycle-and-revocation.md) | A revoked token, deleted trust or downgraded permission actually stops working, instead of being honoured for up to the 5-minute cache TTL in every warm process | `clear_token_from_cache()` has exactly **one** caller (logout) — `revoke_token`, `revoke_all_tokens`, `/oauth/revoke`, trust deletion and permission downgrade all miss it. The tuple-keyed `_trust_cache` the trust-cache plan added already supports the eviction, so §1 is wiring, not design. Don't let §2 (cross-process invalidation, genuinely large) block it. **Decided 2026-08-14: both paths** — token-keyed eviction on the three revocation endpoints, plus direct `_trust_cache` eviction on trust deletion and permission downgrade. **Landed 2026-08-15**, but not as written: the cache-lifetime question INDEX required first showed `_actor_cache` holds a live `ActorInterface` carrying the trust list, so `_trust_cache`-only eviction would have left the shared wrapper stale. Eviction is actor-wide on every path. §2 (cross-process) stays open |
+| 4 | [`ListAttribute` shift-loop design](attribute-list-shift-design.md) | Removes the **last instance** of the design that caused the production list corruption — `ListAttribute` still has, verbatim, what `ListProperty` had before the 3.13 fix | Materially cheaper than when filed: the fractional-rank v2 format, its `verify()`/`compact()` primitives and its migration shape now exist and are proven, so option 3 — the only option that closes the corruption class rather than mitigating it — is mostly a port. It waited on **lower blast radius**, not on being safe. **Decided 2026-08-14: option 3, the full v2 port.** Sequence it after row 9b, or the port reproduces that gap in a second class |
 
 ## 3. Real, not urgent
 
 | # | Item | Impact of doing it | Why now |
 | --- | --- | --- | --- |
-| 7 | [`subs_list` cache asymmetry](subs-list-cache-asymmetry.md) | Drops one **strongly-consistent Query per property write** for every actor with no subscribers | **The ordering is the whole item.** The one-line guard fix (`is None`) is unsafe until the cross-request `Actor` cache is dealt with: the falsy guard is exactly what stops a long-lived MCP-cached actor going permanently blind to subscriptions created in another container. The correctness half landed in rc2; landing the cost half first trades a bounded cost bug for an unbounded correctness one. **Half of item 4 answered 2026-08-15** (`thoughts/research/2026-08-15-mcp-actor-cache-holds-instance-state.md`): the cache *does* hold instance state, which was enough to make row 6 correct. The *should* — identity-only versus a request-boundary reset — is 3.14, and the guard stays blocked on it. **Decided 2026-08-14: take the cache-lifetime question (item 4) rather than the guard** — does `_actor_cache` hold identity/auth only, or do instance caches need a request-boundary reset? That unblocks the guard and de-risks every future memo. **Pair with row 6**, same cache module |
-| 8 | [`output_schema` on `action_hook` never reaches MCP](action-hook-output-schema-not-visible-to-mcp.md) | Closes an ergonomic trap: an author who declares `output_schema=` or annotates a `TypedDict` return reasonably believes their MCP tool advertises `outputSchema`, and it does not | Documented in rc4, unfixed, and the two decorators keep diverging. Merging **by default** would newly advertise `outputSchema` for every TypedDict-annotated tool and break the ones that return no `structuredContent` — so that decision belongs with the structuredContent research, not on its own. **Decided 2026-08-14: option 4 now** — warn at `tools/list` when `_hook_metadata` carries an `output_schema` and `_mcp_metadata` does not. Cheap, cannot false-positive, catches the confusion at registration rather than call time, and forecloses nothing. **Landed 2026-08-15.** The asymmetry itself is untouched, so the file stays open for options 2/3 |
+| 7 | [`subs_list` cache asymmetry](subs-list-cache-asymmetry.md) | Drops one **strongly-consistent Query per property write** for every actor with no subscribers | **The ordering is the whole item.** The one-line guard fix (`is None`) is unsafe until the cross-request `Actor` cache is dealt with: the falsy guard is exactly what stops a long-lived MCP-cached actor going permanently blind to subscriptions created in another container. The correctness half landed in rc2. **Decided 2026-08-14: take the cache-lifetime question (item 4) rather than the guard** — does `_actor_cache` hold identity/auth only, or do instance caches need a request-boundary reset? The *does it* half was answered on 2026-08-15 (`thoughts/research/2026-08-15-mcp-actor-cache-holds-instance-state.md`: it holds a live `ActorInterface`) and that was enough to make the revocation-eviction work correct (#130); the *should it* is this row's alone, and the guard stays blocked on it |
+| 8 | [`output_schema` on `action_hook` never reaches MCP](action-hook-output-schema-not-visible-to-mcp.md) | Closes an ergonomic trap: an author who declares `output_schema=` or annotates a `TypedDict` return reasonably believes their MCP tool advertises `outputSchema`, and it does not | The cheap half (option 4, warn at `tools/list`) **landed 2026-08-15**; the asymmetry itself is untouched. What is left is options 2 and 3, and merging **by default** would newly advertise `outputSchema` for every TypedDict-annotated tool and break the ones that return no `structuredContent` — so it is not an independent decision. **Decide it with the structuredContent research** (`thoughts/research/2026-08-03-structuredcontent-promotion-drops-tool-text.md`, option C), not on its own |
 | 9 | [Orphan detection in the offline verifier](orphan-detection-in-verifier.md) (DEL5) | Ships the sweep every consumer writes for themselves after a deletion incident — and ships it with the four edge cases that make it safe | Purely additive; `verify_tables` already exists to host it. The reason to do it in the library is that the classification is **not obvious**: an empty actor set must yield *zero* orphans, not "everything", and system actors like `_actingweb_websocket` hold live data under ids deliberately absent from the actors table. All four cases are already written into `docs/reference/actor-deletion.rst` — start there. **Decided 2026-08-14: ship it in `verify_tables`** rather than leaving each consumer to write their own |
-| 9b | [Whole-list rewrite atomicity](whole-list-rewrite-atomicity.md) | An interrupted `compact()` stops leaving a double of the list that `--repair` will not itself remove — the former row 2's problem, still unsolved | **Deferred from GA on 2026-08-15, and the reason is the value of this file.** Two designs died under adversarial review — a lease-plus-journal whose replay destroys data a plain re-run preserves, and a stage-and-flip whose metadata marker silently permutes lists on the documented `--repair` → `--migrate` sequence. The successor todo carries the constraints they established, chiefly that **`fetch_all_including_lists` is a paginated DynamoDB query, not a snapshot**, which rules out storing "which namespace is live" in the item partition. Do not propose a third design without reading them. Reachability is low and the current failure is loud, which is what makes deferring defensible |
-| 10 | [Postgres parallel CI flakiness](ci-postgres-parallel-flakiness.md) | Removes the remaining instability the hang watchdog only bounds — a fixed-`creator` test racing two process-global singletons, a full alembic chain per xdist worker, and an unexamined `--dist loadgroup` requirement | Not the same defect as row 3 (that one is correctness, this is test infra), but same matrix and same conditions, and follow-up 1's process-global psycopg pool is row 3's leading hypothesis. **Decided 2026-08-14: one instrumentation branch shared with row 3**, which promotes this off "not urgent" as a passenger. **That branch ran 2026-08-15 and collected for row 3 only** — the shared surface was follow-up 1's process-global singletons, and the pool half of it had already been rebuilt in #117, leaving nothing here to instrument. All three follow-ups stay open |
-
-## 4. Cheap cleanups
-
-Small, mechanical, each removes something actively misleading.
-
-| # | Item | Impact of doing it | Why now |
-| --- | --- | --- | --- |
-| 11 | **Harden the `-32600` dual-era signal** — "Cheap hardening" in [dual-era support](mcp-2026-07-28-dual-era-support.md) | Pins the behaviour that lets dual-era MCP clients fall back to us, names our supported versions where a client can surface them, and makes modern-only clients visible in telemetry rather than via user reports | **Read the trap before touching the error path.** The HTTP 400 + `-32600` we answer an unknown protocol version with **is** the legacy-server signal a dual-era client falls back on. Replacing it with a spec-shaped `-32022` + `data.supported` looks more correct and converts every dual-era client's working fallback into a retry loop — and **no test asserts it as the fallback signal**. **Decided 2026-08-14: all three items** — regression test, versions named in the `message` string (never `data.supported`), and the log level raised so row 13's trigger is observable. Needs none of the deferred work in row 13. **All three landed 2026-08-15** (#129); the rejection turned out not to be logged at all rather than logged at debug. The rest of the file — the modern revision itself — stays open as row 13, trigger unfired, and is now *observable* for the first time |
+| 9b | [Whole-list rewrite atomicity](whole-list-rewrite-atomicity.md) | An interrupted `compact()` stops leaving a double of the list that `--repair` will not itself remove — the former row 2's problem, still unsolved | **Deferred from GA on 2026-08-15, and the reason is the value of this file.** Two designs died under adversarial review — a lease-plus-journal whose replay destroys data a plain re-run preserves, and a stage-and-flip whose metadata marker silently permutes lists on the documented `--repair` → `--migrate` sequence. The file carries the constraints they established, chiefly that **`fetch_all_including_lists` is a paginated DynamoDB query, not a snapshot**, which rules out storing "which namespace is live" in the item partition. Do not propose a third design without reading them. Reachability is low and the current failure is loud, which is what makes deferring defensible. Shares its file with row 9c, which is a smaller consequence of the same missing CAS |
+| 10 | [Postgres parallel CI flakiness](ci-postgres-parallel-flakiness.md) | Removes the remaining instability the hang watchdog only bounds — a fixed-`creator` test racing two process-global singletons, a full alembic chain per xdist worker, and an unexamined `--dist loadgroup` requirement | Not the same defect as row 3 (that one is correctness, this is test infra), but same matrix and same conditions. **Decided 2026-08-14: one instrumentation branch shared with row 3.** That branch ran 2026-08-15 and **collected for row 3 only** — the shared surface was follow-up 1's process-global singletons, and the pool half of it had already been rebuilt in #117, leaving nothing here to instrument. All three follow-ups stay open |
 
 ## 5. Blocked or waiting on someone else
 
@@ -136,8 +100,9 @@ neglected work.
 
 | # | Item | Waiting on |
 | --- | --- | --- |
+| 3 | [Postgres parallel DELETE not persisting](2026-06-15-postgres-parallel-delete-not-persisting.md) | **Time, then deletion of the file.** The quarantine was lifted and the path instrumented on 2026-08-15 (#128); the postgres matrix has been green on every run since, across five PRs, with zero reruns. That is evidence the symptom is gone, **not** a diagnosis — both ranked hypotheses had their proximate mechanism removed by #115 and #117 without anyone noticing. `ACTINGWEB_PG_DELETE_DIAGNOSTICS` stays on in CI so a recurrence names its mechanism in the first failing run. **Delete this file after a few more weeks of green (~early September 2026).** If it recurs first, the diagnostics are the whole point and the file is where the evidence goes |
 | 12 | [Remove the legacy property GSI machinery](legacy-property-gsi-removal.md) | The **next major version bump**. Five removals, enumerated. Note the sequencing constraint: release notes telling legacy-GSI holdouts to migrate must ship in a release that **still contains the backfill script** — so the note is written before the removal, not alongside it. Also absorbs I3 (the `use_lookup_table` three-sources-of-truth wart), which was deferred to be paired with exactly this |
-| 13 | [Dual-era MCP support](mcp-2026-07-28-dual-era-support.md) | A client we serve going **modern-only**. A dual-era client needs nothing from us, so "supports 2026-07-28" is not the signal — a *sustained* stream of 400/`-32600` from one origin is (a single one is the healthy handshake). Also blocked-adjacent: `actingweb_mcp`'s `require_mcp_auth_for_init` middleware silently becomes a no-op under the modern revision, since both of its inputs are removed |
+| 13 | [Dual-era MCP support](mcp-2026-07-28-dual-era-support.md) | A client we serve going **modern-only**. A dual-era client needs nothing from us, so "supports 2026-07-28" is not the signal — a *sustained* stream of 400/`-32600` from one origin is (a single one is the healthy handshake). Since #129 the library fires that criterion itself: a run from one origin escalates to a WARNING naming it, where previously the rejection was not logged at all. Also blocked-adjacent: `actingweb_mcp`'s `require_mcp_auth_for_init` middleware silently becomes a no-op under the modern revision, since both of its inputs are removed |
 
 ## 6. Registers — records, not schedulable work
 
@@ -148,8 +113,8 @@ decisions being re-litigated.
 
 | Item | What it holds |
 | --- | --- |
-| [DynamoDB known-next](dynamodb-known-next.md) | 9 items deferred from the v3.13 scalability plan — batch writes, the `consistent_read` audit, `SubscriptionDiff` seqnr ordering, import-time table-name freezing. Item 9 is row 7 above; row 5 is the adjacent per-partition defect. Line references are from `29783f8` and have **not** been re-verified since July — **decided 2026-08-14: fold a re-verification pass into the 3.13.0 GA work**, when the codebase settles. **Done 2026-08-15** against `6187636`, after the last GA branch landed: all nine still stand, none silently fixed, item 3 is 27 sites rather than ~22 |
-| [MCP cache lifecycle and revocation](mcp-cache-lifecycle-and-revocation.md) | 8 items scoped out of the trust-cache plan by name. §1 is row 6 above. §5 is worth reading even if never actioned: it records *why* the surviving substring peer-id match on the deletion path is not the bug the resolver fix closed — server-generated high-entropy client ids make it a collision, not a steerable attack |
+| [DynamoDB known-next](dynamodb-known-next.md) | 9 items deferred from the v3.13 scalability plan — batch writes, the `consistent_read` audit, `SubscriptionDiff` seqnr ordering, import-time table-name freezing. Item 9 is row 7 above; row 5 is the adjacent per-partition defect. **Re-verified 2026-08-15 against `6187636`**: all nine still stand, none silently fixed, item 3 is 27 sites rather than ~22, and item 2's proposed fix is partly *already shipped* (fractional ranks are the stable item ids it asks for). #132 postdates that pass and affects no item |
+| [MCP cache lifecycle and revocation](mcp-cache-lifecycle-and-revocation.md) | 8 items scoped out of the trust-cache plan by name. §1 landed in #130 — with the constraint that eviction must be **actor-wide**, because `_actor_cache` holds a live `ActorInterface` carrying the trust list. §2 (cross-process invalidation) is the large one still open. §5 is worth reading even if never actioned: it records *why* the surviving substring peer-id match on the deletion path is not the bug the resolver fix closed — server-generated high-entropy client ids make it a collision, not a steerable attack |
 
 ---
 
@@ -167,10 +132,13 @@ repeating because they shape this list:
   to an undated name and don't read it as a write date.
 - **A todo that grows phases becomes a plan.** `/create_plan` from it, then
   either leave a stub pointing at the plan or delete the todo — the plan
-  supersedes it. Rows 1+2 were planned jointly on 2026-08-15 and now carry
-  stubs; both are deleted when that plan lands. Row 4 is next nearest.
+  supersedes it. Rows 1 and 2 were planned jointly on 2026-08-15 and their files
+  were deleted when that plan landed; row 2's surviving remainder was refiled as
+  `whole-list-rewrite-atomicity.md` rather than kept as a stub, because the
+  reasons its designs were cut are worth more than a pointer. Row 4 is the next
+  nearest candidate.
 - **A closed plan's unfinished remainder belongs here, not in an `active`
-  plan.** As of 2026-08-14 every plan in `plans/` is `status: done`, so
+  plan.** Every plan in `plans/` is `status: done`, so
   `grep -l "^status: active"` returning nothing is correct — it means "nobody is
   mid-implementation", not "the grep is broken". Five plans were carrying a
   wrong status from a 2026-07-26 bulk edit (`cc29c03`) that added the

--- a/thoughts/todo/action-hook-output-schema-not-visible-to-mcp.md
+++ b/thoughts/todo/action-hook-output-schema-not-visible-to-mcp.md
@@ -53,23 +53,17 @@ point is to make one behaviour predictable.
    structured content* warning off `tools/list` does not apply here: this
    condition is knowable at listing time and cannot false-positive.
 
-Option 4 is the cheapest real improvement and is independent of the rest.
+**Option 4 landed 2026-08-15 (#130)** —
+`_warn_hook_output_schema_not_advertised_once()` in
+`actingweb/handlers/mcp.py`, firing once per tool per process from the
+`tools/list` loop, covering both the explicit `output_schema=` case and the
+`TypedDict` auto-derivation.
 
-**Decided 2026-08-14** (owner walkthrough): **option 4 now.** It catches the
-confusion at registration rather than call time, cannot false-positive, and
-forecloses nothing. Options 2 and 3 stay open and stay tied to the
-structuredContent decision — do not take them as a side effect of this.
-
-**Landed 2026-08-15.** `_warn_hook_output_schema_not_advertised_once()` in
-`actingweb/handlers/mcp.py` fires from the `tools/list` loop when a tool has no
-`_mcp_metadata` output schema but `get_hook_metadata()` reports one — which
-covers both the explicit `action_hook(output_schema=)` case and the `TypedDict`
-auto-derivation. Once per tool per process, since `tools/list` runs per request.
-
-**The asymmetry itself is unchanged, and this file stays open for that.** The
-warning tells an author their schema is not being advertised; it does not
-advertise it. Options 2 and 3 remain the actual fix and remain tied to the
-structuredContent decision.
+**The asymmetry itself is untouched, which is why this file is still open.** The
+warning tells an author their schema is not advertised; it does not advertise
+it. Options 2 and 3 remain the actual fix, and remain tied to the
+structuredContent decision — do not take either as a side effect of something
+else.
 
 ## Related
 

--- a/thoughts/todo/dynamodb-known-next.md
+++ b/thoughts/todo/dynamodb-known-next.md
@@ -80,6 +80,10 @@ a disappointing one. Specifics:
   half-answered on 2026-08-15 (see it); the guard stays blocked. Caught by
   Codex review on PR #131.
 
+**#132 (the v3.13.0 tag) postdates this pass** and affects no item: it added a
+repair refusal and a stale-format warning to `property_list.py` /
+`verify_property_lists.py`, no new delete loop or read path.
+
 **Line references are deliberately not re-pinned to specific numbers** for items
 whose anchors are stable by name. Pinning them is what made this list go stale
 in the first place: `29783f8`'s numbers were wrong within weeks. Where a number

--- a/thoughts/todo/mcp-2026-07-28-dual-era-support.md
+++ b/thoughts/todo/mcp-2026-07-28-dual-era-support.md
@@ -85,53 +85,30 @@ the absence of `data`, which is the half a `-32022` "fix" would change.
 `tests/test_mcp_dual_era_signal.py` now guards it, and the rejection site
 carries the reasoning inline so it is visible to whoever edits it.
 
-## Cheap hardening — DONE 2026-08-15
+## Cheap hardening — DONE 2026-08-15 (#129)
 
-Each is independent of the dual-era decision. **Decided 2026-08-14** (owner
-walkthrough): **do all three.** Item 1 is the one that matters — it is what
-stops a well-meaning `-32022` "fix" from breaking every dual-era client — and
-item 3 is what makes criterion 2 above observable in telemetry rather than via
-user reports. Item 2 stays in the `message` string; `data.supported` is the trap.
+All three landed: the regression test (`tests/test_mcp_dual_era_signal.py`,
+which asserts the *absence* of `data` and that the code falls outside the whole
+reserved `-32020`–`-32099` range), the supported versions named in the error
+`message` via `unsupported_version_message()` in `actingweb/mcp/protocol.py`,
+and origin-graded logging of the rejection. None of it implements any part of
+the modern revision — it protects the current behaviour and makes criterion 2
+observable.
 
-**All three landed 2026-08-15.** The rest of this file is unchanged and still
-open: the hardening protects the current behaviour, it does not implement any
-part of the modern revision. Criterion 2 above is now the *observable* trigger
-it was written to be, which it was not before.
+Two facts from that work that outlive it:
 
-1. ~~**Regression test**~~ **Done** — `tests/test_mcp_dual_era_signal.py`. It
-   asserts the *absence* of `data`, not just the presence of `-32600`, plus
-   that the code falls outside the whole reserved `-32020`–`-32099` range
-   rather than differing from one tempting constant. Verified non-vacuous by
-   making the exact change the trap describes (`-32022` +
-   `data.supported`): 4 assertions fail. The module docstring carries the
-   reasoning, because a guard nobody understands gets deleted.
-2. ~~**Name supported versions in the error `message` string**~~ **Done** —
-   `unsupported_version_message()` in `actingweb/mcp/protocol.py`, next to
-   `SUPPORTED_PROTOCOL_VERSIONS` so the two cannot drift. The docstring says
-   why the versions must not migrate to `data`.
-3. ~~**Raise the log level**~~ **Done**, though the premise was off twice
-   over. First, the rejection did not log at debug — it **did not log at all**.
-   Second, "raise the log level" was the wrong shape, and review on #129
-   surfaced why: the rejection is answered on an **unauthenticated** path, so
-   an unconditional WARNING is a log-volume and alert-noise lever any anonymous
-   caller can pull, and it buries the actionable case among the healthy ones.
-
-   What landed instead grades by origin: a lone rejection is the healthy
-   handshake and logs at INFO; a run of five from the same origin inside a
-   five-minute window escalates to WARNING **once**, naming the origin and this
-   file. Criterion 2 above is a statement about *sustained traffic from one
-   origin*, so this makes the criterion itself the thing that fires, rather than
-   asking an operator to reconstruct it from a pile of identical lines.
-
-   Note on the origin: `remote_addr` is **not** available. Two call sites read
-   `getattr(self.request, "remote_addr", "unknown")`, but nothing ever sets it —
-   `AWWebObj`/`AWRequest` take only url, params, body, headers and cookies, and
-   neither integration passes an address, so both existing reads always evaluate
-   to the literal `"unknown"`. The origin is therefore `Mcp-Session-Id` when
-   present, else the `User-Agent` — which is also the field that actually names
-   the client *implementation*, i.e. the thing criterion 1 asks you to watch.
-   Both are client-supplied and spoofable, which is acceptable because nothing
-   here is a security decision and the counter is capped.
+- **The rejection escalates by origin, not by volume.** A lone rejection logs at
+  INFO (it is the healthy handshake); five from one origin inside five minutes
+  warn once, naming the origin. An unconditional WARNING was rejected because
+  the path is unauthenticated — any anonymous caller could pull it as an
+  alert-noise lever, burying the actionable case.
+- **`remote_addr` does not exist on this request object.** `AWWebObj`/`AWRequest`
+  carry only url, params, body, headers and cookies, and neither integration
+  sets an address, so the two call sites reading
+  `getattr(self.request, "remote_addr", "unknown")` always evaluate to
+  `"unknown"`. Origin is `Mcp-Session-Id` when present, else `User-Agent` —
+  which is also the field naming the client implementation criterion 1 asks you
+  to watch.
 
 ## Scope when it is picked up
 

--- a/thoughts/todo/mcp-cache-lifecycle-and-revocation.md
+++ b/thoughts/todo/mcp-cache-lifecycle-and-revocation.md
@@ -13,53 +13,21 @@ correctness/robustness issues found along the way.
 (research Patch 5, "cache lifecycle"), plus items discovered while
 implementing Phases 1–4 of the plan above.
 
-## 1. Revocation does not evict the MCP caches (research C7) — DONE 2026-08-15
+## 1. Revocation does not evict the MCP caches (research C7) — DONE (#130)
 
-`MCPHandler.clear_token_from_cache()` (`actingweb/handlers/mcp.py`) has
-exactly **one** caller: the logout handler
-(`actingweb/handlers/oauth2_endpoints.py:861`). None of the other paths that
-should invalidate a client's cached identity call it:
+**Landed 2026-08-15**, single-process eviction on every revocation path:
+`TokenManager.revoke_token()`, `OAuthSession.revoke_all_tokens()`,
+`Trust.delete()`, and both the store and delete paths of
+`TrustPermissionStore`, via the lazy shims in `actingweb/mcp/invalidation.py`.
 
-- `TokenManager.revoke_token()` (`actingweb/oauth2_server/token_manager.py:304`)
-- `revoke_all_tokens()` (same file)
-- `/oauth/revoke` endpoint
-- Trust deletion (any path — peer-initiated, admin-initiated, or
-  actor-initiated)
-- Trust modification (e.g. permission downgrade via
-  `TrustPermissionStore`)
+**Eviction is actor-wide, not `_trust_cache`-keyed as this file originally
+proposed.** `_actor_cache` holds a live `ActorInterface` carrying the trust list
+itself, so dropping the tuple alone leaves the shared wrapper serving stale
+trust — see
+`thoughts/research/2026-08-15-mcp-actor-cache-holds-instance-state.md`. Anyone
+adding a seventh cache or a new revocation path inherits that constraint.
 
-A token revoked, or a trust relationship deleted/downgraded, through any of
-these paths still authenticates/authorizes from a warm process for up to the
-5-minute token-cache TTL (`_cache_ttl` in `mcp.py`). This is a **staleness**
-window, not the cross-client bypass the parent plan fixed — a revoked
-client still only ever gets *its own* prior permissions, not someone else's.
-
-**Decided 2026-08-14** (owner walkthrough): **do both halves** — token-keyed
-eviction on `revoke_token`, `revoke_all_tokens` and `/oauth/revoke`, *and*
-direct `_trust_cache` eviction on trust deletion and permission downgrade. That
-closes everything a single process can close. §2 (cross-process) is explicitly
-**not** a blocker for this. Sequence alongside item 4 of
-`thoughts/todo/subs-list-cache-asymmetry.md` — same cache module, and the
-actor-cache lifetime question decides what is left to evict.
-
-**Landed 2026-08-15.** Eviction is wired into `TokenManager.revoke_token()`,
-`OAuthSession.revoke_all_tokens()`, `Trust.delete()`, and both the store and
-delete paths of `TrustPermissionStore`. `actingweb/mcp/invalidation.py` holds the
-two shims callers use — the import of the handler is lazy and failure-tolerant,
-because these are core modules calling into an optional higher layer and a
-revocation must never fail because a cache could not be told about it.
-
-**The scope decision this asked for went the other way, and the reason is
-recorded in `thoughts/research/2026-08-15-mcp-actor-cache-holds-instance-state.md`.**
-This file suggested evicting the `_trust_cache` tuple alone for trust changes,
-"without touching `_token_cache`/`_actor_cache`". That is unsound: `_actor_cache`
-holds a live `ActorInterface`, which carries the trust list itself, so dropping
-the tuple leaves the shared wrapper serving stale trust. Eviction is therefore
-actor-wide on every path — which is also what `clear_token_from_cache()` already
-concluded for itself ("actor-wide by design").
-
-Answering that question on paper first was an INDEX §0 sequencing requirement,
-and it changed the implementation rather than confirming it.
+§2 below is the part that stays open: none of this crosses a process boundary.
 
 ## 2. No cross-process invalidation
 

--- a/thoughts/todo/subs-list-cache-asymmetry.md
+++ b/thoughts/todo/subs-list-cache-asymmetry.md
@@ -151,9 +151,12 @@ cache-lifetime question — not the guard.** Deciding whether `_actor_cache` hol
 only identity/auth context with the `Actor` rebuilt per request, or whether
 instance caches need an explicit request-boundary reset, is what unblocks item 2
 *and* de-risks every future instance-level memo. The guard alone was rejected as
-trading a bounded cost bug for an unbounded correctness one. Pair the work with
-§1 of `thoughts/todo/mcp-cache-lifecycle-and-revocation.md` — same module, and
-the eviction wiring depends on what the cache ends up holding.
+trading a bounded cost bug for an unbounded correctness one.
+
+The half of item 4 that §1 of
+`thoughts/todo/mcp-cache-lifecycle-and-revocation.md` needed was answered on
+2026-08-15 and that work landed, so this no longer pairs with anything — the
+*should* is now this file's alone to answer.
 
 1. ~~**Centralise invalidation.**~~ **DONE in rc2** — `create_subscription()`
    resets `self.subs_list`. The hand-rolled reset at
@@ -172,11 +175,11 @@ the eviction wiring depends on what the cache ends up holding.
    `thoughts/research/2026-08-15-mcp-actor-cache-holds-instance-state.md`
    establishes that it *does*: `_actor_cache` stores a live `ActorInterface`,
    keyed by actor id, on a **sliding** TTL, shared across requests and across
-   users of the container. That was the half row 6 needed, and it is enough to
-   make row 6's eviction correct regardless of how the rest is decided. What
-   remains open is the *should* — identity-only with the `Actor` rebuilt per
-   request, versus an explicit request-boundary reset — which INDEX §0 assigns
-   to 3.14, and item 2 below stays blocked on it. Fixing invalidation inside `create_subscription()` closes the
+   users of the container. That was the half the MCP revocation work needed, and it is enough to
+   make the revocation-eviction work (#130) correct regardless of how the rest
+   is decided. What remains open is the *should* — identity-only with the
+   `Actor` rebuilt per request, versus an explicit request-boundary reset. That
+   question is now this file's alone, and item 2 below stays blocked on it. Fixing invalidation inside `create_subscription()` closes the
    window for one process, but `handlers/mcp.py`'s `_actor_cache` shares an
    `Actor` across requests *and across users of that container*, so any
    future instance-level memo inherits the same hazard. Either the MCP cache

--- a/thoughts/todo/whole-list-rewrite-atomicity.md
+++ b/thoughts/todo/whole-list-rewrite-atomicity.md
@@ -110,6 +110,10 @@ second of which is the most valuable constraint any of this produced.
 
 ## Adjacent residual: mutations dispatch on a cached format (found 2026-08-16)
 
+**This section is NOT deferred** — it is INDEX row 9c, in "Do next", while the
+rest of the file is row 9b. Reachable only during a migration, which is what GA
+triggers fleet-wide, so it is live now and quiet later.
+
 Consumer verification of 3.13.0 GA reproduced a second, smaller consequence of
 the same missing primitive. A `ListProperty` retained across a migration
 dispatches its next mutation on its **cached** `format`, so a v1-shaped item


### PR DESCRIPTION
v3.13.0 is tagged (#132), so the index's organising structure — a GA-scope lens assigning every row to *before GA*, *at GA*, or *3.14* — describes an event that has happened. Rewritten around what is actually next.

## What moved

**§0 becomes a shipped-record rather than a lens.** It keeps the one thing the tier table existed to preserve — why the release shipped with `compact()` not crash-safe — as a pointer to row 9b, whose file carries the two dead designs in full. Everything else it held is now history.

**One new row, and it is the reason this pass matters.** Consumer verification of the tag reproduced a write from a `ListProperty` held across a migration landing in a row shape the current format never reads — silent, and `verify()` still reports the list healthy. #132 shipped a WARNING; the actual fix (dispatch on a fresh metadata read) was filed, not done. It is **row 9c, in "Do next"**, because it is reachable *only* during a migration and GA is what triggers those fleet-wide. Quiet later, live now.

| Row | Was | Now |
| --- | --- | --- |
| 9c | *(new)* | §1 Do next — the #132 residual |
| 5 | §2, "at GA, not before" | §1 Do next — that window is open |
| 3 | §1 Do next | §5 Waiting — symptom gone, diagnosis not; delete the file after a few more weeks of green |
| 6, 11 | §2, §4 | Retired (landed in #130, #129) |
| 8 | §3 | §3, re-scoped to options 2/3, tied to the structuredContent decision |

§4 (cheap cleanups) is deleted with row 11. Neither row nor section numbers are re-flowed — other files cite both — and the header now says so, since a gap at §4 otherwise reads as a mistake.

## Pruning

~90 net lines across six todo files. Landed sections compressed to a breadcrumb with their PR number. The rule applied: a paragraph stays if its job is to stop future re-litigation, goes if its job is to narrate the past. So the `-32600` trap, the two cut designs, the actor-wide-eviction constraint and the `remote_addr`-does-not-exist finding all stay; the review-comment anecdotes go, because git has them.

Five stale cross-references fixed — row 7 and the register both cited retired row 6, `subs-list-cache-asymmetry.md` claimed "INDEX §0 assigns this to 3.14", and the dynamodb register's "#132 affects no item" was asserted only in the index, which is the drift its own maintenance rule warns about.

## Checks

All 12 todo files have exactly one row or register entry; every link resolves; no dangling row citation. Plans and verifications untouched, and stale row references inside dated `research/` files left alone — those are snapshots by convention.

Documentation only, all under `thoughts/todo/`. No CHANGELOG entry, matching #126 and #131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019wTmWvkPKhpcZfqM8dA2dp